### PR TITLE
Add GET /robots.txt to control crawlers

### DIFF
--- a/conbench/app/__init__.py
+++ b/conbench/app/__init__.py
@@ -9,5 +9,6 @@ from .batches import *  # noqa
 from .benchmarks import *  # noqa
 from .compare import *  # noqa
 from .index import *  # noqa
+from .robots import *  # noqa
 from .runs import *  # noqa
 from .users import *  # noqa

--- a/conbench/app/robots.py
+++ b/conbench/app/robots.py
@@ -1,0 +1,23 @@
+import flask as f
+
+from ..app import rule
+from ..app._endpoint import AppEndpoint
+from ..app.benchmarks import RunMixin
+
+
+class Robots(AppEndpoint, RunMixin):
+    def get(self):
+        response = f.Response(
+            response="User-Agent: *\nDisallow: /compare/\n",
+            status=200,
+            mimetype="text/plain",
+        )
+        response.headers["Content-Type"] = "text/plain; charset=utf-8"
+        return response
+
+
+rule(
+    "/robots.txt",
+    view_func=Robots.as_view("robots"),
+    methods=["GET"],
+)

--- a/conbench/tests/app/test_robots.py
+++ b/conbench/tests/app/test_robots.py
@@ -1,4 +1,4 @@
-def test_robots(self, client):
+def test_robots(client):
     response = client.get("/robots.txt")
     assert response.status_code == 200
     assert response.data == "User-Agent: *\nDisallow: /compare/\n"

--- a/conbench/tests/app/test_robots.py
+++ b/conbench/tests/app/test_robots.py
@@ -1,0 +1,4 @@
+def test_robots(self, client):
+    response = client.get("/robots.txt")
+    assert response.status_code == 200
+    assert response.data == "User-Agent: *\nDisallow: /compare/\n"

--- a/conbench/tests/app/test_robots.py
+++ b/conbench/tests/app/test_robots.py
@@ -1,4 +1,4 @@
 def test_robots(client):
     response = client.get("/robots.txt")
     assert response.status_code == 200
-    assert response.data == "User-Agent: *\nDisallow: /compare/\n"
+    assert response.get_data(as_text=True) == "User-Agent: *\nDisallow: /compare/\n"


### PR DESCRIPTION
Crawlers are creating too much load on Conbench db. 

Followed https://developers.google.com/search/docs/advanced/robots/create-robots-txt instructions to prevent crawlers from crawling expensive `/compare/*` links.

Note that most crawlers actually try to load `GET /robots.txt`:
<img width="1624" alt="Screen Shot 2022-01-11 at 2 54 22 PM" src="https://user-images.githubusercontent.com/5522472/149034367-d2c02555-7bf8-4652-9ab8-5175a7c61e8c.png">

