### PR TITLE
URSA-253 > Do not expect author field to contain author info in Github /commits/id response and do not try requests with 500 responses

### DIFF
--- a/conbench/entities/commit.py
+++ b/conbench/entities/commit.py
@@ -8,6 +8,7 @@ from ..entities._entity import (
     EntitySerializer,
     generate_uuid,
     NotNull,
+    Nullable
 )
 
 
@@ -19,8 +20,8 @@ class Commit(Base, EntityMixin):
     url = NotNull(s.String(250))
     message = NotNull(s.String(250))
     author_name = NotNull(s.String(100))
-    author_login = NotNull(s.String(50))
-    author_avatar = NotNull(s.String(100))
+    author_login = Nullable(s.String(50))
+    author_avatar = Nullable(s.String(100))
     timestamp = NotNull(s.DateTime(timezone=False))
 
 

--- a/conbench/entities/commit.py
+++ b/conbench/entities/commit.py
@@ -8,7 +8,7 @@ from ..entities._entity import (
     EntitySerializer,
     generate_uuid,
     NotNull,
-    Nullable
+    Nullable,
 )
 
 

--- a/conbench/entities/commit.py
+++ b/conbench/entities/commit.py
@@ -50,6 +50,6 @@ def parse_commit(commit):
         "date": dateutil.parser.isoparse(commit["commit"]["author"]["date"]),
         "message": commit["commit"]["message"].split("\n")[0],
         "author_name": commit["commit"]["author"]["name"],
-        "author_login": commit["author"]["login"],
-        "author_avatar": commit["author"]["avatar_url"],
+        "author_login": commit["author"]["login"] if commit["author"] else None,
+        "author_avatar": commit["author"]["avatar_url"] if commit["author"] else None,
     }

--- a/conbench/util.py
+++ b/conbench/util.py
@@ -14,7 +14,7 @@ from requests.packages.urllib3.util.retry import Retry
 
 retry_strategy = Retry(
     total=5,
-    status_forcelist=[500, 502, 503, 504],
+    status_forcelist=[502, 503, 504],
     allowed_methods=frozenset(["GET", "POST"]),
     backoff_factor=4,  # will retry in 2, 4, 8, 16, 32 seconds
 )


### PR DESCRIPTION
This PR:
- removes 500 responses from being retried when `POST /api/benchmarks/` requests get 500 errors. BK builds time out (we have a 2 hour time out for BK builds) when we retry 500s.
- updates `parse_commit`  to not expect `author` field to contain any author info in Github's `GET https://api.github.com/repos/apache/arrow/commits/id` response.

`GET https://api.github.com/repos/apache/arrow/commits/id` response sometimes has `author = None`. This is somewhat intermittent behavior. I could not find any explanation for this but Github API users run into this issue.

Here is an example of a response like this:

<img width="1404" alt="Screen Shot 2021-03-15 at 12 22 38 PM" src="https://user-images.githubusercontent.com/5522472/111210387-6ddb4600-858a-11eb-8212-8c4313de4493.png">
