### PR TITLE
Added reason as first-class requestable attribute of Run

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,10 @@ Options:
   --show-result BOOLEAN  [default: true]
   --show-output BOOLEAN  [default: false]
   --run-id TEXT          Group executions together with a run id.
-  --run-name TEXT        Name of run (commit, pull request, etc).
+  --run-name TEXT        Free-text name of run (commit ABC, pull request 123,
+                         etc).
+  --run-reason TEXT      Low-cardinality reason for run (commit, pull request,
+                         manual, etc).
   --help                 Show this message and exit.
 ```
 
@@ -534,7 +537,10 @@ Options:
   --show-result BOOLEAN  [default: true]
   --show-output BOOLEAN  [default: false]
   --run-id TEXT          Group executions together with a run id.
-  --run-name TEXT        Name of run (commit, pull request, etc).
+  --run-name TEXT        Free-text name of run (commit ABC, pull request 123,
+                         etc).
+  --run-reason TEXT      Low-cardinality reason for run (commit, pull request,
+                         manual, etc).
   --help                 Show this message and exit.
 ```
 
@@ -709,7 +715,10 @@ Options:
   --show-result BOOLEAN  [default: true]
   --show-output BOOLEAN  [default: false]
   --run-id TEXT          Group executions together with a run id.
-  --run-name TEXT        Name of run (commit, pull request, etc).
+  --run-name TEXT        Free-text name of run (commit ABC, pull request 123,
+                         etc).
+  --run-reason TEXT      Low-cardinality reason for run (commit, pull request,
+                         manual, etc).
   --help                 Show this message and exit.
     """
 ```
@@ -963,7 +972,10 @@ Options:
   --show-result BOOLEAN  [default: true]
   --show-output BOOLEAN  [default: false]
   --run-id TEXT          Group executions together with a run id.
-  --run-name TEXT        Name of run (commit, pull request, etc).
+  --run-name TEXT        Free-text name of run (commit ABC, pull request 123,
+                         etc).
+  --run-reason TEXT      Low-cardinality reason for run (commit, pull request,
+                         manual, etc).
   --help                 Show this message and exit.
 ```
 
@@ -1033,6 +1045,9 @@ Options:
   --show-result BOOLEAN  [default: true]
   --show-output BOOLEAN  [default: false]
   --run-id TEXT          Group executions together with a run id.
-  --run-name TEXT        Name of run (commit, pull request, etc).
+  --run-name TEXT        Free-text name of run (commit ABC, pull request 123,
+                         etc).
+  --run-reason TEXT      Low-cardinality reason for run (commit, pull request,
+                         manual, etc).
   --help                 Show this message and exit.
 ```

--- a/conbench/api/_examples.py
+++ b/conbench/api/_examples.py
@@ -404,6 +404,7 @@ def _api_hardware_entity(
 def _api_run_entity(
     run_id,
     run_name,
+    run_reason,
     commit_id,
     parent_id,
     hardware_id,
@@ -417,6 +418,7 @@ def _api_run_entity(
     result = {
         "id": run_id,
         "name": run_name,
+        "reason": run_reason,
         "timestamp": now,
         "commit": _api_commit_entity(commit_id, parent_id, links=False),
         "hardware": _api_hardware_entity(
@@ -517,6 +519,7 @@ HARDWARE_ENTITY = _api_hardware_entity("some-machine-uuid-1", "some-machine-name
 RUN_ENTITY = _api_run_entity(
     "some-run-uuid-1",
     "some run name",
+    "some run reason",
     "some-commit-uuid-1",
     "some-parent-commit-uuid-1",
     "some-machine-uuid-1",
@@ -529,6 +532,7 @@ RUN_LIST = [
     _api_run_entity(
         "some-run-uuid-1",
         "some run name",
+        "some run reason",
         "some-commit-uuid-1",
         "some-parent-commit-uuid-1",
         "some-machine-uuid-1",

--- a/conbench/cli.py
+++ b/conbench/cli.py
@@ -129,7 +129,14 @@ for name, benchmark in BENCHMARKS.items():
         click.Option(
             ("--run-name",),
             type=str,
-            help="Name of run (commit, pull request, etc).",
+            help="Free-text name of run (commit ABC, pull request 123, etc).",
+        )
+    )
+    params.append(
+        click.Option(
+            ("--run-reason",),
+            type=str,
+            help="Low-cardinality reason for run (commit, pull request, manual, etc).",
         )
     )
 

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -111,6 +111,7 @@ class BenchmarkResult(Base, EntityMixin):
         # create if not exists
         run_id = data["run_id"]
         run_name = data.pop("run_name", None)
+        run_reason = data.pop("run_reason", None)
         run = Run.first(id=run_id)
         if run:
             if has_error:
@@ -121,6 +122,7 @@ class BenchmarkResult(Base, EntityMixin):
                 {
                     "id": run_id,
                     "name": run_name,
+                    "reason": run_reason,
                     "commit_id": commit.id,
                     "hardware_id": hardware.id,
                     "has_errors": has_error,
@@ -235,6 +237,7 @@ class GitHubCreate(marshmallow.Schema):
 class _BenchmarkFacadeSchemaCreate(marshmallow.Schema):
     run_id = marshmallow.fields.String(required=True)
     run_name = marshmallow.fields.String(required=False)
+    run_reason = marshmallow.fields.String(required=False)
     batch_id = marshmallow.fields.String(required=True)
     timestamp = marshmallow.fields.DateTime(required=True)
     machine_info = marshmallow.fields.Nested(MachineSchema().create, required=False)

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -12,6 +12,7 @@ class Run(Base, EntityMixin):
     __tablename__ = "run"
     id = NotNull(s.String(50), primary_key=True)
     name = Nullable(s.String(250))
+    reason = Nullable(s.String(250))
     timestamp = NotNull(s.DateTime(timezone=False), server_default=s.sql.func.now())
     commit_id = NotNull(s.String(50), s.ForeignKey("commit.id"))
     commit = relationship("Commit", lazy="joined")
@@ -85,6 +86,7 @@ class _Serializer(EntitySerializer):
         result = {
             "id": run.id,
             "name": run.name,
+            "reason": run.reason,
             "timestamp": run.timestamp.isoformat(),
             "commit": commit,
             "hardware": hardware,

--- a/conbench/runner.py
+++ b/conbench/runner.py
@@ -63,7 +63,9 @@ class Benchmark(abc.ABC):
         run_id : str, optional
             Group executions together with a run id.
         run_name : str, optional
-            Name of run (commit, pull request, etc).
+            Name of run (commit ABC, pull request 123, etc).
+        run_reason : str, optional
+            Reason for run (commit, pull request, manual, etc).
         Returns
         -------
         (result, output) : sequence
@@ -260,6 +262,10 @@ class Conbench(Connection, MixinPython, MixinR):
         run_name = options.get("run_name")
         if run_name is not None:
             benchmark["run_name"] = run_name
+
+        run_reason = options.get("run_reason")
+        if run_reason is not None:
+            benchmark["run_reason"] = run_reason
 
         if publish:
             self.publish(benchmark)

--- a/conbench/runner.py
+++ b/conbench/runner.py
@@ -63,9 +63,10 @@ class Benchmark(abc.ABC):
         run_id : str, optional
             Group executions together with a run id.
         run_name : str, optional
-            Name of run (commit ABC, pull request 123, etc).
+            Free-text name of run (commit ABC, pull request 123, etc).
         run_reason : str, optional
-            Reason for run (commit, pull request, manual, etc).
+            Reason for run (commit, pull request, manual, etc). Probably will be used
+            to group runs, so try to keep the cardinality low.
         Returns
         -------
         (result, output) : sequence

--- a/conbench/static/app.css
+++ b/conbench/static/app.css
@@ -21,7 +21,6 @@ table.dataTable thead .sorting_desc {
 }
 
 table.dataTable td {
-  padding: 6px !important;
   font-size: 13.4px;
 }
 

--- a/conbench/templates/benchmark-entity.html
+++ b/conbench/templates/benchmark-entity.html
@@ -46,10 +46,18 @@
               </div>
             </li>
             <li class="list-group-item" style="overflow-y: auto;">
-              <b>reason</b>
+              <b>run name</b>
               <div align="right" style="display:inline-block; float: right;">
 	            {% if run.name %}
                   {{ run.name }}
+                {% endif %}
+              </div>
+            </li>
+            <li class="list-group-item" style="overflow-y: auto;">
+              <b>run reason</b>
+              <div align="right" style="display:inline-block; float: right;">
+	            {% if run.reason %}
+                  {{ run.reason }}
                 {% endif %}
               </div>
             </li>

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -35,6 +35,7 @@
                     <th scope="col">Commit</th>
                     <th scope="col">Hash</th>
                     <th scope="col">Hardware</th>
+                    <th scope="col">Reason</th>
                     <th scope="col">Name</th>
                 </tr>
             </thead>
@@ -71,6 +72,12 @@
                      <td>{{ run.commit.sha }}</td>
                      <td><div class="ellipsis-175">{{ run.hardware.name }}</div></td>
 
+                     {% if run.reason %}
+                       <td><div class="ellipsis-175">{{ run.reason }}</div></td>
+                     {% else %}
+                       <td></td>
+                     {% endif %}
+
                      {% if run.name %}
                        <td><div class="wordbreak-175">{{ run.name }}</div></td>
                      {% else %}
@@ -101,7 +108,6 @@
   var table = $('#runs').dataTable( {
       "responsive": true,
       "order": [[0, 'desc']],
-      "autoWidth": false,
       "columnDefs": [
           {
               "targets": [4],
@@ -111,16 +117,7 @@
       ],
       "language": {
           "searchPlaceholder": "commit hash works too",
-      },
-      "columns": [
-         { "width": "15%" },
-         { "width": "25%" },
-         { "width": "10%" },
-         { "width": "30%" },
-         { "width": "0%" },
-         { "width": "10%" },
-         { "width": "10%" },
-      ],
+      }
   } );
 
 enable_search_query_string('#runs');

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -305,6 +305,63 @@
                 },
                 "description": "OK",
             },
+            "CompareBenchmarkResult": {
+                "content": {
+                    "application/json": {
+                        "example": {
+                            "commits": {
+                                "baseline": {
+                                    "author_avatar": "https://avatars.githubusercontent.com/u/1299904?v=4",
+                                    "author_login": "bkietz",
+                                    "author_name": "Benjamin Kietzman",
+                                    "id": "some-baseline-commit-id",
+                                    "message": "ARROW-11767: [C++] Scalar::Hash may segfault",
+                                    "parent_sha": "6d703c4c7b15be630af48d5e9ef61628751674b2",
+                                    "repository": "https://github.com/apache/arrow",
+                                    "sha": "4beb514d071c9beec69b8917b5265e77ade22fb3",
+                                    "timestamp": "2021-02-24T22:12:11",
+                                    "url": "https://github.com/apache/arrow/commit/4beb514d071c9beec69b8917b5265e77ade22fb3",
+                                },
+                                "contender": {
+                                    "author_avatar": "https://avatars.githubusercontent.com/u/878798?v=4",
+                                    "author_login": "dianaclarke",
+                                    "author_name": "Diana Clarke",
+                                    "id": "some-contender-commit-id",
+                                    "message": "ARROW-11771: [Developer][Archery] Move benchmark tests (so CI runs them)",
+                                    "parent_sha": "4beb514d071c9beec69b8917b5265e77ade22fb3",
+                                    "repository": "https://github.com/apache/arrow",
+                                    "sha": "02addad336ba19a654f9c857ede546331be7b631",
+                                    "timestamp": "2021-02-25T01:02:51",
+                                    "url": "https://github.com/apache/arrow/commit/02addad336ba19a654f9c857ede546331be7b631",
+                                },
+                            },
+                            "links": {
+                                "self": "http://localhost/api/compare/commits/4beb514d071c9beec69b8917b5265e77ade22fb3...02addad336ba19a654f9c857ede546331be7b631/"
+                            },
+                            "runs": [
+                                {
+                                    "baseline": {
+                                        "hardware_name": "diana",
+                                        "run": "http://localhost/api/runs/some-baseline-run-id/",
+                                        "run_id": "some-baseline-run-id",
+                                        "run_name": "commit: 4beb514d071c9beec69b8917b5265e77ade22fb3",
+                                        "run_timestamp": "2021-02-24T23:12:11",
+                                    },
+                                    "compare": "http://localhost/api/compare/runs/some-baseline-run-id...some-contender-run-id/",
+                                    "contender": {
+                                        "hardware_name": "diana",
+                                        "run": "http://localhost/api/runs/some-contender-run-id/",
+                                        "run_id": "some-contender-run-id",
+                                        "run_name": "commit: 02addad336ba19a654f9c857ede546331be7b631",
+                                        "run_timestamp": "2021-02-25T06:02:51",
+                                    },
+                                }
+                            ],
+                        }
+                    }
+                },
+                "description": "OK",
+            },
             "CompareEntity": {
                 "content": {
                     "application/json": {
@@ -425,63 +482,6 @@
                                 "unit": "s",
                             },
                         ]
-                    }
-                },
-                "description": "OK",
-            },
-            "CompareBenchmarkResult": {
-                "content": {
-                    "application/json": {
-                        "example": {
-                            "commits": {
-                                "baseline": {
-                                    "author_avatar": "https://avatars.githubusercontent.com/u/1299904?v=4",
-                                    "author_login": "bkietz",
-                                    "author_name": "Benjamin Kietzman",
-                                    "id": "some-baseline-commit-id",
-                                    "message": "ARROW-11767: [C++] Scalar::Hash may segfault",
-                                    "parent_sha": "6d703c4c7b15be630af48d5e9ef61628751674b2",
-                                    "repository": "https://github.com/apache/arrow",
-                                    "sha": "4beb514d071c9beec69b8917b5265e77ade22fb3",
-                                    "timestamp": "2021-02-24T22:12:11",
-                                    "url": "https://github.com/apache/arrow/commit/4beb514d071c9beec69b8917b5265e77ade22fb3",
-                                },
-                                "contender": {
-                                    "author_avatar": "https://avatars.githubusercontent.com/u/878798?v=4",
-                                    "author_login": "dianaclarke",
-                                    "author_name": "Diana Clarke",
-                                    "id": "some-contender-commit-id",
-                                    "message": "ARROW-11771: [Developer][Archery] Move benchmark tests (so CI runs them)",
-                                    "parent_sha": "4beb514d071c9beec69b8917b5265e77ade22fb3",
-                                    "repository": "https://github.com/apache/arrow",
-                                    "sha": "02addad336ba19a654f9c857ede546331be7b631",
-                                    "timestamp": "2021-02-25T01:02:51",
-                                    "url": "https://github.com/apache/arrow/commit/02addad336ba19a654f9c857ede546331be7b631",
-                                },
-                            },
-                            "links": {
-                                "self": "http://localhost/api/compare/commits/4beb514d071c9beec69b8917b5265e77ade22fb3...02addad336ba19a654f9c857ede546331be7b631/"
-                            },
-                            "runs": [
-                                {
-                                    "baseline": {
-                                        "hardware_name": "diana",
-                                        "run": "http://localhost/api/runs/some-baseline-run-id/",
-                                        "run_id": "some-baseline-run-id",
-                                        "run_name": "commit: 4beb514d071c9beec69b8917b5265e77ade22fb3",
-                                        "run_timestamp": "2021-02-24T23:12:11",
-                                    },
-                                    "compare": "http://localhost/api/compare/runs/some-baseline-run-id...some-contender-run-id/",
-                                    "contender": {
-                                        "hardware_name": "diana",
-                                        "run": "http://localhost/api/runs/some-contender-run-id/",
-                                        "run_id": "some-contender-run-id",
-                                        "run_name": "commit: 02addad336ba19a654f9c857ede546331be7b631",
-                                        "run_timestamp": "2021-02-25T06:02:51",
-                                    },
-                                }
-                            ],
-                        }
                     }
                 },
                 "description": "OK",
@@ -733,6 +733,7 @@
                                 "self": "http://localhost/api/runs/some-run-uuid-1/",
                             },
                             "name": "some run name",
+                            "reason": "some run reason",
                             "timestamp": "2021-02-04T17:22:05.225583",
                         }
                     }
@@ -788,6 +789,7 @@
                                     "self": "http://localhost/api/runs/some-run-uuid-1/",
                                 },
                                 "name": "some run name",
+                                "reason": "some run reason",
                                 "timestamp": "2021-02-04T17:22:05.225583",
                             }
                         ]
@@ -867,6 +869,7 @@
                     "machine_info": {"$ref": "#/components/schemas/MachineCreate"},
                     "run_id": {"type": "string"},
                     "run_name": {"type": "string"},
+                    "run_reason": {"type": "string"},
                     "stats": {"$ref": "#/components/schemas/BenchmarkResultCreate"},
                     "tags": {"type": "object"},
                     "timestamp": {"format": "date-time", "type": "string"},
@@ -879,6 +882,25 @@
                     "tags",
                     "timestamp",
                 ],
+                "type": "object",
+            },
+            "BenchmarkResultCreate": {
+                "properties": {
+                    "data": {"items": {"type": "number"}, "type": "array"},
+                    "iqr": {"type": "number"},
+                    "iterations": {"type": "integer"},
+                    "max": {"type": "number"},
+                    "mean": {"type": "number"},
+                    "median": {"type": "number"},
+                    "min": {"type": "number"},
+                    "q1": {"type": "number"},
+                    "q3": {"type": "number"},
+                    "stdev": {"type": "number"},
+                    "time_unit": {"type": "string"},
+                    "times": {"items": {"type": "number"}, "type": "array"},
+                    "unit": {"type": "string"},
+                },
+                "required": ["data", "iterations", "time_unit", "times", "unit"],
                 "type": "object",
             },
             "ClusterCreate": {
@@ -1000,25 +1022,6 @@
                     "secret": {"type": "string"},
                 },
                 "required": ["email", "name", "password", "secret"],
-                "type": "object",
-            },
-            "BenchmarkResultCreate": {
-                "properties": {
-                    "data": {"items": {"type": "number"}, "type": "array"},
-                    "iqr": {"type": "number"},
-                    "iterations": {"type": "integer"},
-                    "max": {"type": "number"},
-                    "mean": {"type": "number"},
-                    "median": {"type": "number"},
-                    "min": {"type": "number"},
-                    "q1": {"type": "number"},
-                    "q3": {"type": "number"},
-                    "stdev": {"type": "number"},
-                    "time_unit": {"type": "string"},
-                    "times": {"items": {"type": "number"}, "type": "array"},
-                    "unit": {"type": "string"},
-                },
-                "required": ["data", "iterations", "time_unit", "times", "unit"],
                 "type": "object",
             },
             "UserCreate": {

--- a/conbench/tests/api/_fixtures.py
+++ b/conbench/tests/api/_fixtures.py
@@ -24,6 +24,7 @@ Z_SCORE_DOWN_COMPUTED_VIA_POSTGRES = (
 VALID_PAYLOAD = {
     "run_id": "2a5709d179f349cba69ed242be3e6321",
     "run_name": "commit: 02addad336ba19a654f9c857ede546331be7b631",
+    "run_reason": "commit",
     "batch_id": "7b2fdd9f929d47b9960152090d47f8e6",
     "timestamp": "2020-11-25T21:02:42.706806+00:00",
     "context": {
@@ -156,6 +157,7 @@ def benchmark_result(
         data[f"{hardware_type}_info"]["name"] = hardware_name
     if pull_request:
         data["run_name"] = "pull request: some commit"
+        data["run_reason"] = "pull request"
     if sha:
         data["github"]["commit"] = sha
     if commit:

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -12,6 +12,7 @@ def _expected_entity(run, baseline_id=None, include_baseline=True):
     return _api_run_entity(
         run.id,
         run.name,
+        run.reason,
         run.commit_id,
         parent.id,
         run.hardware_id,

--- a/conbench/tests/benchmark/test_cli.py
+++ b/conbench/tests/benchmark/test_cli.py
@@ -79,7 +79,10 @@ Options:
   --show-result BOOLEAN  [default: true]
   --show-output BOOLEAN  [default: false]
   --run-id TEXT          Group executions together with a run id.
-  --run-name TEXT        Name of run (commit, pull request, etc).
+  --run-name TEXT        Free-text name of run (commit ABC, pull request 123,
+                         etc).
+  --run-reason TEXT      Low-cardinality reason for run (commit, pull request,
+                         manual, etc).
   --help                 Show this message and exit.
 """
 
