### PR TITLE
Print instead of log what's posted

### DIFF
--- a/benchadapt/python/benchadapt/adapters/_adapter.py
+++ b/benchadapt/python/benchadapt/adapters/_adapter.py
@@ -170,8 +170,8 @@ class BenchmarkAdapter(abc.ABC):
 
             try:
                 res = client.post(path="/benchmarks/", json=result_dict)
-            except requests.exceptions.ReadTimeout as e:
-                print(f"POST timed out: {e.response.content.decode()}. Retrying...")
+            except requests.exceptions.ReadTimeout:
+                print("POST timed out. Retrying...")
                 try:
                     res = client.post(path="/benchmarks/", json=result_dict)
                 except requests.exceptions.ReadTimeout as ee:
@@ -180,6 +180,7 @@ class BenchmarkAdapter(abc.ABC):
             res_list.append(res)
 
         if error:
+            print("Prior POST timed out twice:")
             raise error
 
         log.info("All results sent to conbench")

--- a/benchadapt/python/benchadapt/client.py
+++ b/benchadapt/python/benchadapt/client.py
@@ -52,13 +52,7 @@ class _BaseClient(abc.ABC):
         # log.debug(f"POST {url} {dumps(json)}")
         print(f"POST {url} {dumps(json)}")
 
-        try:
-            res = self.session.post(url=url, json=json, timeout=self.timeout_s)
-        except requests.exceptions.ReadTimeout as e:
-            print(f"POST timed out: {e.response.content.decode()}. Retrying...")
-            print(f"POST {url} {dumps(json)}")
-            res = self.session.post(url=url, json=json, timeout=self.timeout_s)
-
+        res = self.session.post(url=url, json=json, timeout=self.timeout_s)
         self._maybe_raise(res=res)
 
         if res.content:

--- a/benchadapt/python/benchadapt/client.py
+++ b/benchadapt/python/benchadapt/client.py
@@ -52,7 +52,13 @@ class _BaseClient(abc.ABC):
         # log.debug(f"POST {url} {dumps(json)}")
         print(f"POST {url} {dumps(json)}")
 
-        res = self.session.post(url=url, json=json, timeout=self.timeout_s)
+        try:
+            res = self.session.post(url=url, json=json, timeout=self.timeout_s)
+        except requests.exceptions.ReadTimeout as e:
+            print(f"POST timed out: {e.response.content.decode()}. Retrying...")
+            print(f"POST {url} {dumps(json)}")
+            res = self.session.post(url=url, json=json, timeout=self.timeout_s)
+
         self._maybe_raise(res=res)
 
         if res.content:

--- a/benchadapt/python/benchadapt/client.py
+++ b/benchadapt/python/benchadapt/client.py
@@ -48,7 +48,10 @@ class _BaseClient(abc.ABC):
 
     def post(self, path: str, json: dict) -> Optional[dict]:
         url = self.base_url + path
-        log.debug(f"POST {url} {dumps(json)}")
+
+        # log.debug(f"POST {url} {dumps(json)}")
+        print(f"POST {url} {dumps(json)}")
+
         res = self.session.post(url=url, json=json, timeout=self.timeout_s)
         self._maybe_raise(res=res)
 


### PR DESCRIPTION
Print to stdout so as not to worry about logging across packages. Should solve this better long-term, but for now we need to debug