### PR TITLE
Modify conbench api to accept multiple queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # PyCharm
 .idea/
+
+# vscode project settings
+.vscode/launch.json

--- a/conbench/api/benchmarks.py
+++ b/conbench/api/benchmarks.py
@@ -100,29 +100,25 @@ class BenchmarkListAPI(ApiEndpoint, BenchmarkValidationMixin):
         tags:
           - Benchmarks
         """
-        name = f.request.args.get("name")
-        batch_id = f.request.args.get("batch_id")
-        run_id = f.request.args.get("run_id")
-        if name:
+        if name_arg := f.request.args.get("name"):
             benchmark_results = BenchmarkResult.search(
-                filters=[Case.name == name],
+                filters=[Case.name == name_arg],
                 joins=[Case],
             )
             # TODO: cannot currently compute z_score on an arbitrary
             # list of benchmark_results - assumes same machine/sha/repository.
             for benchmark_result in benchmark_results:
                 benchmark_result.z_score = 0
-        elif batch_id:
-            batch_id_list = batch_id.split(",")
+        elif batch_id_arg := f.request.args.get("batch_id"):
+            batch_ids = batch_id_arg.split(",")
             benchmark_results = BenchmarkResult.search(
-                filters=[BenchmarkResult.batch_id.in_(batch_id_list)]
+                filters=[BenchmarkResult.batch_id.in_(batch_ids)]
             )
-            # benchmark_results = BenchmarkResult.all(batch_id=batch_id)
             set_z_scores(benchmark_results)
-        elif run_id:
-            run_id_list = run_id.split(",")
+        elif run_id_arg := f.request.args.get("run_id"):
+            run_ids = run_id_arg.split(",")
             benchmark_results = BenchmarkResult.search(
-                filters=[BenchmarkResult.run_id.in_(run_id_list)]
+                filters=[BenchmarkResult.run_id.in_(run_ids)]
             )
             set_z_scores(benchmark_results)
         else:

--- a/conbench/api/benchmarks.py
+++ b/conbench/api/benchmarks.py
@@ -113,10 +113,17 @@ class BenchmarkListAPI(ApiEndpoint, BenchmarkValidationMixin):
             for benchmark_result in benchmark_results:
                 benchmark_result.z_score = 0
         elif batch_id:
-            benchmark_results = BenchmarkResult.all(batch_id=batch_id)
+            batch_id_list = batch_id.split(",")
+            benchmark_results = BenchmarkResult.search(
+                filters=[BenchmarkResult.batch_id.in_(batch_id_list)]
+            )
+            # benchmark_results = BenchmarkResult.all(batch_id=batch_id)
             set_z_scores(benchmark_results)
         elif run_id:
-            benchmark_results = BenchmarkResult.all(run_id=run_id)
+            run_id_list = run_id.split(",")
+            benchmark_results = BenchmarkResult.search(
+                filters=[BenchmarkResult.run_id.in_(run_id_list)]
+            )
             set_z_scores(benchmark_results)
         else:
             benchmark_results = BenchmarkResult.all(

--- a/conbench/api/commits.py
+++ b/conbench/api/commits.py
@@ -1,3 +1,5 @@
+import flask as f
+
 from ..api import rule
 from ..api._endpoint import ApiEndpoint, maybe_login_required
 from ..entities._entity import NotFound
@@ -18,7 +20,12 @@ class CommitListAPI(ApiEndpoint):
         tags:
           - Commits
         """
-        commits = Commit.all(order_by=Commit.timestamp.desc(), limit=500)
+        commit = f.request.args.get("commit")
+        if commit:
+            commit_list = commit.split(",")
+            commits = Commit.search([Commit.sha.in_(commit_list)])
+        else:
+            commits = Commit.all(order_by=Commit.timestamp.desc(), limit=500)
         return self.serializer.many.dump(commits)
 
 

--- a/conbench/api/commits.py
+++ b/conbench/api/commits.py
@@ -20,10 +20,9 @@ class CommitListAPI(ApiEndpoint):
         tags:
           - Commits
         """
-        commit = f.request.args.get("commit")
-        if commit:
-            commit_list = commit.split(",")
-            commits = Commit.search([Commit.sha.in_(commit_list)])
+        if sha_arg := f.request.args.get("sha"):
+            shas = sha_arg.split(",")
+            commits = Commit.search([Commit.sha.in_(shas)])
         else:
             commits = Commit.all(order_by=Commit.timestamp.desc(), limit=500)
         return self.serializer.many.dump(commits)

--- a/conbench/api/runs.py
+++ b/conbench/api/runs.py
@@ -85,8 +85,7 @@ class RunListAPI(ApiEndpoint):
         """
         sha = f.request.args.get("sha") 
         if sha:
