### PR TITLE
Accept partial successful benchmarks

### DIFF
--- a/conbench/api/_examples.py
+++ b/conbench/api/_examples.py
@@ -30,11 +30,31 @@ def _api_benchmark_entity(
     batch_id,
     run_id,
     name,
+    stats=None,
     error=None,
     validation=None,
     optional_benchmark_info=None,
 ):
-    if error:
+    if stats:
+        stats = {
+            "data": stats.get("data"),
+            "times": stats.get("times"),
+            "unit": "s",
+            "time_unit": "s",
+            "iqr": None,
+            "iterations": 10,
+            "max": None,
+            "mean": None,
+            "median": None,
+            "min": None,
+            "q1": None,
+            "q3": None,
+            "stdev": None,
+            "z_score": None,
+            "z_regression": False,
+            "z_improvement": False,
+        }
+    elif error:
         stats = {
             "data": [],
             "times": [],

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -194,22 +194,83 @@ s.Index("benchmark_result_context_id_index", BenchmarkResult.context_id)
 
 class BenchmarkResultCreate(marshmallow.Schema):
     data = marshmallow.fields.List(
-        marshmallow.fields.Decimal(allow_none=True), required=True
+        marshmallow.fields.Decimal(allow_none=True),
+        required=True,
+        metadata={
+            "description": "A list of benchmark results (e.g. durations, throughput). This will be used as the main + only metric for regression and improvement. The values should be ordered in the order the iterations were executed (the first element is the first iteration, the second element is the second iteration, etc.). If an iteration did not complete but others did and you want to send partial data, mark each iteration that didn't complete as `null`."
+        },
     )
     times = marshmallow.fields.List(
-        marshmallow.fields.Decimal(allow_none=True), required=True
+        marshmallow.fields.Decimal(allow_none=True),
+        required=True,
+        metadata={
+            "description": "A list of benchmark durations. If `data` is a duration measure, this should be a duplicate of that object. The values should be ordered in the order the iterations were executed (the first element is the first iteration, the second element is the second iteration, etc.). If an iteration did not complete but others did and you want to send partial data, mark each iteration that didn't complete as `null`."
+        },
     )
-    unit = marshmallow.fields.String(required=True)
-    time_unit = marshmallow.fields.String(required=True)
-    iterations = marshmallow.fields.Integer(required=True)
-    min = marshmallow.fields.Decimal(required=False)
-    max = marshmallow.fields.Decimal(required=False)
-    mean = marshmallow.fields.Decimal(required=False)
-    median = marshmallow.fields.Decimal(required=False)
-    stdev = marshmallow.fields.Decimal(required=False)
-    q1 = marshmallow.fields.Decimal(required=False)
-    q3 = marshmallow.fields.Decimal(required=False)
-    iqr = marshmallow.fields.Decimal(required=False)
+    unit = marshmallow.fields.String(
+        required=True,
+        metadata={"description": "The unit of the data object (e.g. seconds, B/s)"},
+    )
+    time_unit = marshmallow.fields.String(
+        required=True,
+        metadata={
+            "description": "The unit of the times object (e.g. seconds, nanoseconds)"
+        },
+    )
+    iterations = marshmallow.fields.Integer(
+        required=True,
+        metadata={
+            "description": "Number of iterations that were executed (should be the length of `data` and `times`)"
+        },
+    )
+    min = marshmallow.fields.Decimal(
+        required=False,
+        metadata={
+            "description": "The minimum from `data`, will be calculdated on the server if not present (the preferred method), but can be overridden if sent. Will be marked `null` if any iterations are missing."
+        },
+    )
+    max = marshmallow.fields.Decimal(
+        required=False,
+        metadata={
+            "description": "The maximum from `data`, will be calculdated on the server if not present (the preferred method), but can be overridden if sent. Will be marked `null` if any iterations are missing."
+        },
+    )
+    mean = marshmallow.fields.Decimal(
+        required=False,
+        metadata={
+            "description": "The mean from `data`, will be calculdated on the server if not present (the preferred method), but can be overridden if sent. Will be marked `null` if any iterations are missing."
+        },
+    )
+    median = marshmallow.fields.Decimal(
+        required=False,
+        metadata={
+            "description": "The median from `data`, will be calculdated on the server if not present (the preferred method), but can be overridden if sent. Will be marked `null` if any iterations are missing."
+        },
+    )
+    stdev = marshmallow.fields.Decimal(
+        required=False,
+        metadata={
+            "description": "The standard deviation from `data`, will be calculdated on the server if not present (the preferred method), but can be overridden if sent. Will be marked `null` if any iterations are missing."
+        },
+    )
+    q1 = marshmallow.fields.Decimal(
+        required=False,
+        metadata={
+            "description": "The first quartile from `data`, will be calculdated on the server if not present (the preferred method), but can be overridden if sent. Will be marked `null` if any iterations are missing."
+        },
+    )
+    q3 = marshmallow.fields.Decimal(
+        required=False,
+        metadata={
+            "description": "The third quartile from `data`, will be calculdated on the server if not present (the preferred method), but can be overridden if sent. Will be marked `null` if any iterations are missing."
+        },
+    )
+    iqr = marshmallow.fields.Decimal(
+        required=False,
+        metadata={
+            "description": "The inter-quartile range from `data`, will be calculdated on the server if not present (the preferred method), but can be overridden if sent. Will be marked `null` if any iterations are missing."
+        },
+    )
 
 
 class BenchmarkResultSchema:

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -112,6 +112,15 @@ class BenchmarkResult(Base, EntityMixin):
         if has_error:
             benchmark_result_data["error"] = data["error"]
 
+        # If there was no explicit error *and* the iterations aren't complete, we should add an error
+        if (
+            benchmark_result_data.get("error", None) is None
+            and complete_iterations is False
+        ):
+            benchmark_result_data["error"] = {
+                "status": "Partial result: not all iterations completed"
+            }
+
         name = tags.pop("name")
 
         # create if not exists

--- a/conbench/entities/distribution.py
+++ b/conbench/entities/distribution.py
@@ -210,7 +210,7 @@ def set_z_scores(benchmark_results):
             continue
 
         d = lookup.get(f"{benchmark_result.case_id}-{benchmark_result.context_id}")
-        if d and d.mean_sd:
+        if d and d.mean_sd and benchmark_result.mean:
             benchmark_result.z_score = (benchmark_result.mean - d.mean_mean) / d.mean_sd
         if _less_is_better(benchmark_result.unit) and benchmark_result.z_score:
             benchmark_result.z_score = benchmark_result.z_score * -1

--- a/conbench/templates/benchmark-entity.html
+++ b/conbench/templates/benchmark-entity.html
@@ -77,7 +77,8 @@
         <div align="left" style="display:inline-block; white-space: pre; float: center;">{{ v }}</div>
       </li>
       {% endfor %}
-      {% else %}
+      {% endif %}
+      {% if benchmark.stats %}
       <li class="list-group-item active">Result</li>
       <li class="list-group-item" style="overflow-y: auto;">
         <b>timestamp</b>

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -994,24 +994,59 @@
             "BenchmarkResultCreate": {
                 "properties": {
                     "data": {
+                        "description": "A list of benchmark results (e.g. durations, throughput). This will be used as the main + only metric for regression and improvement. The values should be ordered in the order the iterations were executed (the first element is the first iteration, the second element is the second iteration, etc.). If an iteration did not complete but others did and you want to send partial data, mark each iteration that didn't complete as `null`.",
                         "items": {"nullable": True, "type": "number"},
                         "type": "array",
                     },
-                    "iqr": {"type": "number"},
-                    "iterations": {"type": "integer"},
-                    "max": {"type": "number"},
-                    "mean": {"type": "number"},
-                    "median": {"type": "number"},
-                    "min": {"type": "number"},
-                    "q1": {"type": "number"},
-                    "q3": {"type": "number"},
-                    "stdev": {"type": "number"},
-                    "time_unit": {"type": "string"},
+                    "iqr": {
+                        "description": "The inter-quartile range from `data`, will be calculdated on the server if not present (the preferred method), but can be overridden if sent. Will be marked `null` if any iterations are missing.",
+                        "type": "number",
+                    },
+                    "iterations": {
+                        "description": "Number of iterations that were executed (should be the length of `data` and `times`)",
+                        "type": "integer",
+                    },
+                    "max": {
+                        "description": "The maximum from `data`, will be calculdated on the server if not present (the preferred method), but can be overridden if sent. Will be marked `null` if any iterations are missing.",
+                        "type": "number",
+                    },
+                    "mean": {
+                        "description": "The mean from `data`, will be calculdated on the server if not present (the preferred method), but can be overridden if sent. Will be marked `null` if any iterations are missing.",
+                        "type": "number",
+                    },
+                    "median": {
+                        "description": "The median from `data`, will be calculdated on the server if not present (the preferred method), but can be overridden if sent. Will be marked `null` if any iterations are missing.",
+                        "type": "number",
+                    },
+                    "min": {
+                        "description": "The minimum from `data`, will be calculdated on the server if not present (the preferred method), but can be overridden if sent. Will be marked `null` if any iterations are missing.",
+                        "type": "number",
+                    },
+                    "q1": {
+                        "description": "The first quartile from `data`, will be calculdated on the server if not present (the preferred method), but can be overridden if sent. Will be marked `null` if any iterations are missing.",
+                        "type": "number",
+                    },
+                    "q3": {
+                        "description": "The third quartile from `data`, will be calculdated on the server if not present (the preferred method), but can be overridden if sent. Will be marked `null` if any iterations are missing.",
+                        "type": "number",
+                    },
+                    "stdev": {
+                        "description": "The standard deviation from `data`, will be calculdated on the server if not present (the preferred method), but can be overridden if sent. Will be marked `null` if any iterations are missing.",
+                        "type": "number",
+                    },
+                    "time_unit": {
+                        "description": "The unit of the times object (e.g. seconds, nanoseconds)",
+                        "type": "string",
+                    },
                     "times": {
+                        "description": "A list of benchmark durations. If `data` is a duration measure, this should be a duplicate of that object. The values should be ordered in the order the iterations were executed (the first element is the first iteration, the second element is the second iteration, etc.). If an iteration did not complete but others did and you want to send partial data, mark each iteration that didn't complete as `null`.",
                         "items": {"nullable": True, "type": "number"},
                         "type": "array",
                     },
-                    "unit": {"type": "string"},
+                    "unit": {
+                        "description": "The unit of the data object (e.g. seconds, B/s)",
+                        "type": "string",
+                    },
                 },
                 "required": ["data", "iterations", "time_unit", "times", "unit"],
                 "type": "object",

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -993,7 +993,10 @@
             },
             "BenchmarkResultCreate": {
                 "properties": {
-                    "data": {"items": {"type": "number"}, "type": "array"},
+                    "data": {
+                        "items": {"nullable": True, "type": "number"},
+                        "type": "array",
+                    },
                     "iqr": {"type": "number"},
                     "iterations": {"type": "integer"},
                     "max": {"type": "number"},
@@ -1004,7 +1007,10 @@
                     "q3": {"type": "number"},
                     "stdev": {"type": "number"},
                     "time_unit": {"type": "string"},
-                    "times": {"items": {"type": "number"}, "type": "array"},
+                    "times": {
+                        "items": {"nullable": True, "type": "number"},
+                        "type": "array",
+                    },
                     "unit": {"type": "string"},
                 },
                 "required": ["data", "iterations", "time_unit", "times", "unit"],

--- a/conbench/tests/api/_fixtures.py
+++ b/conbench/tests/api/_fixtures.py
@@ -126,6 +126,45 @@ VALID_PAYLOAD_WITH_ERROR = dict(
     },
 )
 
+VALID_PAYLOAD_WITH_ITERATION_ERROR = dict(
+    run_id="ya5709d179f349cba69ed242be3e6323",
+    error={"stack_trace": "some trace", "command": "ls"},
+    **{
+        key: value
+        for key, value in VALID_PAYLOAD.items()
+        if key not in ("stats", "run_id")
+    },
+    stats={
+        "data": [
+            "0.099094",
+            None,
+            "0.036381",
+            "0.148896",
+            "0.008104",
+            "0.005496",
+            "0.009871",
+            "0.006008",
+            "0.007978",
+            "0.004733",
+        ],
+        "times": [
+            "0.099094",
+            None,
+            "0.036381",
+            "0.148896",
+            "0.008104",
+            "0.005496",
+            "0.009871",
+            "0.006008",
+            "0.007978",
+            "0.004733",
+        ],
+        "unit": "s",
+        "time_unit": "s",
+        "iterations": 10,
+    },
+)
+
 VALID_PAYLOAD_FOR_CLUSTER = dict(
     run_id="3a5709d179f349cba69ed242be3e6323",
     cluster_info=CLUSTER_INFO,
@@ -182,6 +221,7 @@ def benchmark_result(
     commit=None,
     pull_request=False,
     error=None,
+    empty_results=False,
 ):
     data = copy.deepcopy(VALID_PAYLOAD)
     data["run_name"] = f"commit: {_uuid()}"
@@ -206,6 +246,9 @@ def benchmark_result(
     if results is not None:
         unit = unit if unit else "s"
         data["stats"] = Conbench._stats(results, unit, [], "s")
+
+    if empty_results:
+        data.pop("stats", None)
 
     if error is not None:
         data["error"] = error

--- a/conbench/tests/api/test_benchmarks.py
+++ b/conbench/tests/api/test_benchmarks.py
@@ -15,7 +15,7 @@ ARROW_REPO = "https://github.com/apache/arrow"
 CONBENCH_REPO = "https://github.com/conbench/conbench"
 
 
-def _expected_entity(benchmark_result):
+def _expected_entity(benchmark_result, stats=None):
     return _api_benchmark_entity(
         benchmark_result.id,
         benchmark_result.case_id,
@@ -24,6 +24,7 @@ def _expected_entity(benchmark_result):
         benchmark_result.batch_id,
         benchmark_result.run_id,
         benchmark_result.case.name,
+        stats,
         benchmark_result.error,
         benchmark_result.validation,
         benchmark_result.optional_benchmark_info,
@@ -312,6 +313,7 @@ class TestBenchmarkPost(_asserts.PostEnforcer):
     valid_payload = _fixtures.VALID_PAYLOAD
     valid_payload_for_cluster = _fixtures.VALID_PAYLOAD_FOR_CLUSTER
     valid_payload_with_error = _fixtures.VALID_PAYLOAD_WITH_ERROR
+    valid_payload_with_iteration_error = _fixtures.VALID_PAYLOAD_WITH_ITERATION_ERROR
     required_fields = [
         "batch_id",
         "context",
@@ -393,6 +395,24 @@ class TestBenchmarkPost(_asserts.PostEnforcer):
         location = f"http://localhost/api/benchmarks/{new_id}/"
         self.assert_201_created(response, _expected_entity(benchmark_result), location)
         assert Run.one(id=run_payload["id"]).has_errors is True
+
+    def test_create_benchmark_with_one_iteration_error(self, client):
+        self.authenticate(client)
+        response = client.post(
+            "/api/benchmarks/", json=self.valid_payload_with_iteration_error
+        )
+        new_id = response.json["id"]
+        benchmark_result = BenchmarkResult.one(id=new_id)
+        location = "http://localhost/api/benchmarks/%s/" % new_id
+        stats = self.valid_payload_with_iteration_error["stats"]
+        stats["data"] = [float(x) if x else None for x in stats["data"]]
+        stats["times"] = [float(x) if x else None for x in stats["times"]]
+        self.assert_201_created(
+            response, _expected_entity(benchmark_result, stats), location
+        )
+        assert (
+            benchmark_result.error == self.valid_payload_with_iteration_error["error"]
+        )
 
     def test_create_benchmark_for_cluster_with_optional_info_changed(self, client):
         # Post benchmarks for cluster-1
@@ -800,14 +820,4 @@ class TestBenchmarkPost(_asserts.PostEnforcer):
         del data["stats"]
         response = client.post(self.url, json=data)
         message = {"_schema": ["Either stats or error field is required"]}
-        self.assert_400_bad_request(response, message)
-
-    def test_stats_and_error_fields_are_present(self, client):
-        self.authenticate(client)
-        data = copy.deepcopy(self.valid_payload)
-        data["error"] = {}
-        response = client.post(self.url, json=data)
-        message = {
-            "_schema": ["stats and error fields can not be used at the same time"]
-        }
         self.assert_400_bad_request(response, message)

--- a/conbench/tests/api/test_compare.py
+++ b/conbench/tests/api/test_compare.py
@@ -205,7 +205,11 @@ class TestCompareBenchmarksGet(_asserts.GetEnforcer):
             sha=_fixtures.GRANDPARENT,
         )
         benchmark_result_1 = _fixtures.benchmark_result(
-            name=name, results=None, sha=_fixtures.PARENT, error=baseline_error
+            name=name,
+            results=None,
+            sha=_fixtures.PARENT,
+            error=baseline_error,
+            empty_results=True,
         )
         benchmark_result_2 = _fixtures.benchmark_result(
             name=name,
@@ -293,6 +297,7 @@ class TestCompareBenchmarksGet(_asserts.GetEnforcer):
                 "contender_z_regression": False,
             }
         )
+
         self.assert_200_ok(response, expected)
 
     def test_compare_unknown_compare_ids(self, client):
@@ -409,6 +414,7 @@ class TestCompareRunsGet(_asserts.GetEnforcer):
             batch_id=batch_id,
             results=None,
             error=baseline_error,
+            empty_results=True,
         )
         entity = FakeEntity(f"{run_id}...{run_id}")
         if verbose:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ requirements_test = parse_requirements(path="requirements-test.txt")
 
 setuptools.setup(
     name="conbench",
-    version="1.61.0",
+    version="1.62.0",
     description="Continuous Benchmarking (CB) Framework",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
resolves #395 

This works for uploading so far, ~but I need to work more to confirm that things like comparisons will do the correct thing and dis-allow comparing a partial success to something that actually succeeded. Also need to confirm that partial success don't show up in history~ 

This should now work for comparisons as well. The way this is set up, if a partial result (e.g. if `stats.data` has any `None`s in it) and no error is reported, we will add in an error that says it's an incomplete iteration. Thus all of our history + comparisons that check if error exists will all _just work_.

I could imagine a situation where we might want to distinguish between a partial run and an errored run (without needing to inspect `stats.data`) where it might make sense to have a separate property like `completed_iterations: True|False`, but let's deal with that if|when it comes up.