### PR TITLE
Schema type should be integer not int

### DIFF
--- a/conbench/api/compare.py
+++ b/conbench/api/compare.py
@@ -50,7 +50,7 @@ class CompareBenchmarksAPI(ApiEndpoint):
           - in: query
             name: threshold
             schema:
-              type: int
+              type: integer
         tags:
           - Compare
         """
@@ -111,7 +111,7 @@ class CompareBatchesAPI(ApiEndpoint):
           - in: query
             name: threshold
             schema:
-              type: int
+              type: integer
         tags:
           - Compare
         """

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -767,7 +767,7 @@
                         "schema": {"type": "string"},
                     },
                     {"in": "query", "name": "raw", "schema": {"type": "boolean"}},
-                    {"in": "query", "name": "threshold", "schema": {"type": "int"}},
+                    {"in": "query", "name": "threshold", "schema": {"type": "integer"}},
                 ],
                 "responses": {
                     "200": {"$ref": "#/components/responses/CompareList"},
@@ -789,7 +789,7 @@
                         "schema": {"type": "string"},
                     },
                     {"in": "query", "name": "raw", "schema": {"type": "boolean"}},
-                    {"in": "query", "name": "threshold", "schema": {"type": "int"}},
+                    {"in": "query", "name": "threshold", "schema": {"type": "integer"}},
                 ],
                 "responses": {
                     "200": {"$ref": "#/components/responses/CompareEntity"},
@@ -811,7 +811,7 @@
                         "schema": {"type": "string"},
                     },
                     {"in": "query", "name": "raw", "schema": {"type": "boolean"}},
-                    {"in": "query", "name": "threshold", "schema": {"type": "int"}},
+                    {"in": "query", "name": "threshold", "schema": {"type": "integer"}},
                 ],
                 "responses": {
                     "200": {"$ref": "#/components/responses/CompareList"},

--- a/conbench/tests/api/test_docs.py
+++ b/conbench/tests/api/test_docs.py
@@ -27,7 +27,6 @@ class TestDocs(_asserts.ApiEndpointTest):
                 f.write(str(response.json))
             subprocess.run(["black", path])
 
-
-#         with open(path) as f:
-#             expected_docs = ast.literal_eval(f.read())
-#         validate_spec(expected_docs)
+        with open(path) as f:
+            expected_docs = ast.literal_eval(f.read())
+        validate_spec(expected_docs)


### PR DESCRIPTION
Fixes the following error that starting happening in `openapi-spec-validator==0.3.0`.

```
    def validate(self, spec, spec_url=''):
        for err in self.iter_errors(spec, spec_url=spec_url):
>           raise err
E           openapi_spec_validator.exceptions.OpenAPIValidationError: {'in': 'query', 'name': 'threshold', 'schema': {'type': 'int'}} is not valid under any of the given schemas
E           
E           Failed validating 'oneOf' in schema['properties']['paths']['patternProperties']['^\\/']['patternProperties']['^(get|put|post|delete|options|head|patch|trace)$']['properties']['parameters']['items']:
E               {'oneOf': [{'$ref': '#/definitions/Parameter'},
E                          {'$ref': '#/definitions/Reference'}]}
E           
E           On instance['paths']['/api/compare/batches/{compare_ids}/']['get']['parameters'][2]:
E               {'in': 'query', 'name': 'threshold', 'schema': {'type': 'int'}}

../../envs/qa/lib/python3.8/site-packages/openapi_spec_validator/validators.py:48: OpenAPIValidationError

```