### PR TITLE
Adding version tracking

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -28,6 +28,7 @@ jobs:
           pip install -r requirements-test.txt
           pip install -r requirements-cli.txt
           pip install -r requirements-build.txt
+          pip install .
           pip install coveralls
       - name: Migrations
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,12 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# bin and lib
+bin
+include
+lib64
+pyvenv.cfg
+
+# generated version
+_generated_version.py

--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,3 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-
-# generated version
-_generated_version.py

--- a/.gitignore
+++ b/.gitignore
@@ -128,11 +128,5 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-# bin and lib
-bin
-include
-lib64
-pyvenv.cfg
-
 # generated version
 _generated_version.py

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ repository, and the results are hosted on the
     $ brew services start postgres
 
 On Linux this would be
+
     $ sudo service postgresql start 
 
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ repository, and the results are hosted on the
 ### Start postgres
     $ brew services start postgres
 
+On Linux this would be
+    $ sudo service postgresql start 
+
 
 ### Create databases
     $ psql
@@ -102,6 +105,20 @@ repository, and the results are hosted on the
      * Environment: development
      * Debug mode: on
      * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
+
+If this renders an authentication error, set the password for your user.
+
+    $ psql
+    # ALTER USER <username> PASSWORD '<password>';
+
+Then, set an environmental variable `DB_PASSWORD` to reflect the chosen password.
+
+    $ export DB_PASSWORD=<password>
+
+Alternatively, if you don't want to set the `DB_PASSWORD` you can change the password in postgres to `postgres`.
+
+    $ psql
+    # ALTER USER <username> PASSWORD 'postgres';
 
 
 ### Test app

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ repository, and the results are hosted on the
 
 On Linux this would be
 
-    $ sudo service postgresql start 
+    $ sudo service postgresql start
 
 
 ### Create databases

--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -1,5 +1,19 @@
 import os
 
+# set the version
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    # TODO: remove this when Python 3.7 support is dropped
+    import importlib_metadata
+
+try:
+    __version__ = importlib_metadata.version(__name__)
+except Exception:
+    __version__ = importlib_metadata.version("conbench")
+
+del importlib_metadata
+
 
 def create_application(config):
     import flask as f

--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -1,4 +1,3 @@
-# set the version
 import importlib.metadata as importlib_metadata
 import os
 

--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -1,11 +1,7 @@
 import os
 
 # set the version
-try:
-    import importlib.metadata as importlib_metadata
-except ImportError:
-    # TODO: remove this when Python 3.7 support is dropped
-    import importlib_metadata
+import importlib.metadata as importlib_metadata
 
 try:
     __version__ = importlib_metadata.version(__name__)

--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -1,7 +1,6 @@
-import os
-
 # set the version
 import importlib.metadata as importlib_metadata
+import os
 
 try:
     __version__ = importlib_metadata.version(__name__)

--- a/conbench/api/index.py
+++ b/conbench/api/index.py
@@ -11,11 +11,8 @@ from ..api._endpoint import ApiEndpoint
 from ..db import Session
 
 # get the version
-try:
-    import importlib.metadata as importlib_metadata
-except ImportError:
-    # TODO: remove this when Python 3.7 support is dropped
-    import importlib_metadata
+
+import importlib.metadata as importlib_metadata
 
 try:
     __version__ = importlib_metadata.version(__name__)

--- a/conbench/api/index.py
+++ b/conbench/api/index.py
@@ -10,6 +10,20 @@ from ..api._docs import spec
 from ..api._endpoint import ApiEndpoint
 from ..db import Session
 
+# get the version
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    # TODO: remove this when Python 3.7 support is dropped
+    import importlib_metadata
+
+try:
+    __version__ = importlib_metadata.version(__name__)
+except Exception:
+    __version__ = importlib_metadata.version("conbench")
+
+del importlib_metadata
+
 
 @api.route("/docs.json")
 def docs():
