### PR TITLE
Bugfix: Trailing slash for benchmarks endpoint

### DIFF
--- a/benchadapt/python/benchadapt/adapters/_adapter.py
+++ b/benchadapt/python/benchadapt/adapters/_adapter.py
@@ -143,7 +143,7 @@ class BenchmarkAdapter(abc.ABC):
             log.debug(
                 f"Posting benchmark result to conbench: `{json.dumps(result_dict)}`"
             )
-            res = client.post(path="/benchmarks", json=result_dict)
+            res = client.post(path="/benchmarks/", json=result_dict)
             res_list.append(res)
 
         log.info("All results sent to conbench")


### PR DESCRIPTION
ideally we'd make the client more robust and the endpoint would fail better (or work), but this will unblock us