### PR TITLE
app config: introduce INTENDED_BASE_URL, use for api docs

### DIFF
--- a/conbench/api/_docs.py
+++ b/conbench/api/_docs.py
@@ -13,7 +13,7 @@ spec = apispec.APISpec(
         apispec_webframeworks.flask.FlaskPlugin(),
         apispec.ext.marshmallow.MarshmallowPlugin(),
     ],
-    servers=[{"url": "http://localhost:5000/"}],
+    servers=[{"url": Config.INTENDED_BASE_URL}],
 )
 
 

--- a/conbench/config.py
+++ b/conbench/config.py
@@ -25,6 +25,27 @@ class Config:
     # to recalculate history.
     DISTRIBUTION_COMMITS = int(os.environ.get("DISTRIBUTION_COMMITS", 100))
 
+    # The base URL (scheme, DNS name, path prefix) that regular HTTP clients
+    # are expected to use for reaching the HTTP server exposing the app.
+    # Depends on the deployment and cannot generally be determined by the app
+    # itself (requires human input). The default value is tailored to the Flask
+    # development HTTP server defaults (non-TLS, binds on 127.0.0.1, port
+    # 5000). Can be adjusted via the `--host` and `--port` command line flags
+    # when invoking `flask run`. Three interesting scenarios:
+    # - local dev setup with default listen address: no action needed
+    # - local dev setup with custom listen address: user should set meaningful
+    #   value
+    # - prod/staging setup: user should set meaningful value such as for
+    #   example https://conbench.ursa.dev/
+    #
+    # Currently used for populating the 'Servers' dropdown in the
+    # Swagger/OpenAPI docs website.
+    INTENDED_BASE_URL = os.environ.get(
+        "CONBENCH_INTENDED_BASE_URL", "http://127.0.0.1:5000/"
+    )
+    # Require trailing slash towards tidy URL generation.
+    assert INTENDED_BASE_URL.endswith("/"), "INTENDED_BASE_URL must have trailing slash"
+
 
 class TestConfig(Config):
     DB_NAME = os.environ.get("DB_NAME", f"{APPLICATION_NAME.lower()}_test")

--- a/conbench/config.py
+++ b/conbench/config.py
@@ -44,7 +44,10 @@ class Config:
         "CONBENCH_INTENDED_BASE_URL", "http://127.0.0.1:5000/"
     )
     # Require trailing slash towards tidy URL generation.
-    assert INTENDED_BASE_URL.endswith("/"), "INTENDED_BASE_URL must have trailing slash"
+    # Note: might want to catch bad input via e.g.
+    # https://validators.readthedocs.io/en/latest/#module-validators.url
+    if not INTENDED_BASE_URL.endswith("/"):
+        INTENDED_BASE_URL += "/"
 
 
 class TestConfig(Config):

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -1824,7 +1824,7 @@
             },
         },
     },
-    "servers": [{"url": "http://localhost:5000/"}],
+    "servers": [{"url": "http://127.0.0.1:5000/"}],
     "tags": [
         {"name": "Authentication"},
         {"description": "List of endpoints", "name": "Index"},


### PR DESCRIPTION
This change is motivated by #393. See commit message for details!

Tested this locally. A few screenshots:

![Screenshot from 2022-11-16 10-51-37](https://user-images.githubusercontent.com/265630/202170390-9f810d54-4632-4a0c-abf0-092fb441bbfe.png)

'Try it out' feature now works against default dev server (HTTP request was handled by app):
![Screenshot from 2022-11-16 10-51-59](https://user-images.githubusercontent.com/265630/202170726-331941ea-24ce-4c26-a882-4893cd1fedaf.png)

This is to show the failure with `localhost` (w/o patch):
![Screenshot from 2022-11-16 10-52-35](https://user-images.githubusercontent.com/265630/202170538-6c7f36a0-ac24-485e-b67f-da4e53497fc9.png)

Review appreciated :)