@@ -74,6 +88,7 @@ class PingAPI(ApiEndpoint):
             version = "unknown"
         return {
             "date": now.strftime("%a, %d %b %Y %H:%M:%S %Z"),
+            "conbench_version": __version__,
             "alembic_version": version,
         }
 

--- a/conbench/api/index.py
+++ b/conbench/api/index.py
@@ -5,13 +5,12 @@ import flask_login
 import marshmallow
 from sqlalchemy.sql import text
 
+# get the version
+from .. import __version__
 from ..api import api, rule
 from ..api._docs import spec
 from ..api._endpoint import ApiEndpoint
 from ..db import Session
-
-# get the version
-from .. import __version__
 
 
 @api.route("/docs.json")

--- a/conbench/api/index.py
+++ b/conbench/api/index.py
@@ -11,15 +11,7 @@ from ..api._endpoint import ApiEndpoint
 from ..db import Session
 
 # get the version
-
-import importlib.metadata as importlib_metadata
-
-try:
-    __version__ = importlib_metadata.version(__name__)
-except Exception:
-    __version__ = importlib_metadata.version("conbench")
-
-del importlib_metadata
+from .. import __version__
 
 
 @api.route("/docs.json")

--- a/conbench/api/index.py
+++ b/conbench/api/index.py
@@ -5,7 +5,6 @@ import flask_login
 import marshmallow
 from sqlalchemy.sql import text
 
-# get the version
 from .. import __version__
 from ..api import api, rule
 from ..api._docs import spec

--- a/conbench/app/index.py
+++ b/conbench/app/index.py
@@ -31,7 +31,7 @@ class Index(AppEndpoint, RunMixin):
             title="Home",
             version=__version__,
             runs=runs,
-            has_reasons=len(reasons) > 0, 
+            has_reasons=len(reasons) > 0,
             has_authors=len(authors) > 0,
             has_commits=len(commits) > 0,
         )

--- a/conbench/app/index.py
+++ b/conbench/app/index.py
@@ -3,6 +3,20 @@ from ..app._endpoint import AppEndpoint
 from ..app.benchmarks import RunMixin
 from ..config import Config
 
+# set the version
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    # TODO: remove this when Python 3.7 support is dropped
+    import importlib_metadata
+
+try:
+    __version__ = importlib_metadata.version(__name__)
+except Exception:
+    __version__ = importlib_metadata.version("conbench")
+
+del importlib_metadata
+
 
 class Index(AppEndpoint, RunMixin):
     def page(self, runs):
@@ -13,7 +27,7 @@ class Index(AppEndpoint, RunMixin):
         }
         return self.render_template(
             "index.html",
-            application=Config.APPLICATION_NAME,
+            application=f"{Config.APPLICATION_NAME}, ver. {__version__}",
             title="Home",
             runs=runs,
             has_reasons=len(reasons) > 0,

--- a/conbench/app/index.py
+++ b/conbench/app/index.py
@@ -4,11 +4,7 @@ from ..app.benchmarks import RunMixin
 from ..config import Config
 
 # set the version
-try:
-    import importlib.metadata as importlib_metadata
-except ImportError:
-    # TODO: remove this when Python 3.7 support is dropped
-    import importlib_metadata
+import importlib.metadata as importlib_metadata
 
 try:
     __version__ = importlib_metadata.version(__name__)

--- a/conbench/app/index.py
+++ b/conbench/app/index.py
@@ -27,10 +27,11 @@ class Index(AppEndpoint, RunMixin):
         }
         return self.render_template(
             "index.html",
-            application=f"{Config.APPLICATION_NAME}, ver. {__version__}",
+            application=Config.APPLICATION_NAME,
             title="Home",
+            version=__version__,
             runs=runs,
-            has_reasons=len(reasons) > 0,
+            has_reasons=len(reasons) > 0, 
             has_authors=len(authors) > 0,
             has_commits=len(commits) > 0,
         )

--- a/conbench/app/index.py
+++ b/conbench/app/index.py
@@ -4,14 +4,7 @@ from ..app.benchmarks import RunMixin
 from ..config import Config
 
 # set the version
