### PR TITLE
Rename machine table to hardware at the database level

### DIFF
--- a/conbench/entities/distribution.py
+++ b/conbench/entities/distribution.py
@@ -18,7 +18,7 @@ class Distribution(Base, EntityMixin):
     context_id = NotNull(s.String(50), s.ForeignKey("context.id", ondelete="CASCADE"))
     commit_id = NotNull(s.String(50), s.ForeignKey("commit.id", ondelete="CASCADE"))
     # machine table/columns are only renamed to hardware at code level but not at database level
-    hardware_hash = NotNull("machine_hash", s.String(250))
+    hardware_hash = NotNull(s.String(250))
     unit = NotNull(s.Text)
     mean_mean = Nullable(s.Numeric, check("mean_mean>=0"))
     mean_sd = Nullable(s.Numeric, check("mean_sd>=0"))
@@ -44,7 +44,7 @@ s.Index(
 )
 
 s.Index(
-    "distribution_commit_machine_index",
+    "distribution_commit_hardware_index",
     Distribution.commit_id,
     Distribution.hardware_hash,
 )
@@ -120,8 +120,7 @@ def update_distribution(benchmark_result, limit):
 
     values = dict(distribution)
     hardware_hash = values.pop("hash")
-    # machine table/columns are only renamed to hardware at code level but not at database level
-    values["machine_hash"] = hardware_hash
+    values["hardware_hash"] = hardware_hash
     values["limit"] = limit
 
     with engine.connect() as conn:
@@ -129,8 +128,7 @@ def update_distribution(benchmark_result, limit):
             insert(Distribution.__table__)
             .values(values)
             .on_conflict_do_update(
-                # machine table/columns are only renamed to hardware at code level but not at database level
-                index_elements=["case_id", "context_id", "commit_id", "machine_hash"],
+                index_elements=["case_id", "context_id", "commit_id", "hardware_hash"],
                 set_=values,
             )
         )

