### PR TITLE
Baseline run should be last run for parent commit with at least one benchmark and context pair matching contender's

### DIFF
--- a/.buildkite/conbench-test/pipeline.yml
+++ b/.buildkite/conbench-test/pipeline.yml
@@ -8,7 +8,7 @@ steps:
   - label: "Test"
     key: "test"
     depends_on: "build"
-    command: docker-compose run app pytest -vv conbench/tests/api/test_runs.py
+    command: docker-compose run app pytest -vv conbench/tests/
 
   - label: "Test Migrations"
     key: "test-migrations"

--- a/.buildkite/conbench-test/pipeline.yml
+++ b/.buildkite/conbench-test/pipeline.yml
@@ -8,7 +8,7 @@ steps:
   - label: "Test"
     key: "test"
     depends_on: "build"
-    command: docker-compose run app pytest -vv conbench/tests/
+    command: docker-compose run app pytest -vv conbench/tests/api/test_runs.py
 
   - label: "Test Migrations"
     key: "test-migrations"

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -64,12 +64,9 @@ class Run(Base, EntityMixin):
         for row in result:
             parent_run_items[row[0]].append((row[1], row[2]))
 
-        # return run with matching contexts & cases
-        # TODO:
-        #   - what if all the contexts/cases just aren't yet in?
-        #   - what if one of N benchmark cases failed?
+        # return last run with intersecting case and context pairs
         for parent_run in parent_runs:
-            if set(run_items) == set(parent_run_items[parent_run.id]):
+            if set(run_items) & set(parent_run_items[parent_run.id]):
                 return parent_run
 
         return None

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -97,6 +97,7 @@ class TestRunGet(_asserts.GetEnforcer):
             name=name_1, sha=_fixtures.PARENT, language=language_2, run_id="3"
         )
         response = client.get(f"/api/runs/{1}/")
+        print(response.json)
         assert not response.json
 
     def test_closest_commit_different_machines(self, client):

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -77,28 +77,66 @@ class TestRunGet(_asserts.GetEnforcer):
         self.assert_200_ok(response, _expected_entity(run_2, baseline_2.id))
 
     def test_get_run_find_correct_baseline_with_multiple_runs(self, client):
-        # same context for different benchmark runs, but different benchmarks
         language_1, language_2, name_1, name_2 = _uuid(), _uuid(), _uuid(), _uuid()
+        contender_run_id, baseline_run_id_1, baseline_run_id_2 = (
+            _uuid(),
+            _uuid(),
+            _uuid(),
+        )
 
         self.authenticate(client)
-        # Create contender run with id = 1 and two benchmark results
+        # Create contender run with two benchmark results
         _fixtures.benchmark_result(
-            name=name_1, sha=_fixtures.CHILD, language=language_1, run_id="1"
+            name=name_1,
+            sha=_fixtures.CHILD,
+            language=language_1,
+            run_id=contender_run_id,
         )
         _fixtures.benchmark_result(
-            name=name_2, sha=_fixtures.CHILD, language=language_1, run_id="1"
+            name=name_2,
+            sha=_fixtures.CHILD,
+            language=language_1,
+            run_id=contender_run_id,
         )
-        # Create baseline run with id = 2 and one benchmark result matching contender's
+        # Create baseline run one benchmark result matching contender's
         _fixtures.benchmark_result(
-            name=name_1, sha=_fixtures.PARENT, language=language_1, run_id="2"
+            name=name_1,
+            sha=_fixtures.PARENT,
+            language=language_1,
+            run_id=baseline_run_id_1,
         )
-        # Create baseline run with id = 3 with no benchmark results matching contender's
+        # Create baseline run with no benchmark results matching contender's
         _fixtures.benchmark_result(
-            name=name_1, sha=_fixtures.PARENT, language=language_2, run_id="3"
+            name=name_1,
+            sha=_fixtures.PARENT,
+            language=language_2,
+            run_id=baseline_run_id_2,
         )
-        response = client.get(f"/api/runs/{1}/")
-        print(response.json)
-        assert not response.json
+        response = client.get(f"/api/runs/{contender_run_id}/")
+        assert (
+            response.json["links"]["baseline"]
+            == f"http://localhost/api/runs/{baseline_run_id_1}/"
+        )
+
+    def test_get_run_without_baseline_run_with_matching_benchmarks(self, client):
+        language_1, language_2, name, = (
+            _uuid(),
+            _uuid(),
+            _uuid(),
+        )
+        contender_run_id, baseline_run_id = _uuid(), _uuid()
+
+        self.authenticate(client)
+        # Create contender run with one benchmark result
+        _fixtures.benchmark_result(
+            name=name, sha=_fixtures.CHILD, language=language_1, run_id=contender_run_id
+        )
+        # Create baseline run with no benchmark results matching contender's
+        _fixtures.benchmark_result(
+            name=name, sha=_fixtures.PARENT, language=language_2, run_id=baseline_run_id
+        )
+        response = client.get(f"/api/runs/{contender_run_id}/")
+        assert not response.json["links"]["baseline"]
 
     def test_closest_commit_different_machines(self, client):
         # same benchmarks, different machines

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -76,6 +76,29 @@ class TestRunGet(_asserts.GetEnforcer):
         response = client.get(f"/api/runs/{run_2.id}/")
         self.assert_200_ok(response, _expected_entity(run_2, baseline_2.id))
 
+    def test_get_run_find_correct_baseline_with_multiple_runs(self, client):
+        # same context for different benchmark runs, but different benchmarks
+        language_1, language_2, name_1, name_2 = _uuid(), _uuid(), _uuid(), _uuid()
+
+        self.authenticate(client)
+        # Create contender run with id = 1 and two benchmark results
+        _fixtures.benchmark_result(
+            name=name_1, sha=_fixtures.CHILD, language=language_1, run_id="1"
+        )
+        _fixtures.benchmark_result(
+            name=name_2, sha=_fixtures.CHILD, language=language_1, run_id="1"
+        )
+        # Create baseline run with id = 2 and one benchmark result matching contender's
+        _fixtures.benchmark_result(
+            name=name_1, sha=_fixtures.PARENT, language=language_1, run_id="2"
+        )
+        # Create baseline run with id = 3 with no benchmark results matching contender's
+        _fixtures.benchmark_result(
+            name=name_1, sha=_fixtures.PARENT, language=language_2, run_id="3"
+        )
+        response = client.get(f"/api/runs/{1}/")
+        assert not response.json
+
     def test_closest_commit_different_machines(self, client):
         # same benchmarks, different machines
         name, machine_1, machine_2 = _uuid(), _uuid(), _uuid()


### PR DESCRIPTION
This PR changes logic used for finding a baseline run for a contender run. 
Baseline run is now set to the last run for a parent commit with at least one benchmark/context pair matching contender's instead of all benchmark and context pairs matching contender's.