### PR TITLE
urlize some things

### DIFF
--- a/conbench/templates/benchmark-entity.html
+++ b/conbench/templates/benchmark-entity.html
@@ -74,7 +74,8 @@
       <li class="list-group-item" style="overflow-y: auto;">
         <b>{{ k }}</b>
         <br> <br />
-        <div align="left" style="display:inline-block; white-space: pre; float: center;">{{ v }}</div>
+        <div align="left" style="display:inline-block; white-space: pre; float: center;">{{ v | urlize(target="_blank")
+          }}</div>
       </li>
       {% endfor %}
       {% endif %}
@@ -111,7 +112,7 @@
       <li class="list-group-item" style="overflow-y: auto;">
         <b>{{ k }}</b>
         {% if v is not none %}
-        <div align="right" style="display:inline-block; float: right;">{{ v }}</div>
+        <div align="right" style="display:inline-block; float: right;">{{ v | urlize(target="_blank") }}</div>
         {% endif %}
       </li>
       {% endfor %}
@@ -202,7 +203,7 @@
       {% for k,v in benchmark.info.items() %}
       <li class="list-group-item" style="overflow-y: auto;">
         <b>{{ k }}</b>
-        <div align="right" style="display:inline-block; float: right;">{{ v }}</div>
+        <div align="right" style="display:inline-block; float: right;">{{ v | urlize(target="_blank") }}</div>
       </li>
       {% endfor %}
       {% endif %}

--- a/conbench/tests/populate_local_conbench.py
+++ b/conbench/tests/populate_local_conbench.py
@@ -71,6 +71,7 @@ def generate_benchmarks_data(
 
     data["optional_benchmark_info"] = {
         "log uri": "s3://some/log",
+        "log url": "https://some/log",
         "trace uri": "s3://some/trace",
     }
 


### PR DESCRIPTION
Resolves #426 

Adds Jinja's `urlize` to some of our free-form fields so that things like https://foo.bar are auto-linked:

<img width="570" alt="image" src="https://user-images.githubusercontent.com/700357/200386779-301e3eab-8218-460b-8aae-9584b80f032f.png">
