### PR TITLE
Unpin pytest and fix issue with pytest 7.2

### DIFF
--- a/conbench/util.py
+++ b/conbench/util.py
@@ -142,4 +142,4 @@ def register_benchmarks(directory=None):
                     or filename.endswith("benchmark.py")
                     or filename.endswith("benchmarks.py")
                 ):
-                    import_path(f"{directory}/{filename}")
+                    import_path(f"{directory}/{filename}", root=entry)

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -19,7 +19,7 @@ openapi-spec-validator
 psutil
 psycopg2-binary
 py-cpuinfo
-pytest==6.2.5
+pytest
 python-dotenv
 PyYAML
 requests

--- a/requirements-cli.txt
+++ b/requirements-cli.txt
@@ -2,6 +2,6 @@ click
 numpy
 psutil
 py-cpuinfo
-pytest==6.2.5
+pytest
 PyYAML
 requests

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,4 +3,4 @@ coverage
 coveralls
 flake8
 isort
-pytest==6.2.5
+pytest


### PR DESCRIPTION
pytest==6.2.5 is making https://buildkite.com/apache-arrow/arrow-bci-benchmark-on-ec2-t3-xlarge-us-east-2/builds/1735 builds fail with:
```


INFO:root:Done executing -> conbench dataset-read ALL --iterations=3 --all=true --drop-caches=true --run-id=$RUN_ID --run-name="$RUN_NAME" --run-reason="$RUN_REASON"
--
  | INFO:root:{'type': 'BenchmarkGroupExecution', 'id': 'c22ab27e197545eba83465c0bd849f21', 'lang': 'Python', 'name': 'dataset-read', 'options': 'ALL --iterations=3 --all=true --drop-caches=true', 'flags': {'cloud': True, 'language': 'Python'}, 'benchmarkable_id': 'eb45b86fe8b3af583d2dcb09466ecd45d04774af', 'run_id': '11db0feba6ed47219ff8c3f39a7f2915', 'run_name': 'commit: eb45b86fe8b3af583d2dcb09466ecd45d04774af', 'machine': 'ec2-t3-xlarge-us-east-2', 'process_pid': 817142, 'command': 'conbench dataset-read ALL --iterations=3 --all=true --drop-caches=true --run-id=$RUN_ID --run-name="$RUN_NAME" --run-reason="$RUN_REASON"', 'started_at': '2022-10-25 18:25:18.412414', 'finished_at': '2022-10-25 18:25:18.751029', 'total_run_time': '0:00:00.338615', 'failed': True, 'return_code': 1, 'stderr': 'Traceback (most recent call last):\n  File "/var/lib/buildkite-agent/miniconda3/envs/arrow-commit/bin/conbench", line 33, in <module>\n    sys.exit(load_entry_point(\'conbench==1.58.0\', \'console_scripts\', \'conbench\')())\n  File "/var/lib/buildkite-agent/miniconda3/envs/arrow-commit/bin/conbench", line 25, in importlib_load_entry_point\n    return next(matches).load()\n  File "/var/lib/buildkite-agent/miniconda3/envs/arrow-commit/lib/python3.8/importlib/metadata.py", line 77, in load\n    module = import_module(match.group(\'module\'))\n  File "/var/lib/buildkite-agent/miniconda3/envs/arrow-commit/lib/python3.8/importlib/__init__.py", line 127, in import_module\n    return _bootstrap._gcd_import(name[level:], package, level)\n  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import\n  File "<frozen importlib._bootstrap>", line 991, in _find_and_load\n  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked\n  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked\n  File "<frozen importlib._bootstrap_external>", line 843, in exec_module\n  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed\n  File "/var/lib/buildkite-agent/miniconda3/envs/arrow-commit/lib/python3.8/site-packages/conbench-1.58.0-py3.8.egg/conbench/cli.py", line 6, in <module>\n    from .runner import LIST, REGISTRY\n  File "/var/lib/buildkite-agent/miniconda3/envs/arrow-commit/lib/python3.8/site-packages/conbench-1.58.0-py3.8.egg/conbench/runner.py", line 15, in <module>\n    from .util import Connection\n  File "/var/lib/buildkite-agent/miniconda3/envs/arrow-commit/lib/python3.8/site-packages/conbench-1.58.0-py3.8.egg/conbench/util.py", line 9, in <module>\n    from _pytest.pathlib import import_path\n  File "/var/lib/buildkite-agent/miniconda3/envs/arrow-commit/lib/python3.8/site-packages/_pytest/pathlib.py", line 33, in <module>\n    import py\nModuleNotFoundError: No module named \'py\'\n', 'total_machine_virtual_memory': 16591859712}
  | INFO:root:{'type': 'BenchmarkGroupExecution', 'id': '758904a29bac4fcf8728cde00d660abb', 'lang': 'Python', 'name': 'dataset-select', 'options': 'ALL --iterations=3 --drop-caches=true', 'flags': {'cloud': True, 'language': 'Python'}, 'benchmarkable_id': 'eb45b86fe8b3af583d2dcb09466ecd45d04774af', 'run_id': '11db0feba6ed47219ff8c3f39a7f2915', 'run_name': 'commit: eb45b86fe8b3af583d2dcb09466ecd45d04774af', 'machine': 'ec2-t3-xlarge-us-east-2', 'process_pid': 817142, 'command': 'conbench dataset-select ALL --iterations=3 --drop-caches=true --run-id=$RUN_ID --run-name="$RUN_NAME" --run-reason="$RUN_REASON"', 'started_at': '2022-10-25 18:25:18.785201', 'finished_at': None, 'total_run_time': None, 'failed': False, 'return_code': None, 'stderr': None, 'total_machine_virtual_memory': 16591859712}
  | INFO:root:Started executing -> conbench dataset-select ALL --iterations=3 --drop-caches=true --run-id=$RUN_ID --run-name="$RUN_NAME" --run-reason="$RUN_REASON"
  | INFO:root:Traceback (most recent call last):
  | File "/var/lib/buildkite-agent/miniconda3/envs/arrow-commit/bin/conbench", line 33, in <module>
  | sys.exit(load_entry_point('conbench==1.58.0', 'console_scripts', 'conbench')())
  | File "/var/lib/buildkite-agent/miniconda3/envs/arrow-commit/bin/conbench", line 25, in importlib_load_entry_point
  | return next(matches).load()
  | File "/var/lib/buildkite-agent/miniconda3/envs/arrow-commit/lib/python3.8/importlib/metadata.py", line 77, in load
  | module = import_module(match.group('module'))
  | File "/var/lib/buildkite-agent/miniconda3/envs/arrow-commit/lib/python3.8/importlib/__init__.py", line 127, in import_module
  | return _bootstrap._gcd_import(name[level:], package, level)
  | File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  | File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  | File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  | File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  | File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  | File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  | File "/var/lib/buildkite-agent/miniconda3/envs/arrow-commit/lib/python3.8/site-packages/conbench-1.58.0-py3.8.egg/conbench/cli.py", line 6, in <module>
  | from .runner import LIST, REGISTRY
  | File "/var/lib/buildkite-agent/miniconda3/envs/arrow-commit/lib/python3.8/site-packages/conbench-1.58.0-py3.8.egg/conbench/runner.py", line 15, in <module>
  | from .util import Connection
  | File "/var/lib/buildkite-agent/miniconda3/envs/arrow-commit/lib/python3.8/site-packages/conbench-1.58.0-py3.8.egg/conbench/util.py", line 9, in <module>
  | from _pytest.pathlib import import_path
  | File "/var/lib/buildkite-agent/miniconda3/envs/arrow-commit/lib/python3.8/site-packages/_pytest/pathlib.py", line 33, in <module>
  | import py
  | ModuleNotFoundError: No module named 'py'
```