-import importlib.metadata as importlib_metadata
-
-try:
-    __version__ = importlib_metadata.version(__name__)
-except Exception:
-    __version__ = importlib_metadata.version("conbench")
-
-del importlib_metadata
+from .. import __version__
 
 
 class Index(AppEndpoint, RunMixin):

--- a/conbench/app/index.py
+++ b/conbench/app/index.py
@@ -1,4 +1,3 @@
-# set the version
 from .. import __version__
 from ..app import rule
 from ..app._endpoint import AppEndpoint

--- a/conbench/app/index.py
+++ b/conbench/app/index.py
@@ -1,10 +1,9 @@
+# set the version
+from .. import __version__
 from ..app import rule
 from ..app._endpoint import AppEndpoint
 from ..app.benchmarks import RunMixin
 from ..config import Config
-
-# set the version
-from .. import __version__
 
 
 class Index(AppEndpoint, RunMixin):

--- a/conbench/cli.py
+++ b/conbench/cli.py
@@ -2,10 +2,9 @@ import json
 
 import click
 
+from . import __version__
 from .runner import LIST, REGISTRY
 from .util import register_benchmarks
-
-from . import __version__
 
 register_benchmarks()
 BENCHMARKS = {}

--- a/conbench/cli.py
+++ b/conbench/cli.py
@@ -5,6 +5,8 @@ import click
 from .runner import LIST, REGISTRY
 from .util import register_benchmarks
 
+from . import __version__
+
 register_benchmarks()
 BENCHMARKS = {}
 for benchmark in REGISTRY:
@@ -34,14 +36,6 @@ def list_benchmarks():
 
 @conbench.command(name="version")
 def version():
-    import importlib.metadata as importlib_metadata
-
-    try:
-        __version__ = importlib_metadata.version(__name__)
-    except Exception:
-        __version__ = importlib_metadata.version("conbench")
-    del importlib_metadata
-
     print(f"conbench version: {__version__}")
 
 

--- a/conbench/cli.py
+++ b/conbench/cli.py
@@ -31,6 +31,7 @@ def list_benchmarks():
         benchmarks = LIST[0]().list(BENCHMARKS)
     print(json.dumps(benchmarks, indent=2))
 
+
 @conbench.command(name="version")
 def version():
     try:
@@ -38,14 +39,14 @@ def version():
     except ImportError:
         # TODO: remove this when Python 3.7 support is dropped
         import importlib_metadata
-    
+
     try:
         __version__ = importlib_metadata.version(__name__)
     except Exception:
         __version__ = importlib_metadata.version("conbench")
     del importlib_metadata
 
-    print(f'conbench version: {__version__}')
+    print(f"conbench version: {__version__}")
 
 
 def _option(params, name, default, _type, help_msg=None):

--- a/conbench/cli.py
+++ b/conbench/cli.py
@@ -31,6 +31,22 @@ def list_benchmarks():
         benchmarks = LIST[0]().list(BENCHMARKS)
     print(json.dumps(benchmarks, indent=2))
 
