### PR TITLE
Configure number of commits for calculating stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,9 @@ Most are self-descriptive, e.g. `DB_PORT`. Exceptions:
 * `DISTRIBUTION_COMMITS`: An integer number of commits to use when calculating
 statistics. The default is 100; larger numbers will lead to more false negatives,
 especially after large changes. We recommend leaving it as the default. Previously
-recorded values will not be recalculated if this value is changed.
+recorded values will not be recalculated if this value is changed. If you would
+like to change previous values, you would need to write a migration of the data
+to recalculate history.
 
 ## Authoring benchmarks
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ repository, and the results are hosted on the
 ## Index
 
 * [Contributing](https://github.com/conbench/conbench#contributing)
+* [Configuring the server](https://github.com/conbench/conbench#configuring-the-server)
 * [Authoring benchmarks](https://github.com/conbench/conbench#authoring-benchmarks)
   * [Simple benchmarks](https://github.com/conbench/conbench#example-simple-benchmarks)
   * [External benchmarks](https://github.com/conbench/conbench#example-external-benchmarks)
@@ -193,7 +194,7 @@ password in postgres to `postgres`.
     (conbench) $ brew services start postgres
     (conbench) $ dropdb conbench_prod
     (conbench) $ createdb conbench_prod
-    (conbench) $ git checkout main && git pull    
+    (conbench) $ git checkout main && git pull
     (conbench) $ alembic upgrade head
     (conbench) $ git checkout your-branch
     (conbench) $ alembic revision --autogenerate -m "new"
@@ -203,7 +204,7 @@ password in postgres to `postgres`.
 1. Start conbench app in Terminal window 1:
 
         (conbench) $ dropdb conbench_prod && createdb conbench_prod && alembic upgrade head && flask run
-    
+
 2. Run `conbench.tests.populate_local_conbench` in Terminal window 2 while conbench app is running:
 
         (conbench) $ python -m conbench.tests.populate_local_conbench
@@ -214,6 +215,17 @@ password in postgres to `postgres`.
 2. Commit your change into `main` branch
 
 New version of conbench package will be uploaded into PyPI by a new build for [conbench-deploy](.buildkite/conbench-deploy/pipeline.yml) Buildkite pipeline
+
+## Configuring the server
+
+The conbench server can be configured with various environment variables as
+defined in [config.py](https://github.com/conbench/conbench/blob/main/conbench/config.py).
+Most are self-descriptive, e.g. `DB_PORT`. Exceptions:
+
+* `DISTRIBUTION_COMMITS`: An integer number of commits to use when calculating
+statistics. The default is 100; larger numbers will lead to more false negatives,
+especially after large changes. We recommend leaving it as the default. Previously
+recorded values will not be recalculated if this value is changed.
 
 ## Authoring benchmarks
 
@@ -619,7 +631,7 @@ Benchmark result:
 If your benchmark is executed on a machine cluster instead of one machine, you
 can capture cluster info in the following manner.
 Note that a benchmark will have a continuous history on a specific cluster as long as cluster's `name` and `info` do not change.
-There is also an `optional_info` field for information that should not impact the cluster's hash (and thus disrupt the distribution history), but should still be recorded. 
+There is also an `optional_info` field for information that should not impact the cluster's hash (and thus disrupt the distribution history), but should still be recorded.
 ```python
 import conbench.runner
 

--- a/conbench/config.py
+++ b/conbench/config.py
@@ -17,6 +17,8 @@ class Config:
         f"postgresql://{DB_USERNAME}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
     )
     CREATE_ALL_TABLES = os.environ.get("CREATE_ALL_TABLES", "true") == "true"
+    # Number of commits to use when calculating statistics
+    DISTRIBUTION_COMMITS = int(os.environ.get("DISTRIBUTION_COMMITS", 100))
 
 
 class TestConfig(Config):

--- a/conbench/config.py
+++ b/conbench/config.py
@@ -17,7 +17,10 @@ class Config:
         f"postgresql://{DB_USERNAME}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
     )
     CREATE_ALL_TABLES = os.environ.get("CREATE_ALL_TABLES", "true") == "true"
-    # Number of commits to use when calculating statistics
+    # An integer number of commits to use when calculating
+    # statistics. The default is 100; larger numbers will lead to more false negatives,
+    # especially after large changes. We recommend leaving it as the default. Previously
+    # recorded values will not be recalculated if this value is changed.
     DISTRIBUTION_COMMITS = int(os.environ.get("DISTRIBUTION_COMMITS", 100))
 
 

--- a/conbench/config.py
+++ b/conbench/config.py
@@ -20,7 +20,9 @@ class Config:
     # An integer number of commits to use when calculating
     # statistics. The default is 100; larger numbers will lead to more false negatives,
     # especially after large changes. We recommend leaving it as the default. Previously
-    # recorded values will not be recalculated if this value is changed.
+    # recorded values will not be recalculated if this value is changed. If you would
+    # like to change previous values, you would need to write a migration of the data
+    # to recalculate history.
     DISTRIBUTION_COMMITS = int(os.environ.get("DISTRIBUTION_COMMITS", 100))
 
 

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -6,6 +6,7 @@ from sqlalchemy import CheckConstraint as check
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import relationship
 
+from ..config import Config
 from ..entities._comparator import z_improvement, z_regression
 from ..entities._entity import (
     Base,
@@ -168,7 +169,7 @@ class BenchmarkResult(Base, EntityMixin):
         if "error" in data:
             return benchmark_result
 
-        update_distribution(benchmark_result, 100)
+        update_distribution(benchmark_result, limit=Config.DISTRIBUTION_COMMITS)
 
         return benchmark_result
 


### PR DESCRIPTION
Closes #379 by allowing users to specify a `DISTRIBUTION_COMMITS` env var when starting a conbench server.