-            sha_list = sha.split(",")
-            runs = Run.search(filters=[Commit.sha.in_(sha_list)], joins=[Commit])
+            runs = Run.search(filters=[Commit.sha.in_(sha.split(","))], joins=[Commit])
         else:
             runs = Run.all(order_by=Run.timestamp.desc(), limit=1000)
         return self.serializer.many.dump(runs)

--- a/conbench/api/runs.py
+++ b/conbench/api/runs.py
@@ -83,10 +83,9 @@ class RunListAPI(ApiEndpoint):
         tags:
           - Runs
         """
-        sha = f.request.args.get("sha")
-        if sha:
-            sha_list = sha.split(",")
-            runs = Run.search(filters=[Commit.sha.in_(sha_list)], joins=[Commit])
+        if sha_arg := f.request.args.get("sha"):
+            shas = sha_arg.split(",")
+            runs = Run.search(filters=[Commit.sha.in_(shas)], joins=[Commit])
         else:
             runs = Run.all(order_by=Run.timestamp.desc(), limit=1000)
         return self.serializer.many.dump(runs)

--- a/conbench/api/runs.py
+++ b/conbench/api/runs.py
@@ -83,9 +83,10 @@ class RunListAPI(ApiEndpoint):
         tags:
           - Runs
         """
-        sha = f.request.args.getlist("sha")
+        sha = f.request.args.get("sha") 
         if sha:
-            runs = Run.search(filters=[Commit.sha.in_(sha)], joins=[Commit])
+            sha_list = sha.split(",")
+            runs = Run.search(filters=[Commit.sha.in_(sha_list)], joins=[Commit])
         else:
             runs = Run.all(order_by=Run.timestamp.desc(), limit=1000)
         return self.serializer.many.dump(runs)

--- a/conbench/api/runs.py
+++ b/conbench/api/runs.py
@@ -83,9 +83,9 @@ class RunListAPI(ApiEndpoint):
         tags:
           - Runs
         """
-        sha = f.request.args.get("sha")
+        sha = f.request.args.getlist("sha")
         if sha:
-            runs = Run.search(filters=[Commit.sha == sha], joins=[Commit])
+            runs = Run.search(filters=[Commit.sha.in_(sha)], joins=[Commit])
         else:
             runs = Run.all(order_by=Run.timestamp.desc(), limit=1000)
         return self.serializer.many.dump(runs)

--- a/conbench/api/runs.py
+++ b/conbench/api/runs.py
@@ -83,9 +83,10 @@ class RunListAPI(ApiEndpoint):
         tags:
           - Runs
         """
-        sha = f.request.args.get("sha") 
+        sha = f.request.args.get("sha")
         if sha:
-            runs = Run.search(filters=[Commit.sha.in_(sha.split(","))], joins=[Commit])
+            sha_list = sha.split(",")
+            runs = Run.search(filters=[Commit.sha.in_(sha_list)], joins=[Commit])
         else:
             runs = Run.all(order_by=Run.timestamp.desc(), limit=1000)
         return self.serializer.many.dump(runs)

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -182,7 +182,6 @@ class _Serializer(EntitySerializer):
             "run_id": benchmark_result.run_id,
             "batch_id": benchmark_result.batch_id,
             "timestamp": benchmark_result.timestamp.isoformat(),