@@ -120,7 +123,10 @@ Options:
   --show-result BOOLEAN  [default: true]
   --show-output BOOLEAN  [default: false]
   --run-id TEXT          Group executions together with a run id.
-  --run-name TEXT        Name of run (commit, pull request, etc).
+  --run-name TEXT        Free-text name of run (commit ABC, pull request 123,
+                         etc).
+  --run-reason TEXT      Low-cardinality reason for run (commit, pull request,
+                         manual, etc).
   --help                 Show this message and exit.
 """
 
@@ -153,7 +159,10 @@ Options:
   --show-result BOOLEAN  [default: true]
   --show-output BOOLEAN  [default: false]
   --run-id TEXT          Group executions together with a run id.
-  --run-name TEXT        Name of run (commit, pull request, etc).
+  --run-name TEXT        Free-text name of run (commit ABC, pull request 123,
+                         etc).
+  --run-reason TEXT      Low-cardinality reason for run (commit, pull request,
+                         manual, etc).
   --help                 Show this message and exit.
 """
 
@@ -173,7 +182,10 @@ Options:
   --show-result BOOLEAN  [default: true]
   --show-output BOOLEAN  [default: false]
   --run-id TEXT          Group executions together with a run id.
-  --run-name TEXT        Name of run (commit, pull request, etc).
+  --run-name TEXT        Free-text name of run (commit ABC, pull request 123,
+                         etc).
+  --run-reason TEXT      Low-cardinality reason for run (commit, pull request,
+                         manual, etc).
   --help                 Show this message and exit.
 """
 
@@ -187,7 +199,10 @@ Options:
   --show-result BOOLEAN  [default: true]
   --show-output BOOLEAN  [default: false]
   --run-id TEXT          Group executions together with a run id.
-  --run-name TEXT        Name of run (commit, pull request, etc).
+  --run-name TEXT        Free-text name of run (commit ABC, pull request 123,
+                         etc).
+  --run-reason TEXT      Low-cardinality reason for run (commit, pull request,
+                         manual, etc).
   --help                 Show this message and exit.
 """
 
