### PR TITLE
Set query timeout to 30 seconds

### DIFF
--- a/conbench/app/robots.py
+++ b/conbench/app/robots.py
@@ -2,10 +2,9 @@ import flask as f
 
 from ..app import rule
 from ..app._endpoint import AppEndpoint
-from ..app.benchmarks import RunMixin
 
 
-class Robots(AppEndpoint, RunMixin):
+class Robots(AppEndpoint):
     def get(self):
         response = f.Response(
             response="User-Agent: *\nDisallow: /compare/\n",

--- a/conbench/db.py
+++ b/conbench/db.py
@@ -14,7 +14,7 @@ def configure_engine(url):
         future=True,
         echo=False,
         pool_pre_ping=True,
-        connect_args={"options": "-c timezone=utc statement_timeout=30000"},
+        connect_args={"options": "-c timezone=utc -c statement_timeout=30s"},
     )
     session_maker.configure(bind=engine)
 

--- a/conbench/db.py
+++ b/conbench/db.py
@@ -14,7 +14,7 @@ def configure_engine(url):
         future=True,
         echo=False,
         pool_pre_ping=True,
-        connect_args={"options": "-c timezone=utc"},
+        connect_args={"options": "-c timezone=utc statement_timeout=30000"},
     )
     session_maker.configure(bind=engine)
 


### PR DESCRIPTION
A bunch of queries are running > 30 seconds after requests are timed out by gunicorn. Since gunicorn will timeout all requests in 30 seconds, we should not have any sql queries running > 30 seconds. 