### PR TITLE
Add docker-compose based testing to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,11 @@ password in postgres to `postgres`.
     (conbench) $ pytest -vv conbench/tests/
 
 
+### Run tests with docker
+    (conbench) $ cd ~/workspace/conbench/
+    (conbench) $ docker-compose run app pytest -vv conbench/tests/
+
+
 ### Format code
     (conbench) $ cd ~/workspace/conbench/
     (conbench) $ black .


### PR DESCRIPTION
This is a minor edit — we might consider highlighting it slightly more or putting it into two different sections (one for testing with a local postgres instance and one for testing inside of docker)