### PR TITLE
Pass ArcheryAdapter output file

### DIFF
--- a/benchadapt/python/benchadapt/adapters/__init__.py
+++ b/benchadapt/python/benchadapt/adapters/__init__.py
@@ -1,5 +1,11 @@
+from ._adapter import BenchmarkAdapter
 from .archery import ArcheryAdapter
 from .folly import FollyAdapter
 from .gbench import GoogleBenchmarkAdapter
 
-__all__ = ["ArcheryAdapter", "FollyAdapter", "GoogleBenchmarkAdapter"]
+__all__ = [
+    "ArcheryAdapter",
+    "BenchmarkAdapter",
+    "FollyAdapter",
+    "GoogleBenchmarkAdapter",
+]

--- a/benchadapt/python/benchadapt/adapters/_adapter.py
+++ b/benchadapt/python/benchadapt/adapters/_adapter.py
@@ -7,7 +7,7 @@ from ..log import fatal_and_log
 from ..result import BenchmarkResult
 
 
-class _BenchmarkAdapter(abc.ABC):
+class BenchmarkAdapter(abc.ABC):
     """
     An abstract class to run benchmarks, transform results into conbench form,
     and send them to a conbench server

--- a/benchadapt/python/benchadapt/adapters/archery.py
+++ b/benchadapt/python/benchadapt/adapters/archery.py
@@ -12,8 +12,10 @@ class ArcheryAdapter(GoogleBenchmarkAdapter):
     """A class for running Apache Arrow's archery benchmarks and sending the results to conbench"""
 
     def __init__(self) -> None:
+        result_file = Path(tempfile.mktemp())
         super().__init__(
-            command=["archery", "benchmark", "run"], result_file=Path(tempfile.mktemp())
+            command=["archery", "benchmark", "run", "--output", result_file],
+            result_file=result_file,
         )
 
     def transform_results(self) -> List[BenchmarkResult]:

--- a/benchadapt/python/benchadapt/adapters/folly.py
+++ b/benchadapt/python/benchadapt/adapters/folly.py
@@ -4,10 +4,10 @@ from pathlib import Path
 from typing import List
 
 from ..result import BenchmarkResult
-from ._adapter import _BenchmarkAdapter
+from ._adapter import BenchmarkAdapter
 
 
-class FollyAdapter(_BenchmarkAdapter):
+class FollyAdapter(BenchmarkAdapter):
     """Run folly benchmarks and send the results to conbench"""
 
     result_dir: Path

--- a/benchadapt/python/benchadapt/adapters/gbench.py
+++ b/benchadapt/python/benchadapt/adapters/gbench.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 from ..result import BenchmarkResult
-from ._adapter import _BenchmarkAdapter
+from ._adapter import BenchmarkAdapter
 
 
 # adapted from https://github.com/apache/arrow/blob/master/dev/archery/archery/benchmark/google.py
@@ -117,7 +117,7 @@ class GoogleBenchmark:
         )
 
 
-class GoogleBenchmarkAdapter(_BenchmarkAdapter):
+class GoogleBenchmarkAdapter(BenchmarkAdapter):
     """A class for running Google Benchmarks and sending the results to conbench"""
 
     def __init__(self, command: list[str], result_file: Path) -> None:

--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -78,7 +78,7 @@ class BenchmarkResult:
                 "Result not publishable! `machine_info` xor `cluster_info` must be specified"
             )
 
-        if bool(res_dict["stats"]) != bool(res_dict["error"]):
+        if bool(res_dict["stats"]) == bool(res_dict["error"]):
             warnings.warn(
                 "Result not publishable! `stats` xor `error` must be be specified"
             )

--- a/benchadapt/python/tests/test_result.py
+++ b/benchadapt/python/tests/test_result.py
@@ -1,0 +1,66 @@
+import pytest
+
+from benchadapt import BenchmarkResult
+
+res_json = {
+    "run_name": "very-real-benchmark",
+    "run_id": "ezf69672dc3741259aac97650414a18c",
+    "batch_id": "1z21bd2477d04ca8be0f4bad58c61757",
+    "run_reason": None,
+    "timestamp": "2202-09-16T15:42:27.527948+00:00",
+    "stats": {
+        "data": [1.1, 2.2, 3.3],
+        "unit": "ns",
+        "times": [3.3, 2.2, 1.1],
+        "time_unit": "ns",
+    },
+    "tags": {
+        "name": "very-real-benchmark",
+        "suite": "dope-benchmarks",
+        "source": "app-micro",
+    },
+    "info": {},
+    "machine_info": {
+        "name": "beepboop.local",
+        "os_name": "macOS",
+        "os_version": "12.6",
+        "architecture_name": "arm64",
+        "kernel_name": "21.6.0",
+        "memory_bytes": "17179869184",
+        "cpu_model_name": "Apple M3 Pro",
+        "cpu_core_count": "100",
+        "cpu_thread_count": "100",
+        "cpu_l1d_cache_bytes": "655360",
+        "cpu_l1i_cache_bytes": "1310720",
+        "cpu_l2_cache_bytes": "41943040",
+        "cpu_l3_cache_bytes": "0",
+        "cpu_frequency_max_hz": "0",
+        "gpu_count": "0",
+        "gpu_product_names": [],
+    },
+    "context": {"benchmark_language": "A++"},
+    "github": {
+        "commit": "2z8c9c49a5dc4a179243268e4bb6daa5",
+        "repository": "git@github.com:conchair/conchair",
+    },
+}
+
+
+class TestBenchmarkResult:
+    def test_roundtrip(self):
+        res = BenchmarkResult(**res_json)
+        assert res_json == res.to_publishable_dict()
+
+    def test_warns_stats_error(self):
+        with pytest.warns(UserWarning, match="Result not publishable!"):
+            BenchmarkResult(stats={}, error={}).to_publishable_dict()
+
+        with pytest.warns(UserWarning, match="Result not publishable!"):
+            BenchmarkResult(stats=None, error=None).to_publishable_dict()
+
+    def test_warns_machine_cluster(self):
+        with pytest.warns(UserWarning, match="Result not publishable!"):
+            BenchmarkResult(machine_info={}, cluster_info={}).to_publishable_dict()
+
+        with pytest.warns(UserWarning, match="Result not publishable!"):
+            BenchmarkResult(machine_info=None, cluster_info=None).to_publishable_dict()


### PR DESCRIPTION
A quick bugfix PR; I realized I missed moving specifying the output file in the archery command back when cleaning up the gbench one. More minorly, also got the logic backwards when warning about publishable results.