### PR TITLE
Rename machine_index to hardware_index

### DIFF
--- a/conbench/entities/hardware.py
+++ b/conbench/entities/hardware.py
@@ -135,7 +135,7 @@ class Cluster(Hardware):
 
 
 s.Index(
-    "machine_index",
+    "hardware_index",
     Machine.name,
     Machine.architecture_name,
     Machine.kernel_name,


### PR DESCRIPTION
Missed this change when working on https://github.com/conbench/conbench/pull/326