### PR TITLE
Backfilled rows with empty reasons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dmypy.json
 
 # vscode project settings
 .vscode/launch.json
+
+# mac
+*.DS_Store

--- a/migrations/versions/459166107c9d_backfill_reason.py
+++ b/migrations/versions/459166107c9d_backfill_reason.py
@@ -1,0 +1,53 @@
+"""backfill reason
+
+Revision ID: 459166107c9d
+Revises: bc0ac747cec6
+Create Date: 2022-06-10 09:49:05.883111
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '459166107c9d'
+down_revision = 'bc0ac747cec6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        UPDATE run SET reason = 'nightly'
+        WHERE reason IS NULL AND name LIKE '%nightly';
+        """
+    )
+    op.execute(
+        """
+        UPDATE run SET reason = 'commit'
+        WHERE reason IS NULL AND name LIKE 'commit%';
+        """
+    )
+    op.execute(
+        """
+        UPDATE run SET reason = 'pull request'
+        WHERE reason IS NULL AND name LIKE 'pull request%';
+        """
+    )
+    op.execute(
+        """
+        UPDATE run SET reason = 'manual'
+        WHERE reason IS NULL AND name LIKE 'manual%';
+        """
+    )
+    op.execute(
+        """
+        UPDATE run SET reason = 'manual'
+        WHERE reason IS NULL AND name LIKE 'test%';
+        """
+    )
+
+
+def downgrade():
+    pass

--- a/migrations/versions/459166107c9d_backfill_reason.py
+++ b/migrations/versions/459166107c9d_backfill_reason.py
@@ -6,12 +6,10 @@ Create Date: 2022-06-10 09:49:05.883111
 
 """
 from alembic import op
-import sqlalchemy as sa
-
 
 # revision identifiers, used by Alembic.
-revision = '459166107c9d'
-down_revision = 'bc0ac747cec6'
+revision = "459166107c9d"
+down_revision = "bc0ac747cec6"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
This PR adds a db migration to do a one-time backfill of run reasons using custom logic.