### PR TITLE
Specify iterations in adapters

### DIFF
--- a/benchadapt/python/benchadapt/adapters/folly.py
+++ b/benchadapt/python/benchadapt/adapters/folly.py
@@ -72,6 +72,7 @@ class FollyAdapter(BenchmarkAdapter):
                         "unit": "ns",
                         "times": [result[2]],
                         "time_unit": "ns",
+                        "iterations": 1,
                     },
                     tags={"name": bm_name, "suite": suite, "source": "cpp-micro"},
                     info={},

--- a/benchadapt/python/benchadapt/adapters/gbench.py
+++ b/benchadapt/python/benchadapt/adapters/gbench.py
@@ -218,6 +218,7 @@ class GoogleBenchmarkAdapter(BenchmarkAdapter):
                 }.get(result.unit, result.unit),
                 "times": result.times,
                 "time_unit": result.time_unit,
+                "iterations": len(result.values),
             },
             tags=tags,
             info={},

--- a/benchadapt/python/tests/adapters/test_archery.py
+++ b/benchadapt/python/tests/adapters/test_archery.py
@@ -80,6 +80,7 @@ class TestArcheryAdapter:
             assert result.machine_info is not None
             assert result.stats["data"] == original["values"]
             assert result.stats["times"] == original["times"]
+            assert result.stats["iterations"] == len(original["values"])
 
     def test_run(self, archery_adapter) -> None:
         results = archery_adapter.run()

--- a/benchadapt/python/tests/adapters/test_folly.py
+++ b/benchadapt/python/tests/adapters/test_folly.py
@@ -9,44 +9,44 @@ from benchadapt.result import BenchmarkResult
 folly_jsons = {
     "velox_benchmark_basic_selectivity_vector.json": [
         [
-            "/Users/jkeane/repos/velox/velox/benchmarks/basic/SelectivityVector.cpp",
+            "/Users/floopdorp/repos/velox/velox/benchmarks/basic/SelectivityVector.cpp",
             "sumBaselineAll",
             0,
         ],
         [
-            "/Users/jkeane/repos/velox/velox/benchmarks/basic/SelectivityVector.cpp",
+            "/Users/floopdorp/repos/velox/velox/benchmarks/basic/SelectivityVector.cpp",
             "sumSelectivityAll",
             0,
         ],
         [
-            "/Users/jkeane/repos/velox/velox/benchmarks/basic/SelectivityVector.cpp",
+            "/Users/floopdorp/repos/velox/velox/benchmarks/basic/SelectivityVector.cpp",
             "sumSelectivity99PerCent",
             0,
         ],
         [
-            "/Users/jkeane/repos/velox/velox/benchmarks/basic/SelectivityVector.cpp",
+            "/Users/floopdorp/repos/velox/velox/benchmarks/basic/SelectivityVector.cpp",
             "sumSelectivity50PerCent",
             0,
         ],
         [
-            "/Users/jkeane/repos/velox/velox/benchmarks/basic/SelectivityVector.cpp",
+            "/Users/floopdorp/repos/velox/velox/benchmarks/basic/SelectivityVector.cpp",
             "sumSelectivity10PerCent",
             0,
         ],
         [
-            "/Users/jkeane/repos/velox/velox/benchmarks/basic/SelectivityVector.cpp",
+            "/Users/floopdorp/repos/velox/velox/benchmarks/basic/SelectivityVector.cpp",
             "sumSelectivity1PerCent",
             0,
         ],
     ],
     "velox_benchmark_feature_normalization.json": [
         [
-            "/Users/jkeane/repos/velox/velox/benchmarks/basic/FeatureNormalization.cpp",
+            "/Users/floopdorp/repos/velox/velox/benchmarks/basic/FeatureNormalization.cpp",
             "normalize",
             17.781428779296874,
         ],
         [
-            "/Users/jkeane/repos/velox/velox/benchmarks/basic/FeatureNormalization.cpp",
+            "/Users/floopdorp/repos/velox/velox/benchmarks/basic/FeatureNormalization.cpp",
             "normalizeConstant",
             15.583608779296874,
         ],
@@ -89,6 +89,7 @@ class TestFollyAdapter:
             assert result.machine_info is not None
             assert result.stats["data"][0] == original[2]
             assert result.stats["times"][0] == original[2]
+            assert result.stats["iterations"] == 1
 
     def test_run(self, folly_adapter) -> None:
         results = folly_adapter.run()

--- a/benchadapt/python/tests/adapters/test_gbench.py
+++ b/benchadapt/python/tests/adapters/test_gbench.py
@@ -214,6 +214,7 @@ class TestGbenchAdapter:
             assert result.context == {"benchmark_language": "C++"}
             assert "params" in result.tags
             assert result.machine_info is not None
+            assert result.stats["iterations"] == 3
 
     def test_run(self, gbench_adapter) -> None:
         results = gbench_adapter.run()

--- a/benchadapt/python/tests/test_result.py
+++ b/benchadapt/python/tests/test_result.py
@@ -13,6 +13,7 @@ res_json = {
         "unit": "ns",
         "times": [3.3, 2.2, 1.1],
         "time_unit": "ns",
+        "iterations": 3,
     },
     "tags": {
         "name": "very-real-benchmark",


### PR DESCRIPTION
Quick bugfix; `iterations` always needs to be specified in `stats` for the server right now even though it's redundant with the length of `data`