### PR TITLE
Better formatting for traceback in runs that error

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Migrations
         run: |
           alembic upgrade head
+        continue-on-error: true
         env:
           DB_USERNAME: "postgres"
           DB_HOST: "localhost"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -33,7 +33,6 @@ jobs:
       - name: Migrations
         run: |
           alembic upgrade head
-        continue-on-error: true
         env:
           DB_USERNAME: "postgres"
           DB_HOST: "localhost"

--- a/conbench/templates/benchmark-entity.html
+++ b/conbench/templates/benchmark-entity.html
@@ -65,7 +65,8 @@
             {% for k,v in benchmark.error.items() %}
               <li class="list-group-item" style="overflow-y: auto;">
                 <b>{{ k }}</b>
-                <div align="right" style="display:inline-block; float: right;">{{ v }}</div>
+                <br></br>
+                <div align="left" style="display:inline-block; white-space: pre-line; float: center;">{{ v }}</div>
               </li>
             {% endfor %}
           {% else %}

--- a/conbench/templates/benchmark-entity.html
+++ b/conbench/templates/benchmark-entity.html
@@ -65,8 +65,8 @@
             {% for k,v in benchmark.error.items() %}
               <li class="list-group-item" style="overflow-y: auto;">
                 <b>{{ k }}</b>
-                <br></br>
-                <div align="left" style="display:inline-block; white-space: pre-line; float: center;">{{ v }}</div>
+                <br />
+                <div align="left" style="display:inline-block; white-space: pre; float: center;">{{ v }}</div>
               </li>
             {% endfor %}
           {% else %}

--- a/conbench/templates/benchmark-entity.html
+++ b/conbench/templates/benchmark-entity.html
@@ -65,7 +65,7 @@
             {% for k,v in benchmark.error.items() %}
               <li class="list-group-item" style="overflow-y: auto;">
                 <b>{{ k }}</b>
-                <br />
+                <br> <br />
                 <div align="left" style="display:inline-block; white-space: pre; float: center;">{{ v }}</div>
               </li>
             {% endfor %}


### PR DESCRIPTION
Closes #312 

Before this PR an error looks (which don't recognize end of lines `'\n'`)
![conbench_error_before](https://user-images.githubusercontent.com/20308634/160681928-1a6d738f-6868-4211-b1d2-3a0d9cbeb39a.png)

After this PR
![conbench_error_after](https://user-images.githubusercontent.com/20308634/160682053-bf0452cd-2b07-4885-94e9-c7e5ea33da47.png)