Reproduced this issue locally:
```
(benchmarks) elena@e benchmarks % pip install conbench  
Requirement already satisfied: conbench in /Users/elena/miniconda3/envs/benchmarks/lib/python3.8/site-packages/conbench-1.59.0-py3.8.egg (1.59.0)
Requirement already satisfied: click in /Users/elena/miniconda3/envs/benchmarks/lib/python3.8/site-packages (from conbench) (8.1.3)
Requirement already satisfied: numpy in /Users/elena/miniconda3/envs/benchmarks/lib/python3.8/site-packages (from conbench) (1.23.4)
Requirement already satisfied: psutil in /Users/elena/miniconda3/envs/benchmarks/lib/python3.8/site-packages (from conbench) (5.9.3)
Requirement already satisfied: py-cpuinfo in /Users/elena/miniconda3/envs/benchmarks/lib/python3.8/site-packages (from conbench) (9.0.0)
Collecting pytest==6.2.5
  Using cached pytest-6.2.5-py3-none-any.whl (280 kB)
Requirement already satisfied: PyYAML in /Users/elena/miniconda3/envs/benchmarks/lib/python3.8/site-packages (from conbench) (6.0)
Requirement already satisfied: requests in /Users/elena/miniconda3/envs/benchmarks/lib/python3.8/site-packages (from conbench) (2.28.1)
Requirement already satisfied: py>=1.8.2 in /Users/elena/miniconda3/envs/benchmarks/lib/python3.8/site-packages (from pytest==6.2.5->conbench) (1.11.0)
Requirement already satisfied: pluggy<2.0,>=0.12 in /Users/elena/miniconda3/envs/benchmarks/lib/python3.8/site-packages (from pytest==6.2.5->conbench) (1.0.0)
Requirement already satisfied: packaging in /Users/elena/miniconda3/envs/benchmarks/lib/python3.8/site-packages (from pytest==6.2.5->conbench) (21.3)
Requirement already satisfied: iniconfig in /Users/elena/miniconda3/envs/benchmarks/lib/python3.8/site-packages (from pytest==6.2.5->conbench) (1.1.1)
Requirement already satisfied: toml in /Users/elena/miniconda3/envs/benchmarks/lib/python3.8/site-packages (from pytest==6.2.5->conbench) (0.10.2)
Requirement already satisfied: attrs>=19.2.0 in /Users/elena/miniconda3/envs/benchmarks/lib/python3.8/site-packages (from pytest==6.2.5->conbench) (22.1.0)
Requirement already satisfied: charset-normalizer<3,>=2 in /Users/elena/miniconda3/envs/benchmarks/lib/python3.8/site-packages (from requests->conbench) (2.1.1)
Requirement already satisfied: urllib3<1.27,>=1.21.1 in /Users/elena/miniconda3/envs/benchmarks/lib/python3.8/site-packages (from requests->conbench) (1.26.12)
Requirement already satisfied: idna<4,>=2.5 in /Users/elena/miniconda3/envs/benchmarks/lib/python3.8/site-packages (from requests->conbench) (3.4)
Requirement already satisfied: certifi>=2017.4.17 in /Users/elena/miniconda3/envs/benchmarks/lib/python3.8/site-packages (from requests->conbench) (2022.9.24)
Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /Users/elena/miniconda3/envs/benchmarks/lib/python3.8/site-packages (from packaging->pytest==6.2.5->conbench) (3.0.9)
Installing collected packages: pytest
Successfully installed pytest-6.2.5
(benchmarks) elena@e benchmarks % python
Python 3.8.13 | packaged by conda-forge | (default, Mar 25 2022, 06:05:47) 
[Clang 12.0.1 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from _pytest.pathlib import import_path
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/elena/miniconda3/envs/benchmarks/lib/python3.8/site-packages/_pytest/pathlib.py", line 33, in <module>
    import py
ModuleNotFoundError: No module named 'py'
>>> 
```

