### PR TITLE
Changed Reason column on home page to Name

### DIFF
--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -104,15 +104,21 @@ class RunMixin:
         repository_name = repository
         if "github.com/" in repository:
             repository_name = repository.split("github.com/")[1]
-        run["display_name"] = ""
-        if run["name"]:
-            run["display_name"] = run["name"].split(":", 1)[0]
+        self._display_reason(run)
         run["commit"]["display_repository"] = repository_name
         commit_message = display_message(run["commit"]["message"])
         run["commit"]["display_message"] = commit_message
 
     def _display_time(self, obj, field):
         obj[f"display_{field}"] = display_time(obj[field])
+
+    def _display_reason(self, run):
+        run["display_name"] = ""
+        if run["name"]:
+            if "nightly" in run["name"]:
+                run["display_name"] = "nightly"
+            else:
+                run["display_name"] = run["name"].split(":", 1)[0]
 
     def _get_run(self, run_id):
         response = self.api_get("api.run", run_id=run_id)

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -104,21 +104,15 @@ class RunMixin:
         repository_name = repository
         if "github.com/" in repository:
             repository_name = repository.split("github.com/")[1]
-        self._display_reason(run)
+        run["display_name"] = ""
+        if run["name"]:
+            run["display_name"] = run["name"].split(":", 1)[0]
         run["commit"]["display_repository"] = repository_name
         commit_message = display_message(run["commit"]["message"])
         run["commit"]["display_message"] = commit_message
 
     def _display_time(self, obj, field):
         obj[f"display_{field}"] = display_time(obj[field])
-
-    def _display_reason(self, run):
-        run["display_name"] = ""
-        if run["name"]:
-            if "nightly" in run["name"]:
-                run["display_name"] = "nightly"
-            else:
-                run["display_name"] = run["name"].split(":", 1)[0]
 
     def _get_run(self, run_id):
         response = self.api_get("api.run", run_id=run_id)

--- a/conbench/app/index.py
+++ b/conbench/app/index.py
@@ -9,20 +9,12 @@ from ..config import Config
 
 class Index(AppEndpoint, RunMixin):
     def page(self, runs):
-        reasons = {r["display_name"] for r in runs if r["display_name"]}
-        commits = {r["commit"]["url"] for r in runs if r["commit"]["url"]}
-        authors = {
-            r["commit"]["author_name"] for r in runs if r["commit"]["author_name"]
-        }
         return self.render_template(
             "index.html",
             application=Config.APPLICATION_NAME,
             title="Home",
             version=__version__,
             runs=runs,
-            has_reasons=len(reasons) > 0,
-            has_authors=len(authors) > 0,
-            has_commits=len(commits) > 0,
             search_value=f.request.args.get("search"),
         )
 

--- a/conbench/static/app.css
+++ b/conbench/static/app.css
@@ -14,8 +14,8 @@ html {
 }
 
 /* fix datatable sorting icons */
-table.dataTable thead .sorting, 
-table.dataTable thead .sorting_asc, 
+table.dataTable thead .sorting,
+table.dataTable thead .sorting_asc,
 table.dataTable thead .sorting_desc {
   background : none;
 }