-            "info": benchmark_result.info_id,
             "tags": tags,
             "stats": {
                 "data": [to_float(x) for x in benchmark_result.data],

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -182,6 +182,7 @@ class _Serializer(EntitySerializer):
             "run_id": benchmark_result.run_id,
             "batch_id": benchmark_result.batch_id,
             "timestamp": benchmark_result.timestamp.isoformat(),
+            "info": benchmark_result.info_id,
             "tags": tags,
             "stats": {
                 "data": [to_float(x) for x in benchmark_result.data],

--- a/conbench/tests/api/test_benchmarks.py
+++ b/conbench/tests/api/test_benchmarks.py
@@ -271,11 +271,19 @@ class TestBenchmarkList(_asserts.ListEnforcer):
 
     def test_benchmark_list_filter_by_batch_id(self, client):
         self.authenticate(client)
-        _fixtures.benchmark_result(batch_id="10")
         benchmark_result = _fixtures.benchmark_result(batch_id="20")
-        _fixtures.benchmark_result(batch_id="30")
         response = client.get("/api/benchmarks/?batch_id=20")
         self.assert_200_ok(response, [_expected_entity(benchmark_result)])
+
+    def test_benchmark_list_filter_by_multiple_batch_id(self, client):
+        self.authenticate(client)
+        benchmark_result_1 = _fixtures.benchmark_result()
+        batch_id1 = benchmark_result_1.batch_id
+        benchmark_result_2 = _fixtures.benchmark_result()
+        batch_id2 = benchmark_result_2.batch_id
+        response = client.get(f"/api/benchmarks/?batch_id={batch_id1},{batch_id2}")
+        self.assert_200_ok(response, contains=_expected_entity(benchmark_result_1))
+        self.assert_200_ok(response, contains=_expected_entity(benchmark_result_2))
 
     def test_benchmark_list_filter_by_run_id(self, client):
         self.authenticate(client)
@@ -284,6 +292,16 @@ class TestBenchmarkList(_asserts.ListEnforcer):
         _fixtures.benchmark_result(run_id="300")
         response = client.get("/api/benchmarks/?run_id=200")
         self.assert_200_ok(response, [_expected_entity(benchmark_result)])
+
+    def test_benchmark_list_filter_by_multiple_run_id(self, client):
+        self.authenticate(client)
+        benchmark_result_1 = _fixtures.benchmark_result()
+        run_id1 = benchmark_result_1.run_id
+        benchmark_result_2 = _fixtures.benchmark_result()
+        run_id2 = benchmark_result_2.run_id
+        response = client.get(f"/api/benchmarks/?run_id={run_id1},{run_id2}")
+        self.assert_200_ok(response, contains=_expected_entity(benchmark_result_1))
+        self.assert_200_ok(response, contains=_expected_entity(benchmark_result_2))
 
 
 class TestBenchmarkPost(_asserts.PostEnforcer):

--- a/conbench/tests/api/test_benchmarks.py
+++ b/conbench/tests/api/test_benchmarks.py
@@ -278,10 +278,10 @@ class TestBenchmarkList(_asserts.ListEnforcer):
     def test_benchmark_list_filter_by_multiple_batch_id(self, client):
         self.authenticate(client)
         benchmark_result_1 = _fixtures.benchmark_result()
-        batch_id1 = benchmark_result_1.batch_id
+        batch_id_1 = benchmark_result_1.batch_id
         benchmark_result_2 = _fixtures.benchmark_result()
-        batch_id2 = benchmark_result_2.batch_id
-        response = client.get(f"/api/benchmarks/?batch_id={batch_id1},{batch_id2}")
+        batch_id_2 = benchmark_result_2.batch_id
+        response = client.get(f"/api/benchmarks/?batch_id={batch_id_1},{batch_id_2}")
         self.assert_200_ok(response, contains=_expected_entity(benchmark_result_1))
         self.assert_200_ok(response, contains=_expected_entity(benchmark_result_2))
 
@@ -296,10 +296,10 @@ class TestBenchmarkList(_asserts.ListEnforcer):
     def test_benchmark_list_filter_by_multiple_run_id(self, client):
         self.authenticate(client)
         benchmark_result_1 = _fixtures.benchmark_result()
-        run_id1 = benchmark_result_1.run_id
+        run_id_1 = benchmark_result_1.run_id
         benchmark_result_2 = _fixtures.benchmark_result()
-        run_id2 = benchmark_result_2.run_id
-        response = client.get(f"/api/benchmarks/?run_id={run_id1},{run_id2}")
+        run_id_2 = benchmark_result_2.run_id
+        response = client.get(f"/api/benchmarks/?run_id={run_id_1},{run_id_2}")
         self.assert_200_ok(response, contains=_expected_entity(benchmark_result_1))
         self.assert_200_ok(response, contains=_expected_entity(benchmark_result_2))
 

--- a/conbench/tests/api/test_commits.py
+++ b/conbench/tests/api/test_commits.py
@@ -53,14 +53,14 @@ class TestCommitList(_asserts.ListEnforcer):
         sha2 = _fixtures.PARENT
         self.authenticate(client)
         _fixtures.benchmark_result(sha=sha1)
-        benchmark_result1 = _fixtures.benchmark_result()
+        benchmark_result_1 = _fixtures.benchmark_result()
         _fixtures.benchmark_result(sha=sha2)
-        benchmark_result2 = _fixtures.benchmark_result()
+        benchmark_result_2 = _fixtures.benchmark_result()
         response = client.get(f"/api/commits/?commit={sha1},{sha2}")
 
         self.assert_200_ok(
-            response, contains=_expected_entity(benchmark_result1.run.commit)
+            response, contains=_expected_entity(benchmark_result_1.run.commit)
         )
         self.assert_200_ok(
-            response, contains=_expected_entity(benchmark_result2.run.commit)
+            response, contains=_expected_entity(benchmark_result_2.run.commit)
         )

--- a/conbench/tests/api/test_commits.py
+++ b/conbench/tests/api/test_commits.py
@@ -40,3 +40,27 @@ class TestCommitList(_asserts.ListEnforcer):
         commit = self._create()
         response = client.get("/api/commits/")
         self.assert_200_ok(response, contains=_expected_entity(commit))
+
+    def test_commit_list_filter_by_sha(self, client):
+        sha = _fixtures.CHILD
+        self.authenticate(client)
+        commit = self._create()
+        response = client.get(f"/api/commits/?commit={sha}")
+        self.assert_200_ok(response, contains=_expected_entity(commit))
+
+    def test_commit_list_filter_by_multiple_sha(self, client):
+        sha1 = _fixtures.CHILD
+        sha2 = _fixtures.PARENT
+        self.authenticate(client)
+        _fixtures.benchmark_result(sha=sha1)
+        benchmark_result1 = _fixtures.benchmark_result()
+        _fixtures.benchmark_result(sha=sha2)
+        benchmark_result2 = _fixtures.benchmark_result()
+        response = client.get(f"/api/commits/?commit={sha1},{sha2}")
+
+        self.assert_200_ok(
+            response, contains=_expected_entity(benchmark_result1.run.commit)
+        )
+        self.assert_200_ok(
+            response, contains=_expected_entity(benchmark_result2.run.commit)
+        )

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -233,6 +233,19 @@ class TestRunList(_asserts.ListEnforcer):
             response, contains=_expected_entity(run, include_baseline=False)
         )
 
+    def test_run_list_filter_by_multiple_sha(self, client):
+        sha1 = _fixtures.CHILD
+        sha2 = _fixtures.PARENT
+        self.authenticate(client)
+        run = self._create()
+        response = client.get(f"/api/runs/?sha={sha1},{sha2}")
+
+        self.assert_200_ok(
+            response,
+            contains = _expected_entity(run, include_baseline=False)
+        )
+
+
     def test_run_list_filter_by_sha_no_match(self, client):
         sha = "some unknown sha"
         self.authenticate(client)

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -241,10 +241,8 @@ class TestRunList(_asserts.ListEnforcer):
         response = client.get(f"/api/runs/?sha={sha1},{sha2}")
 
         self.assert_200_ok(
-            response,
-            contains = _expected_entity(run, include_baseline=False)
+            response, contains=_expected_entity(run, include_baseline=False)
         )
-
 
     def test_run_list_filter_by_sha_no_match(self, client):
         sha = "some unknown sha"

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -8,7 +8,6 @@ from ...tests.helpers import _uuid
 
 
 def _expected_entity(run, baseline_id=None, include_baseline=True):
-    print(run.commit)
     parent = run.commit.get_parent_commit()
     return _api_run_entity(
         run.id,

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -238,17 +238,17 @@ class TestRunList(_asserts.ListEnforcer):
         sha2 = _fixtures.PARENT
         self.authenticate(client)
         _fixtures.benchmark_result(sha=_fixtures.PARENT)
-        run1 = _fixtures.benchmark_result()
+        run_1 = _fixtures.benchmark_result()
         _fixtures.benchmark_result(sha=_fixtures.CHILD)
-        run2 = _fixtures.benchmark_result()
+        run_2 = _fixtures.benchmark_result()
         response = client.get(f"/api/runs/?sha={sha1},{sha2}")
 
         self.assert_200_ok(
-            response, contains=_expected_entity(run1.run, include_baseline=False)
+            response, contains=_expected_entity(run_1.run, include_baseline=False)
         )
 
         self.assert_200_ok(
-            response, contains=_expected_entity(run2.run, include_baseline=False)
+            response, contains=_expected_entity(run_2.run, include_baseline=False)
         )
 
     def test_run_list_filter_by_sha_no_match(self, client):

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -8,6 +8,7 @@ from ...tests.helpers import _uuid
 
 
 def _expected_entity(run, baseline_id=None, include_baseline=True):
+    print(run.commit)
     parent = run.commit.get_parent_commit()
     return _api_run_entity(
         run.id,
@@ -237,11 +238,18 @@ class TestRunList(_asserts.ListEnforcer):
         sha1 = _fixtures.CHILD
         sha2 = _fixtures.PARENT
         self.authenticate(client)
-        run = self._create()
+        _fixtures.benchmark_result(sha=_fixtures.PARENT)
+        run1 = _fixtures.benchmark_result()
+        _fixtures.benchmark_result(sha=_fixtures.CHILD)
+        run2 = _fixtures.benchmark_result()
         response = client.get(f"/api/runs/?sha={sha1},{sha2}")
 
         self.assert_200_ok(
-            response, contains=_expected_entity(run, include_baseline=False)
+            response, contains=_expected_entity(run1.run, include_baseline=False)
+        )
+
+        self.assert_200_ok(
+            response, contains=_expected_entity(run2.run, include_baseline=False)
         )
 
     def test_run_list_filter_by_sha_no_match(self, client):


### PR DESCRIPTION
This PR adds the ability to query multiple values for the benchmarks, runs and commits endpoints. I _think_ I've written tests that cover this behaviour but some 👀 on that would be much appreciated.

Given the way the history data is created I have not modified that endpoint as that seems a little more involved at this point though any feedback there is also welcomed.  

Closes #343 when merged