### PR TITLE
Backwards compatible type hints

### DIFF
--- a/benchadapt/python/benchadapt/adapters/archery.py
+++ b/benchadapt/python/benchadapt/adapters/archery.py
@@ -34,7 +34,7 @@ class ArcheryAdapter(GoogleBenchmarkAdapter):
 
     def _parse_suite(
         self, results: dict, extra_tags: dict = None
-    ) -> list[BenchmarkResult]:
+    ) -> List[BenchmarkResult]:
         """Parse a blob of results from archery into a list of `BenchmarkResult` instances"""
         # all results share a batch id
         batch_id = uuid.uuid4().hex

--- a/benchadapt/python/benchadapt/adapters/folly.py
+++ b/benchadapt/python/benchadapt/adapters/folly.py
@@ -16,7 +16,7 @@ class FollyAdapter(BenchmarkAdapter):
         """
         Parameters
         ----------
-        command : list[str]
+        command : List[str]
             A list of strings defining a shell command to run folly benchmarks
         result_dir : Path
             Path to directory where folly results will be populated

--- a/benchadapt/python/benchadapt/adapters/gbench.py
+++ b/benchadapt/python/benchadapt/adapters/gbench.py
@@ -91,12 +91,12 @@ class GoogleBenchmark:
     unit: str
     time_unit: str
     less_is_better: bool
-    values: list[float]
-    times: list[float]
-    counters: list = None
+    values: List[float]
+    times: List[float]
+    counters: List = None
 
     @classmethod
-    def from_runs(cls, name: str, runs: list[GoogleBenchmarkObservation]):
+    def from_runs(cls, name: str, runs: List[GoogleBenchmarkObservation]):
         """
         Create a GoogleBenchmarkGroup instance from a list of observations
 
@@ -104,7 +104,7 @@ class GoogleBenchmark:
         ----------
         name: str
               Name of the benchmark
-        runs: list(GoogleBenchmarkObservation)
+        runs: List(GoogleBenchmarkObservation)
               Repetitions of GoogleBenchmarkObservation run.
         """
         return cls(
@@ -120,11 +120,11 @@ class GoogleBenchmark:
 class GoogleBenchmarkAdapter(BenchmarkAdapter):
     """A class for running Google Benchmarks and sending the results to conbench"""
 
-    def __init__(self, command: list[str], result_file: Path) -> None:
+    def __init__(self, command: List[str], result_file: Path) -> None:
         """
         Parameters
         ----------
-        command : list[str]
+        command : List[str]
             A list of strings defining a shell command to run the benchmarks
         result_file : Path
             The path to a file of benchmark results that will be generated when ``.run()`` is called


### PR DESCRIPTION
A quick bugfix PR to make sure type hints are more backwards compatible with Python versions