### PR TITLE
Show more details when HTTP request fails

### DIFF
--- a/benchadapt/python/benchadapt/adapters/_adapter.py
+++ b/benchadapt/python/benchadapt/adapters/_adapter.py
@@ -1,5 +1,4 @@
 import abc
-import json
 import subprocess
 from typing import Any, Dict, List
 
@@ -140,9 +139,6 @@ class BenchmarkAdapter(abc.ABC):
         res_list = []
         for result in self.results:
             result_dict = result.to_publishable_dict()
-            log.debug(
-                f"Posting benchmark result to conbench: `{json.dumps(result_dict)}`"
-            )
             res = client.post(path="/benchmarks/", json=result_dict)
             res_list.append(res)
 

--- a/benchadapt/python/benchadapt/client.py
+++ b/benchadapt/python/benchadapt/client.py
@@ -4,6 +4,7 @@
 
 import abc
 import os
+from json import dumps
 from typing import Optional
 
 import requests
@@ -41,14 +42,26 @@ class _BaseClient(abc.ABC):
         url = self.base_url + path
         log.debug(f"GET {url}")
         res = self.session.get(url=url, timeout=self.timeout_s)
-        res.raise_for_status()
+
+        try:
+            res.raise_for_status()
+        except requests.HTTPError as e:
+            print(e.response.content)
+            raise
+
         return res.json()
 
     def post(self, path: str, json: dict) -> Optional[dict]:
         url = self.base_url + path
-        log.debug(f"POST {url} {json}")
+        log.debug(f"POST {url} {dumps(json)}")
         res = self.session.post(url=url, json=json, timeout=self.timeout_s)
-        res.raise_for_status()
+
+        try:
+            res.raise_for_status()
+        except requests.HTTPError as e:
+            print(e.response.content)
+            raise
+
         if res.content:
             return res.json()
 

--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -27,7 +27,8 @@ class BenchmarkResult:
     stats : Dict[str, Any]
         Measurement data and summary statistics
     tags : Dict[str, Any]
-        Many things. Determines history runs
+        Many things. Must include a ``name`` element; often includes parameters either as
+        separate keys or as a string in a ``params`` key. Determines history runs.
     info : Dict[str, Any]
         Things like ``arrow_version``, ``arrow_compiler_id``, ``arrow_compiler_version``,
         ``benchmark_language_version, ``arrow_version_r``
@@ -58,12 +59,12 @@ class BenchmarkResult:
     )
     stats: Dict[str, Any] = None
     tags: Dict[str, Any] = field(default_factory=dict)
-    info: Dict[str, Any] = None
+    info: Dict[str, Any] = field(default_factory=dict)
     machine_info: Dict[str, Any] = field(
         default_factory=lambda: machine_info(host_name=None)
     )
     cluster_info: Dict[str, Any] = None
-    context: Dict[str, Any] = None
+    context: Dict[str, Any] = field(default_factory=dict)
     github: Dict[str, Any] = field(default_factory=github_info)
     error: str = None
 


### PR DESCRIPTION
Bugfixes and cleanup:

- Print details when HTTP request fails
- Add default for `info` and `context`
- Add more things to docs that I've learned
- Remove duplicative logging
- Format JSON logging in client as JSON