### PR TITLE
Ceilinged SQLAlchemy < 2

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -22,7 +22,13 @@ from conbench.entities import (  # noqa  # isort:skip
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
-sqlalchemy_url = str(engine.url) if engine else Config.SQLALCHEMY_DATABASE_URI
+
+if engine:
+    sqlalchemy_url = engine.url.render_as_string(hide_password=False)
+else:
+    sqlalchemy_url = Config.SQLALCHEMY_DATABASE_URI
+
+
 config.set_main_option("sqlalchemy.url", sqlalchemy_url)
 
 

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -23,4 +23,4 @@ pytest>=7.0.0
 python-dotenv
 PyYAML
 requests
-SQLAlchemy
+SQLAlchemy<2


### PR DESCRIPTION
As we saw in https://github.com/voltrondata-labs/arrow-benchmarks-ci/pull/88 , SQLAlchemy 2.0 is coming out soon, and this repo has at least one thing that will break.

I tried running tests locally with `2.0.0b3`, and got a lot of errors. I'll create an issue to officially migrate and fix those errors, but in the meantime let's ceiling to 2.0 so that we won't be surprised with a breaking change.