### PR TITLE
Filter on run reason instead of name prefix

### DIFF
--- a/conbench/entities/distribution.py
+++ b/conbench/entities/distribution.py
@@ -99,7 +99,7 @@ def get_distribution(benchmark_result, limit):
         .join(Hardware, Hardware.id == Run.hardware_id)
         .join(commits_up, commits_up.c.id == Run.commit_id)
         .filter(
-            Run.name.like("commit: %"),
+            Run.reason == "commit",
             BenchmarkResult.error.is_(None),
             BenchmarkResult.case_id == benchmark_result.case_id,
             BenchmarkResult.context_id == benchmark_result.context_id,
@@ -153,7 +153,7 @@ def get_closest_parent(run):
         .join(Commit, Commit.id == Run.commit_id)
         .join(Hardware, Hardware.id == Run.hardware_id)
         .filter(
-            Run.name.like("commit: %"),
+            Run.reason == "commit",
             Hardware.id.in_(hardware_ids),
             Commit.timestamp.isnot(None),
             Commit.timestamp < commit.timestamp,

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -57,7 +57,7 @@ def get_history(case_id, context_id, hardware_hash):
             BenchmarkResult.case_id == case_id,
             BenchmarkResult.context_id == context_id,
             BenchmarkResult.error.is_(None),
-            Run.name.like("commit: %"),
+            Run.reason == "commit",
             Hardware.hash == hardware_hash,
             Distribution.case_id == case_id,
             Distribution.context_id == context_id,

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -45,7 +45,7 @@ class Run(Base, EntityMixin):
             filters=[
                 Commit.sha == parent.sha,
                 Hardware.id.in_(hardware_ids),
-                Run.name.like("commit: %"),
+                Run.reason == "commit",
             ],
             joins=[Commit, Hardware],
             order_by=Run.timestamp.desc(),

--- a/conbench/tests/api/_fixtures.py
+++ b/conbench/tests/api/_fixtures.py
@@ -147,6 +147,7 @@ def benchmark_result(
 ):
     data = copy.deepcopy(VALID_PAYLOAD)
     data["run_name"] = f"commit: {_uuid()}"
+    data["run_reason"] = "commit"
     data["run_id"] = run_id if run_id else _uuid()
     data["batch_id"] = batch_id if batch_id else _uuid()
     data["tags"]["name"] = name if name else _uuid()

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -61,6 +61,7 @@ class TestRunGet(_asserts.GetEnforcer):
         self.authenticate(client)
         run, baseline = self._create(baseline=True, name=name, language=language)
         baseline.name = "testing"
+        baseline.reason = "test"
         baseline.save()
         response = client.get(f"/api/runs/{run.id}/")
         self.assert_200_ok(response, _expected_entity(run, None))
@@ -199,6 +200,7 @@ class TestRunGet(_asserts.GetEnforcer):
 
         testing_run = testing.run
         testing_run.name = "testing"
+        testing_run.reason = "test"
         testing_run.save()
 
         contender_run = contender.run

--- a/conbench/tests/entities/test_distribution.py
+++ b/conbench/tests/entities/test_distribution.py
@@ -20,7 +20,7 @@ FROM benchmark_result JOIN run ON run.id = benchmark_result.run_id JOIN hardware
 FROM commit 
 WHERE commit.repository = :repository_1 AND commit.timestamp IS NOT NULL AND commit.timestamp <= :timestamp_1 ORDER BY commit.timestamp DESC
  LIMIT :param_1) AS commits_up ON commits_up.id = run.commit_id 
-WHERE run.name LIKE :name_1 AND benchmark_result.error IS NULL AND benchmark_result.case_id = :case_id_1 AND benchmark_result.context_id = :context_id_1 AND hardware.hash = :hash_1 GROUP BY benchmark_result.case_id, benchmark_result.context_id, hardware.hash"""  # noqa
+WHERE run.reason = :reason_1 AND benchmark_result.error IS NULL AND benchmark_result.case_id = :case_id_1 AND benchmark_result.context_id = :context_id_1 AND hardware.hash = :hash_1 GROUP BY benchmark_result.case_id, benchmark_result.context_id, hardware.hash"""  # noqa
 
 
 def test_z_score_calculations():


### PR DESCRIPTION
This attempts to close `#382` (edit: does not, but is useful regardless) by changing filters on run name prefix to filters on run reason, which provided `run_reason` is populated on >100 commits, will not change which commits are selected, but frees up `run_name` to be used for more human-readable purposes.

This might be a fix more for letter than spirit of the issue, but if so hopefully it will be useful to spark conversation about what we want to change.