--- a/conbench/entities/hardware.py
+++ b/conbench/entities/hardware.py
@@ -18,7 +18,7 @@ from ..entities._entity import (
 
 
 class Hardware(Base, EntityMixin):
-    __tablename__ = "machine"
+    __tablename__ = "hardware"
     id = NotNull(s.String(50), primary_key=True, default=generate_uuid)
     name = NotNull(s.Text)
     type = NotNull(s.String(50))

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -16,7 +16,7 @@ class Run(Base, EntityMixin):
     commit_id = NotNull(s.String(50), s.ForeignKey("commit.id"))
     commit = relationship("Commit", lazy="joined")
     has_errors = NotNull(s.Boolean, default=False)
-    hardware_id = NotNull("machine_id", s.String(50), s.ForeignKey("machine.id"))
+    hardware_id = NotNull(s.String(50), s.ForeignKey("hardware.id"))
     hardware = relationship("Hardware", lazy="joined")
 
     def get_baseline_run(self):

--- a/conbench/tests/entities/test_distribution.py
+++ b/conbench/tests/entities/test_distribution.py
@@ -15,12 +15,12 @@ from ...tests.helpers import _uuid
 REPO = "https://github.com/org/something"
 MACHINE = "diana-2-2-4-17179869184"
 
-DISTRIBUTION = """SELECT text(:text_1) AS case_id, text(:text_2) AS context_id, text(:text_3) AS commit_id, machine.hash AS hash, max(benchmark_result.unit) AS unit, avg(benchmark_result.mean) AS mean_mean, stddev(benchmark_result.mean) AS mean_sd, avg(benchmark_result.min) AS min_mean, stddev(benchmark_result.min) AS min_sd, avg(benchmark_result.max) AS max_mean, stddev(benchmark_result.max) AS max_sd, avg(benchmark_result.median) AS median_mean, stddev(benchmark_result.median) AS median_sd, min(commits_up.timestamp) AS first_timestamp, max(commits_up.timestamp) AS last_timestamp, count(benchmark_result.mean) AS observations 
-FROM benchmark_result JOIN run ON run.id = benchmark_result.run_id JOIN machine ON machine.id = run.hardware_id JOIN (SELECT commit.id AS id, commit.timestamp AS timestamp 
+DISTRIBUTION = """SELECT text(:text_1) AS case_id, text(:text_2) AS context_id, text(:text_3) AS commit_id, hardware.hash AS hash, max(benchmark_result.unit) AS unit, avg(benchmark_result.mean) AS mean_mean, stddev(benchmark_result.mean) AS mean_sd, avg(benchmark_result.min) AS min_mean, stddev(benchmark_result.min) AS min_sd, avg(benchmark_result.max) AS max_mean, stddev(benchmark_result.max) AS max_sd, avg(benchmark_result.median) AS median_mean, stddev(benchmark_result.median) AS median_sd, min(commits_up.timestamp) AS first_timestamp, max(commits_up.timestamp) AS last_timestamp, count(benchmark_result.mean) AS observations 
+FROM benchmark_result JOIN run ON run.id = benchmark_result.run_id JOIN hardware ON hardware.id = run.hardware_id JOIN (SELECT commit.id AS id, commit.timestamp AS timestamp 
 FROM commit 
 WHERE commit.repository = :repository_1 AND commit.timestamp IS NOT NULL AND commit.timestamp <= :timestamp_1 ORDER BY commit.timestamp DESC
  LIMIT :param_1) AS commits_up ON commits_up.id = run.commit_id 
-WHERE run.name LIKE :name_1 AND benchmark_result.case_id = :case_id_1 AND benchmark_result.context_id = :context_id_1 AND machine.hash = :hash_1 GROUP BY benchmark_result.case_id, benchmark_result.context_id, machine.hash"""  # noqa
+WHERE run.name LIKE :name_1 AND benchmark_result.case_id = :case_id_1 AND benchmark_result.context_id = :context_id_1 AND hardware.hash = :hash_1 GROUP BY benchmark_result.case_id, benchmark_result.context_id, hardware.hash"""  # noqa
 
 
 def test_z_score_calculations():

--- a/conbench/tests/entities/test_distribution.py
+++ b/conbench/tests/entities/test_distribution.py
@@ -16,7 +16,7 @@ REPO = "https://github.com/org/something"
 MACHINE = "diana-2-2-4-17179869184"
 
 DISTRIBUTION = """SELECT text(:text_1) AS case_id, text(:text_2) AS context_id, text(:text_3) AS commit_id, machine.hash AS hash, max(benchmark_result.unit) AS unit, avg(benchmark_result.mean) AS mean_mean, stddev(benchmark_result.mean) AS mean_sd, avg(benchmark_result.min) AS min_mean, stddev(benchmark_result.min) AS min_sd, avg(benchmark_result.max) AS max_mean, stddev(benchmark_result.max) AS max_sd, avg(benchmark_result.median) AS median_mean, stddev(benchmark_result.median) AS median_sd, min(commits_up.timestamp) AS first_timestamp, max(commits_up.timestamp) AS last_timestamp, count(benchmark_result.mean) AS observations 
-FROM benchmark_result JOIN run ON run.id = benchmark_result.run_id JOIN machine ON machine.id = run.machine_id JOIN (SELECT commit.id AS id, commit.timestamp AS timestamp 
+FROM benchmark_result JOIN run ON run.id = benchmark_result.run_id JOIN machine ON machine.id = run.hardware_id JOIN (SELECT commit.id AS id, commit.timestamp AS timestamp 
 FROM commit 
 WHERE commit.repository = :repository_1 AND commit.timestamp IS NOT NULL AND commit.timestamp <= :timestamp_1 ORDER BY commit.timestamp DESC
  LIMIT :param_1) AS commits_up ON commits_up.id = run.commit_id 

--- a/migrations/versions/5d516a1f293d_rename_machine_table_to_hardware.py
+++ b/migrations/versions/5d516a1f293d_rename_machine_table_to_hardware.py
@@ -1,0 +1,46 @@
+"""Rename machine table to hardware
+
+Revision ID: 5d516a1f293d
+Revises: cdba49649363
+Create Date: 2022-03-31 14:53:55.773066
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "5d516a1f293d"
+down_revision = "cdba49649363"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("ALTER TABLE machine RENAME CONSTRAINT machine_pkey TO hardware_pkey")
+    op.execute("ALTER INDEX machine_index RENAME TO hardware_index")
+    op.execute("DROP INDEX distribution_commit_machine_index")
+    op.execute("ALTER TABLE distribution RENAME COLUMN machine_hash TO hardware_hash")
+    op.execute(
+        "CREATE INDEX distribution_commit_hardware_index ON distribution (commit_id, hardware_hash)"
+    )
+    op.execute("ALTER TABLE run DROP CONSTRAINT run_machine_id_fkey")
+    op.execute("ALTER TABLE run RENAME COLUMN machine_id TO hardware_id")
+    op.rename_table("machine", "hardware")
+    op.execute(
+        "ALTER TABLE run ADD CONSTRAINT run_hardware_id_fkey FOREIGN KEY (hardware_id) REFERENCES hardware (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION"
+    )
+
+
+def downgrade():
+    op.execute("ALTER TABLE run DROP CONSTRAINT run_hardware_id_fkey")
+    op.rename_table("hardware", "machine")
+    op.execute("ALTER TABLE run RENAME COLUMN hardware_id TO machine_id")
+    op.execute(
+        "ALTER TABLE run ADD CONSTRAINT run_machine_id_fkey FOREIGN KEY (machine_id) REFERENCES machine (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION"
+    )
+    op.execute("DROP INDEX distribution_commit_hardware_index")
+    op.execute("ALTER TABLE distribution RENAME COLUMN hardware_hash TO machine_hash")
+    op.execute(
+        "CREATE INDEX distribution_commit_machine_index ON distribution (commit_id, machine_hash)"
+    )
+    op.execute("ALTER INDEX hardware_index RENAME TO machine_index")
+    op.execute("ALTER TABLE hardware RENAME CONSTRAINT hardware_pkey TO machine_pkey")


### PR DESCRIPTION
This PR renames `machine` table to `hardware` at the database level.