@@ -203,7 +218,10 @@ Options:
   --show-result BOOLEAN  [default: true]
   --show-output BOOLEAN  [default: false]
   --run-id TEXT          Group executions together with a run id.
-  --run-name TEXT        Name of run (commit, pull request, etc).
+  --run-name TEXT        Free-text name of run (commit ABC, pull request 123,
+                         etc).
+  --run-reason TEXT      Low-cardinality reason for run (commit, pull request,
+                         manual, etc).
   --help                 Show this message and exit.
 """
 

--- a/conbench/tests/benchmark/test_runner.py
+++ b/conbench/tests/benchmark/test_runner.py
@@ -19,6 +19,7 @@ EXAMPLE_WITH_CLUSTER_INFO = copy.deepcopy(_fixtures.VALID_PAYLOAD_FOR_CLUSTER)
 EXAMPLE_WITH_ERROR = copy.deepcopy(_fixtures.VALID_PAYLOAD_WITH_ERROR)
 for example in [EXAMPLE, EXAMPLE_WITH_CLUSTER_INFO, EXAMPLE_WITH_ERROR]:
     example.pop("run_name")
+    example.pop("run_reason")
     example["info"] = {
         "benchmark_language_version": "Python 3.8.5",
     }

--- a/conbench/tests/populate_local_conbench.py
+++ b/conbench/tests/populate_local_conbench.py
@@ -14,13 +14,10 @@ def generate_benchmarks_data(
     benchmark_language,
     timestamp,
     hardware_type,
-    is_nightly,
+    reason,
     mean=16.670462,
 ):
-    run_name = f"commit: {commit}"
-    if is_nightly:
-        run_name += " nightly"
-
+    run_name = f"{reason}: {commit}" if reason else commit
     data = {
         "batch_id": uuid.uuid4().hex,
         "context": {
@@ -63,6 +60,10 @@ def generate_benchmarks_data(
         },
         "timestamp": str(timestamp),
     }
+
+    if reason:
+        data["run_reason"] = reason
+
     for key in ["info", "tags", "context"]:
         fields_set = {
             f"{benchmark_language}_specific_{key}_field_1": "value-1",
@@ -111,7 +112,7 @@ def generate_benchmarks_data_with_error(
     benchmark_language,
     timestamp,
     hardware_type,
-    is_nightly,
+    reason,
 ):
     data = generate_benchmarks_data(
         run_id,
@@ -120,7 +121,7 @@ def generate_benchmarks_data_with_error(
         benchmark_language,
         timestamp,
         hardware_type,
-        is_nightly,
+        reason,
     )
     data.pop("stats")
     data["error"] = {"command": "some command", "stack trace": "stack trace ..."}
@@ -158,7 +159,7 @@ def create_benchmarks_data():
 
     errors = [False, False, True, False, True, True]
 
-    nightly = [False, True] * 3
+    reasons = ["commit", None, "pull request", "nightly", "manual", "an accident"]
 
     benchmark_names = ["csv-read", "csv-write"]
 
@@ -170,8 +171,8 @@ def create_benchmarks_data():
         for hardware_type in hardware_types:
             for benchmark_language in benchmark_languages:
                 for benchmark_name in benchmark_names:
-                    run_id, commit, mean = f"{hardware_type}{i+1}", commits[i], means[i]
-                    is_nightly = nightly[i]
+                    run_id = f"{hardware_type}{i+1}"
+                    commit, mean, reason = commits[i], means[i], reasons[i]
                     timestamp = datetime.datetime.now() + datetime.timedelta(hours=i)
                     if errors[i] and benchmark_name == "csv-read":
                         benchmark_data = generate_benchmarks_data_with_error(
@@ -181,7 +182,7 @@ def create_benchmarks_data():
                             benchmark_language,
                             timestamp,
                             hardware_type,
-                            is_nightly,
+                            reason,
                         )
                     else:
                         benchmark_data = generate_benchmarks_data(
@@ -191,7 +192,7 @@ def create_benchmarks_data():
                             benchmark_language,
                             timestamp,
                             hardware_type,
-                            is_nightly,
+                            reason,
                             mean,
                         )
 

--- a/migrations/versions/bc0ac747cec6_add_run_reason_column.py
+++ b/migrations/versions/bc0ac747cec6_add_run_reason_column.py
@@ -18,15 +18,6 @@ depends_on = None
 def upgrade():
     op.add_column("run", sa.Column("reason", sa.String(length=250), nullable=True))
 
-    # use some custom logic to backfill the column
-    op.execute("UPDATE run SET reason = 'commit' WHERE name LIKE 'commit%'")
-    op.execute("UPDATE run SET reason = 'pull request' WHERE name LIKE 'pull request%'")
-    op.execute(
-        "UPDATE run SET reason = 'manual commit' WHERE name LIKE 'manual commit%'"
-    )
-    op.execute("UPDATE run SET reason = 'merge commit' WHERE name LIKE '%merge-commit'")
-    op.execute("UPDATE run SET reason = 'nightly' WHERE name LIKE '%nightly'")
-
 
 def downgrade():
     op.drop_column("run", "reason")

--- a/migrations/versions/bc0ac747cec6_add_run_reason_column.py
+++ b/migrations/versions/bc0ac747cec6_add_run_reason_column.py
@@ -1,0 +1,32 @@
+"""add run reason column
+
+Revision ID: bc0ac747cec6
+Revises: 5d516a1f293d
+Create Date: 2022-06-07 15:21:28.698451
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "bc0ac747cec6"
+down_revision = "5d516a1f293d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("run", sa.Column("reason", sa.String(length=250), nullable=True))
+
+    # use some custom logic to backfill the column
+    op.execute("UPDATE run SET reason = 'commit' WHERE name LIKE 'commit%'")
+    op.execute("UPDATE run SET reason = 'pull request' WHERE name LIKE 'pull request%'")
+    op.execute(
+        "UPDATE run SET reason = 'manual commit' WHERE name LIKE 'manual commit%'"
+    )
+    op.execute("UPDATE run SET reason = 'merge commit' WHERE name LIKE '%merge-commit'")
+    op.execute("UPDATE run SET reason = 'nightly' WHERE name LIKE '%nightly'")
+
+
+def downgrade():
+    op.drop_column("run", "reason")

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ install_requires = [
 
 setuptools.setup(
     name="conbench",
-    version="1.57.0",
+    version="1.58.0",
     description="Continuous Benchmarking (CB) Framework",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Fixes #349.

This PR adds a `reason` attribute to the Run entity. When posting benchmarks, users may now add `"run_reason": "..."` to the body, which takes the place of parsing the run name to try to figure out why a run was kicked off. This also exposes the new Reason on the app home page as a new column.