### PR TITLE
Bugfix: Coerce string-likes to strings for logging

### DIFF
--- a/benchadapt/python/benchadapt/adapters/_adapter.py
+++ b/benchadapt/python/benchadapt/adapters/_adapter.py
@@ -73,7 +73,9 @@ class BenchmarkAdapter(abc.ABC):
         if params:
             command += params
 
-        log.info(f"Running benchmarks with command: `{' '.join(command)}`")
+        log.info(
+            f"Running benchmarks with command: `{' '.join([str(x) for x in command])}`"
+        )
         subprocess.run(args=command, check=True)
         log.info("Benchmark run completed")
         self.results = self.transform_results()

--- a/benchadapt/python/tests/adapters/test_adapter.py
+++ b/benchadapt/python/tests/adapters/test_adapter.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import List
 
 from benchadapt.adapters import BenchmarkAdapter
@@ -40,6 +41,12 @@ class TestBenchmarkAdapter:
         fake_adapter = FakeAdapter(command=["echo", "hello"])
 
         res_list = fake_adapter.transform_results()
+        assert res_list[0] == BenchmarkResult(**RESULTS_DICT)
+
+    def test_run(self) -> None:
+        fake_adapter = FakeAdapter(command=["echo", Path(".").resolve()])
+
+        res_list = fake_adapter.run()
         assert res_list[0] == BenchmarkResult(**RESULTS_DICT)
 
     def test_override_results(self) -> None:


### PR DESCRIPTION
The `command` attribute is a list passed to `subprocess.run()`, but it will sometimes contain instances of `pathlib.Path()`, which `.run()` will coerce properly, but we have to coerce manually for logging.