@@ -97,6 +97,11 @@ table.dataTable td {
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
+}
+
+.wordbreak-175 {
+  width: 175px;
+  overflow-wrap: break-word;
 }
 
 .ellipsis-500 {

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -35,7 +35,7 @@
                     <th scope="col">Commit</th>
                     <th scope="col">Hash</th>
                     <th scope="col">Hardware</th>
-                    <th scope="col">Reason</th>
+                    <th scope="col">Name</th>
                 </tr>
             </thead>
             <tbody>
@@ -71,8 +71,8 @@
                      <td>{{ run.commit.sha }}</td>
                      <td><div class="ellipsis-175">{{ run.hardware.name }}</div></td>
 
-                     {% if run.display_name %}
-                       <td><div class="ellipsis-175">{{ run.display_name }}</div></td>
+                     {% if run.name %}
+                       <td><div class="wordbreak-175">{{ run.name }}</div></td>
                      {% else %}
                        <td></td>
                      {% endif %}

--- a/conbench/tests/populate_local_conbench.py
+++ b/conbench/tests/populate_local_conbench.py
@@ -14,8 +14,13 @@ def generate_benchmarks_data(
     benchmark_language,
     timestamp,
     hardware_type,
+    is_nightly,
     mean=16.670462,
 ):
+    run_name = f"commit: {commit}"
+    if is_nightly:
+        run_name += " nightly"
+
     data = {
         "batch_id": uuid.uuid4().hex,
         "context": {
@@ -33,7 +38,7 @@ def generate_benchmarks_data(
             "benchmark_language_version": "Python 3.8.12",
         },
         "run_id": str(run_id),
-        "run_name": f"commit: {commit}",
+        "run_name": run_name,
         "stats": {
             "data": ["14.928533", "14.551965", "14.530887"],
             "iqr": "0.198823",
@@ -100,10 +105,10 @@ def generate_benchmarks_data(
 
 
 def generate_benchmarks_data_with_error(
-    run_id, commit, benchmark_name, benchmark_language, timestamp, hardware_type
+    run_id, commit, benchmark_name, benchmark_language, timestamp, hardware_type, is_nightly
 ):
     data = generate_benchmarks_data(
-        run_id, commit, benchmark_name, benchmark_language, timestamp, hardware_type
+        run_id, commit, benchmark_name, benchmark_language, timestamp, hardware_type, is_nightly
     )
     data.pop("stats")
     data["error"] = {"command": "some command", "stack trace": "stack trace ..."}
@@ -140,6 +145,8 @@ def create_benchmarks_data():
     means = [16.670462, 16.4, 16.5, 16.67, 16.7, 16.7]
 
     errors = [False, False, True, False, True, True]
+    
+    nightly = [False, True] * 3
 
     benchmark_names = ["csv-read", "csv-write"]
 
@@ -152,6 +159,7 @@ def create_benchmarks_data():
             for benchmark_language in benchmark_languages:
                 for benchmark_name in benchmark_names:
                     run_id, commit, mean = f"{hardware_type}{i+1}", commits[i], means[i]
+                    is_nightly = nightly[i]
                     timestamp = datetime.datetime.now() + datetime.timedelta(hours=i)
                     if errors[i] and benchmark_name == "csv-read":
                         benchmark_data = generate_benchmarks_data_with_error(
@@ -161,6 +169,7 @@ def create_benchmarks_data():
                             benchmark_language,
                             timestamp,
                             hardware_type,
+                            is_nightly,
                         )
                     else:
                         benchmark_data = generate_benchmarks_data(
@@ -170,6 +179,7 @@ def create_benchmarks_data():
                             benchmark_language,
                             timestamp,
                             hardware_type,
+                            is_nightly,
                             mean,
                         )
 

--- a/conbench/tests/populate_local_conbench.py
+++ b/conbench/tests/populate_local_conbench.py
@@ -105,10 +105,22 @@ def generate_benchmarks_data(
 
 
 def generate_benchmarks_data_with_error(
-    run_id, commit, benchmark_name, benchmark_language, timestamp, hardware_type, is_nightly
+    run_id,
+    commit,
+    benchmark_name,
+    benchmark_language,
+    timestamp,
+    hardware_type,
+    is_nightly,
 ):
     data = generate_benchmarks_data(
-        run_id, commit, benchmark_name, benchmark_language, timestamp, hardware_type, is_nightly
+        run_id,
+        commit,
+        benchmark_name,
+        benchmark_language,
+        timestamp,
+        hardware_type,
+        is_nightly,
     )
     data.pop("stats")
     data["error"] = {"command": "some command", "stack trace": "stack trace ..."}
@@ -145,7 +157,7 @@ def create_benchmarks_data():
     means = [16.670462, 16.4, 16.5, 16.67, 16.7, 16.7]
 
     errors = [False, False, True, False, True, True]
-    
+
     nightly = [False, True] * 3
 
     benchmark_names = ["csv-read", "csv-write"]


### PR DESCRIPTION
Fixes #336.

This PR changes the "Reason" column on the `conbench` home page to "Name," displaying the full run name, so users can tell at a glance why the run was triggered.