### PR TITLE
Fix Python CI installs

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -36,12 +36,13 @@ jobs:
           src: .
       - name: Install dependencies
         run: |
-          pip install -e benchadapt/python --no-deps && \
-            pip install \
+          pip install --no-deps \
+            -e benchadapt/python \
+            -e benchrun/python && \
+          pip install \
             -U --upgrade-strategy eager \
             -e .[dev] \
-              -e benchclients/python \
-              -e benchrun/python
+            -e benchclients/python
       - name: Migrations
         run: |
           alembic upgrade head


### PR DESCRIPTION
Install both benchadapt and benchrun with no deps since they both only depend on packages in this repo