### PR TITLE
Pin pytest to v. 6.2.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,5 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# PyCharm
+.idea/

--- a/conbench/machine_info.py
+++ b/conbench/machine_info.py
@@ -135,7 +135,7 @@ def machine_info(host_name):
 
 def _round_memory(value):
     # B -> GiB -> B
-    gigs = 1024 ** 3
+    gigs = 1024**3
     return int("{:.0f}".format(value / gigs)) * gigs
 
 
@@ -268,7 +268,7 @@ def _fill_from_lscpu(info, parts):
         try:
             if not info[key]:
                 if lookup.endswith("MHz"):
-                    info[key] = int(float(lscpu_dict[lookup]) * 10 ** 6)
+                    info[key] = int(float(lscpu_dict[lookup]) * 10**6)
                 else:
                     info[key] = int(float(lscpu_dict[lookup]))
         except ValueError:

--- a/conbench/units.py
+++ b/conbench/units.py
@@ -3,12 +3,12 @@ def items_per_second_fmt(value, unit):
         return None
     if value < 1000:
         return "{} {}".format(value, unit)
-    if value < 1000 ** 2:
+    if value < 1000**2:
         return "{:.3f} K {}".format(value / 1000, unit)
-    if value < 1000 ** 3:
-        return "{:.3f} M {}".format(value / 1000 ** 2, unit)
+    if value < 1000**3:
+        return "{:.3f} M {}".format(value / 1000**2, unit)
     else:
-        return "{:.3f} G {}".format(value / 1000 ** 3, unit)
+        return "{:.3f} G {}".format(value / 1000**3, unit)
 
 
 def bytes_per_second_fmt(value, unit):
@@ -16,14 +16,14 @@ def bytes_per_second_fmt(value, unit):
         return None
     if value < 1024:
         return "{} {}".format(value, unit)
-    if value < 1024 ** 2:
+    if value < 1024**2:
         return "{:.3f} Ki{}".format(value / 1024, unit)
-    if value < 1024 ** 3:
-        return "{:.3f} Mi{}".format(value / 1024 ** 2, unit)
-    if value < 1024 ** 4:
-        return "{:.3f} Gi{}".format(value / 1024 ** 3, unit)
+    if value < 1024**3:
+        return "{:.3f} Mi{}".format(value / 1024**2, unit)
+    if value < 1024**4:
+        return "{:.3f} Gi{}".format(value / 1024**3, unit)
     else:
-        return "{:.3f} Ti{}".format(value / 1024 ** 4, unit)
+        return "{:.3f} Ti{}".format(value / 1024**4, unit)
 
 
 def fmt_unit(value, unit):

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -19,7 +19,7 @@ openapi-spec-validator
 psutil
 psycopg2-binary
 py-cpuinfo
-pytest
+pytest==6.2.5
 python-dotenv
 PyYAML
 requests

--- a/requirements-cli.txt
+++ b/requirements-cli.txt
@@ -2,6 +2,6 @@ click
 numpy
 psutil
 py-cpuinfo
-pytest
+pytest==6.2.5
 PyYAML
 requests

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,4 +2,4 @@ black
 coverage
 flake8
 isort
-pytest
+pytest==6.2.5

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ install_requires = [
 
 setuptools.setup(
     name="conbench",
-    version="1.54.0",
+    version="1.55.0",
     description="Continuous Benchmarking (CB) Framework",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
`pytest==7.0.0` is causing these errors:
```
"/mnt/workspace/conda/envs/env/lib/python3.8/site-packages/conbench/util.py", line 145, in register_benchmarks
    import_path(f"{directory}/{filename}")
TypeError: import_path() missing 1 required keyword-only argument: 'root'
```