+@conbench.command(name="version")
+def version():
+    try:
+        import importlib.metadata as importlib_metadata
+    except ImportError:
+        # TODO: remove this when Python 3.7 support is dropped
+        import importlib_metadata
+    
+    try:
+        __version__ = importlib_metadata.version(__name__)
+    except Exception:
+        __version__ = importlib_metadata.version("conbench")
+    del importlib_metadata
+
+    print(f'conbench version: {__version__}')
+
 
 def _option(params, name, default, _type, help_msg=None):
     params.append(

--- a/conbench/cli.py
+++ b/conbench/cli.py
@@ -34,11 +34,7 @@ def list_benchmarks():
 
 @conbench.command(name="version")
 def version():
-    try:
-        import importlib.metadata as importlib_metadata
-    except ImportError:
-        # TODO: remove this when Python 3.7 support is dropped
-        import importlib_metadata
+    import importlib.metadata as importlib_metadata
 
     try:
         __version__ = importlib_metadata.version(__name__)

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -70,6 +70,9 @@
         </table>
     </div>
 </div>
+<footer<>
+    <p>Conbench version: {{ version }}</p>
+</footer>
 
 {% endblock %}
 

--- a/conbench/tests/api/test_index.py
+++ b/conbench/tests/api/test_index.py
@@ -1,7 +1,10 @@
 import datetime
+import importlib.metadata as importlib_metadata
 
 from ...api._examples import API_INDEX
 from ...tests.api import _asserts
+
+__version__ = importlib_metadata.version("conbench")
 
 
 class TestIndexList(_asserts.ListEnforcer):
@@ -23,5 +26,6 @@ class TestAPI(_asserts.ApiEndpointTest):
         data = response.json
         assert response.status_code == 200
         assert response.content_type == "application/json"
-        assert set(data) == {"date", "alembic_version"}
+        assert set(data) == {"date", "conbench_version", "alembic_version"}
         assert str(datetime.datetime.today().year) in data["date"]
+        assert data["conbench_version"] == __version__

--- a/conbench/tests/benchmark/test_cli.py
+++ b/conbench/tests/benchmark/test_cli.py
@@ -21,6 +21,7 @@ Commands:
   list                List of benchmarks (for orchestration).
   matrix              Run matrix benchmark(s).
   matrix-types        Run matrix-types benchmark(s).
+  version
 """
 
 CONBENCH_LIST = """

--- a/conbench/tests/benchmark/test_cli.py
+++ b/conbench/tests/benchmark/test_cli.py
@@ -1,9 +1,13 @@
+import importlib.metadata as importlib_metadata
 import os
 import unittest.mock
 
 import pytest
 
 from ...util import register_benchmarks
+
+__version__ = importlib_metadata.version("conbench")
+
 
 CONBENCH = """
 Usage: conbench [OPTIONS] COMMAND [ARGS]...
@@ -350,3 +354,10 @@ def test_conbench_command_external_options_r_help(runner):
 
     result = runner.invoke(conbench, "external-r-options --help")
     assert_command_output(result, CONBENCH_EXTERNAL_R_OPTIONS_HELP)
+
+
+def test_conbench_command_version(runner):
+    from conbench.cli import conbench
+
+    result = runner.invoke(conbench, "version")
+    assert_command_output(result, f"conbench version: {__version__}")

--- a/conbench/tests/test_version.py
+++ b/conbench/tests/test_version.py
@@ -1,0 +1,9 @@
+import importlib.metadata as importlib_metadata
+
+import conbench
+
+__version__ = importlib_metadata.version("conbench")
+
+
+def test_version():
+    assert __version__ == conbench.__version__

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -24,3 +24,4 @@ python-dotenv
 PyYAML
 requests
 SQLAlchemy
+setuptools_scm

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -24,4 +24,3 @@ python-dotenv
 PyYAML
 requests
 SQLAlchemy
-setuptools_scm

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import pathlib
 import os
 
 import setuptools
-from setuptools_scm.version import simplified_semver_version
+
 
 setup_dir = os.path.abspath(os.path.dirname(__file__))
 
@@ -22,15 +22,19 @@ install_requires = [
 # the code below comes from pyarrow with minor changes
 # In the event of not running from a git clone (e.g. from a git archive
 # or a Python sdist), see if we can set the version number ourselves
-default_version = '1.33.0-SNAPSHOT'
-if (not os.path.exists(os.path.join(setup_dir, '.git')) and
-        not os.environ.get('SETUPTOOLS_SCM_PRETEND_VERSION')):
-    os.environ['SETUPTOOLS_SCM_PRETEND_VERSION'] = \
-        default_version.replace('-SNAPSHOT', '')
+default_version = "1.33.0-SNAPSHOT"
+if not os.path.exists(os.path.join(setup_dir, ".git")) and not os.environ.get(
+    "SETUPTOOLS_SCM_PRETEND_VERSION"
+):
+    os.environ["SETUPTOOLS_SCM_PRETEND_VERSION"] = default_version.replace(
+        "-SNAPSHOT", ""
+    )
 
 # See https://github.com/pypa/setuptools_scm#configuration-parameters
 scm_version_write_to_prefix = os.environ.get(
-    'SETUPTOOLS_SCM_VERSION_WRITE_TO_PREFIX', setup_dir)
+    "SETUPTOOLS_SCM_VERSION_WRITE_TO_PREFIX", setup_dir
+)
+
 
 def parse_git(root, **kwargs):
     """
@@ -38,30 +42,36 @@ def parse_git(root, **kwargs):
     subprojects, e.g. apache-arrow-js-XXX tags.
     """
     from setuptools_scm.git import parse
-    kwargs['describe_command'] =\
-        'git describe --dirty --tags --long --match "conbench-[0-9].*"'
+
+    kwargs[
+        "describe_command"
+    ] = 'git describe --dirty --tags --long --match "conbench-[0-9].*"'
 
     return parse(root, **kwargs)
 
 
 def guess_next_dev_version(version):
     if version.exact or not version.dirty:
-        return version.format_with('{tag}')
+        return version.format_with("{tag}")
 
     else:
+
         def guess_next_version(tag_version):
-            return(str(tag_version) + f'+g{version.node}')
+            return str(tag_version) + f"+g{version.node}"
+
         return version.format_next_version(guess_next_version)
+
 
 setuptools.setup(
     name="conbench",
     use_scm_version={
-        'root': setup_dir,
-        'parse': parse_git,
-        'write_to': os.path.join(scm_version_write_to_prefix,
-                                 'conbench/_generated_version.py'),
-        'version_scheme': guess_next_dev_version,
-        'local_scheme': 'no-local-version'
+        "root": setup_dir,
+        "parse": parse_git,
+        "write_to": os.path.join(
+            scm_version_write_to_prefix, "conbench/_generated_version.py"
+        ),
+        "version_scheme": guess_next_dev_version,
+        "local_scheme": "no-local-version",
     },
     description="Continuous Benchmarking (CB) Framework",
     long_description=long_description,
@@ -81,5 +91,5 @@ setuptools.setup(
     maintainer_email="dev@arrow.apache.org",
     url="https://github.com/conbench/conbench",
     install_requires=install_requires,
-    setup_requires=['setuptools_scm']
+    setup_requires=["setuptools_scm"],
 )

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ def guess_next_dev_version(version):
         return version.format_with('{tag}')
 
     else:
-        print(version)
         def guess_next_version(tag_version):
             return(str(tag_version) + f'+g{version.node}')
         return version.format_next_version(guess_next_version)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import os
 import pathlib
 
 import setuptools

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import pathlib
 import os
 
 import setuptools
+from setuptools_scm.version import simplified_semver_version
 
 setup_dir = os.path.abspath(os.path.dirname(__file__))
 
@@ -44,19 +45,13 @@ def parse_git(root, **kwargs):
 
 
 def guess_next_dev_version(version):
-    print(version.format_with('{tag}'))
-    print(version.exact)
-    print(default_version)
-    print(version)
-    print(type(version))
     if version.exact or not version.dirty:
         return version.format_with('{tag}')
-    # elif not version.dirty:
 
     else:
+        print(version)
         def guess_next_version(tag_version):
-            return default_version.replace('-SNAPSHOT', '')
-        print(version.format_next_version(guess_next_version))
+            return(str(tag_version) + f'+g{version.node}')
         return version.format_next_version(guess_next_version)
 
 setuptools.setup(
@@ -67,7 +62,7 @@ setuptools.setup(
         'write_to': os.path.join(scm_version_write_to_prefix,
                                  'conbench/_generated_version.py'),
         'version_scheme': guess_next_dev_version,
-        # 'local_scheme': guess_next_dev_version
+        'local_scheme': 'no-local-version'
     },
     description="Continuous Benchmarking (CB) Framework",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -22,15 +22,14 @@ install_requires = [
 # In the event of not running from a git clone (e.g. from a git archive
 # or a Python sdist), see if we can set the version number ourselves
 default_version = '1.33.0-SNAPSHOT'
-if (not os.path.exists('../.git') and
+if (not os.path.exists(os.path.join(setup_dir, '.git')) and
         not os.environ.get('SETUPTOOLS_SCM_PRETEND_VERSION')):
     os.environ['SETUPTOOLS_SCM_PRETEND_VERSION'] = \
-        default_version.replace('-SNAPSHOT', 'a0')
+        default_version.replace('-SNAPSHOT', '')
 
 # See https://github.com/pypa/setuptools_scm#configuration-parameters
 scm_version_write_to_prefix = os.environ.get(
     'SETUPTOOLS_SCM_VERSION_WRITE_TO_PREFIX', setup_dir)
-
 
 def parse_git(root, **kwargs):
     """
@@ -40,28 +39,36 @@ def parse_git(root, **kwargs):
     from setuptools_scm.git import parse
     kwargs['describe_command'] =\
         'git describe --dirty --tags --long --match "conbench-[0-9].*"'
+
     return parse(root, **kwargs)
 
 
 def guess_next_dev_version(version):
-    if version.exact:
+    print(version.format_with('{tag}'))
+    print(version.exact)
+    print(default_version)
+    print(version)
+    print(type(version))
+    if version.exact or not version.dirty:
         return version.format_with('{tag}')
+    # elif not version.dirty:
+
     else:
         def guess_next_version(tag_version):
             return default_version.replace('-SNAPSHOT', '')
+        print(version.format_next_version(guess_next_version))
         return version.format_next_version(guess_next_version)
 
 setuptools.setup(
     name="conbench",
-    # version="1.33.0",
     use_scm_version={
-        'root': os.path.dirname(setup_dir),
+        'root': setup_dir,
         'parse': parse_git,
         'write_to': os.path.join(scm_version_write_to_prefix,
                                  'conbench/_generated_version.py'),
-        'version_scheme': guess_next_dev_version
+        'version_scheme': guess_next_dev_version,
+        # 'local_scheme': guess_next_dev_version
     },
-    # use_scm_version=True,
     description="Continuous Benchmarking (CB) Framework",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
-import pathlib
 import os
+import pathlib
 
 import setuptools
-
 
 setup_dir = os.path.abspath(os.path.dirname(__file__))
 
@@ -67,9 +66,6 @@ setuptools.setup(
     use_scm_version={
         "root": setup_dir,
         "parse": parse_git,
-        "write_to": os.path.join(
-            scm_version_write_to_prefix, "conbench/_generated_version.py"
-        ),
         "version_scheme": guess_next_dev_version,
         "local_scheme": "no-local-version",
     },

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,6 @@ import pathlib
 
 import setuptools
 
-setup_dir = os.path.abspath(os.path.dirname(__file__))
-
 with open("README.md", "r") as readme:
     long_description = readme.read()
 
@@ -17,58 +15,10 @@ install_requires = [
     .splitlines()
 ]
 
-# using setuptools SCM versioning
-# the code below comes from pyarrow with minor changes
-# In the event of not running from a git clone (e.g. from a git archive
-# or a Python sdist), see if we can set the version number ourselves
-default_version = "1.33.0-SNAPSHOT"
-if not os.path.exists(os.path.join(setup_dir, ".git")) and not os.environ.get(
-    "SETUPTOOLS_SCM_PRETEND_VERSION"
-):
-    os.environ["SETUPTOOLS_SCM_PRETEND_VERSION"] = default_version.replace(
-        "-SNAPSHOT", ""
-    )
-
-# See https://github.com/pypa/setuptools_scm#configuration-parameters
-scm_version_write_to_prefix = os.environ.get(
-    "SETUPTOOLS_SCM_VERSION_WRITE_TO_PREFIX", setup_dir
-)
-
-
-def parse_git(root, **kwargs):
-    """
-    Parse function for setuptools_scm that ignores tags for non-C++
-    subprojects, e.g. apache-arrow-js-XXX tags.
-    """
-    from setuptools_scm.git import parse
-
-    kwargs[
-        "describe_command"
-    ] = 'git describe --dirty --tags --long --match "conbench-[0-9].*"'
-
-    return parse(root, **kwargs)
-
-
-def guess_next_dev_version(version):
-    if version.exact or not version.dirty:
-        return version.format_with("{tag}")
-
-    else:
-
-        def guess_next_version(tag_version):
-            return str(tag_version) + f"+g{version.node}"
-
-        return version.format_next_version(guess_next_version)
-
 
 setuptools.setup(
     name="conbench",
-    use_scm_version={
-        "root": setup_dir,
-        "parse": parse_git,
-        "version_scheme": guess_next_dev_version,
-        "local_scheme": "no-local-version",
-    },
+    version="1.33.0",
     description="Continuous Benchmarking (CB) Framework",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -87,5 +37,4 @@ setuptools.setup(
     maintainer_email="dev@arrow.apache.org",
     url="https://github.com/conbench/conbench",
     install_requires=install_requires,
-    setup_requires=["setuptools_scm"],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 import pathlib
+import os
 
 import setuptools
+
+setup_dir = os.path.abspath(os.path.dirname(__file__))
 
 with open("README.md", "r") as readme:
     long_description = readme.read()
@@ -14,9 +17,51 @@ install_requires = [
     .splitlines()
 ]
 
+# using setuptools SCM versioning
+# the code below comes from pyarrow with minor changes
+# In the event of not running from a git clone (e.g. from a git archive
+# or a Python sdist), see if we can set the version number ourselves
+default_version = '1.33.0-SNAPSHOT'
+if (not os.path.exists('../.git') and
+        not os.environ.get('SETUPTOOLS_SCM_PRETEND_VERSION')):
+    os.environ['SETUPTOOLS_SCM_PRETEND_VERSION'] = \
+        default_version.replace('-SNAPSHOT', 'a0')
+
+# See https://github.com/pypa/setuptools_scm#configuration-parameters
+scm_version_write_to_prefix = os.environ.get(
+    'SETUPTOOLS_SCM_VERSION_WRITE_TO_PREFIX', setup_dir)
+
+
+def parse_git(root, **kwargs):
+    """
+    Parse function for setuptools_scm that ignores tags for non-C++
+    subprojects, e.g. apache-arrow-js-XXX tags.
+    """
+    from setuptools_scm.git import parse
+    kwargs['describe_command'] =\
+        'git describe --dirty --tags --long --match "conbench-[0-9].*"'
+    return parse(root, **kwargs)
+
+
+def guess_next_dev_version(version):
+    if version.exact:
+        return version.format_with('{tag}')
+    else:
+        def guess_next_version(tag_version):
+            return default_version.replace('-SNAPSHOT', '')
+        return version.format_next_version(guess_next_version)
+
 setuptools.setup(
     name="conbench",
-    version="1.33.0",
+    # version="1.33.0",
+    use_scm_version={
+        'root': os.path.dirname(setup_dir),
+        'parse': parse_git,
+        'write_to': os.path.join(scm_version_write_to_prefix,
+                                 'conbench/_generated_version.py'),
+        'version_scheme': guess_next_dev_version
+    },
+    # use_scm_version=True,
     description="Continuous Benchmarking (CB) Framework",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -35,4 +80,5 @@ setuptools.setup(
     maintainer_email="dev@arrow.apache.org",
     url="https://github.com/conbench/conbench",
     install_requires=install_requires,
+    setup_requires=['setuptools_scm']
 )


### PR DESCRIPTION
This PR adds support for version tracking in conbench via `setuptools_scm`. It also adds content to README.md that helps to log in to `psql`.