Upgrading solves this issue:
```
(benchmarks) elena@e benchmarks % pip install pytest -U
Requirement already satisfied: pytest in /Users/elena/miniconda3/envs/benchmarks/lib/python3.8/site-packages (6.2.5)
Collecting pytest
  Using cached pytest-7.2.0-py3-none-any.whl (316 kB)
Requirement already satisfied: iniconfig in /Users/elena/miniconda3/envs/benchmarks/lib/python3.8/site-packages (from pytest) (1.1.1)
Collecting tomli>=1.0.0
  Using cached tomli-2.0.1-py3-none-any.whl (12 kB)
Requirement already satisfied: attrs>=19.2.0 in /Users/elena/miniconda3/envs/benchmarks/lib/python3.8/site-packages (from pytest) (22.1.0)
Requirement already satisfied: pluggy<2.0,>=0.12 in /Users/elena/miniconda3/envs/benchmarks/lib/python3.8/site-packages (from pytest) (1.0.0)
Collecting exceptiongroup>=1.0.0rc8
  Using cached exceptiongroup-1.0.0rc9-py3-none-any.whl (12 kB)
Requirement already satisfied: packaging in /Users/elena/miniconda3/envs/benchmarks/lib/python3.8/site-packages (from pytest) (21.3)
Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /Users/elena/miniconda3/envs/benchmarks/lib/python3.8/site-packages (from packaging->pytest) (3.0.9)
Installing collected packages: tomli, exceptiongroup, pytest
  Attempting uninstall: pytest
    Found existing installation: pytest 6.2.5
    Uninstalling pytest-6.2.5:
      Successfully uninstalled pytest-6.2.5
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
conbench 1.59.0 requires pytest==6.2.5, but you have pytest 7.2.0 which is incompatible.
Successfully installed exceptiongroup-1.0.0rc9 pytest-7.2.0 tomli-2.0.1
(benchmarks) elena@e benchmarks % python               
Python 3.8.13 | packaged by conda-forge | (default, Mar 25 2022, 06:05:47) 
[Clang 12.0.1 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from _pytest.pathlib import import_path
>>> 
```

However, upgrading uncovers another issue:
```
(benchmarks) elena@e benchmarks % conbench
Traceback (most recent call last):
  File "/Users/elena/miniconda3/envs/benchmarks/bin/conbench", line 33, in <module>
    sys.exit(load_entry_point('conbench', 'console_scripts', 'conbench')())
  File "/Users/elena/miniconda3/envs/benchmarks/bin/conbench", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/Users/elena/miniconda3/envs/benchmarks/lib/python3.8/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "/Users/elena/miniconda3/envs/benchmarks/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/Users/elena/benchmarks/conbench/conbench/cli.py", line 9, in <module>
    register_benchmarks()
  File "/Users/elena/benchmarks/conbench/conbench/util.py", line 145, in register_benchmarks
    import_path(f"{directory}/{filename}")
TypeError: import_path() missing 1 required keyword-only argument: 'root'
(benchmarks) elena@e benchmarks % 
```