### PR TITLE
truncate posted github messages so they fit

### DIFF
--- a/conbench/entities/commit.py
+++ b/conbench/entities/commit.py
@@ -403,7 +403,7 @@ class GitHub:
         return {
             "parent": commit["parents"][0]["sha"] if commit["parents"] else None,
             "date": dateutil.parser.isoparse(commit_author["date"]),
-            "message": commit["commit"]["message"].split("\n")[0],
+            "message": commit["commit"]["message"].split("\n")[0][:240],
             "author_name": commit_author["name"],
             "author_login": author["login"] if author else None,
             "author_avatar": author["avatar_url"] if author else None,

--- a/conbench/entities/commit.py
+++ b/conbench/entities/commit.py
@@ -231,7 +231,7 @@ def backfill_default_branch_commits(
         try:
             commit = Commit.create_github_context(**commit_info)
             backfilled_commits.append(commit)
-        except s.exc.IntegrityError as e:
+        except Exception as e:
             if "commit_index" in str(e):
                 print(f"Commit {commit_info['sha']} already existed in the database")
             else:

--- a/conbench/tests/entities/test_commit.py
+++ b/conbench/tests/entities/test_commit.py
@@ -66,6 +66,11 @@ def test_get_github_commit_none():
 )
 def test_get_github_commit_and_fork_point_sha(branch):
     # NOTE: This integration test intentionally hits GitHub.
+    if os.getenv("BUILDKITE"):
+        pytest.skip(
+            "Buildkite doesn't have a GITHUB_API_TOKEN so we won't hit the GitHub API"
+        )
+
     repo = "https://github.com/apache/arrow"
     sha = "3decc46119d583df56c7c66c77cf2803441c4458"
     tz = dateutil.tz.tzutc()
@@ -96,6 +101,11 @@ def test_get_github_commit_and_fork_point_sha(branch):
 )
 def test_get_github_commit_and_fork_point_sha_pull_request(branch, pr_number):
     # NOTE: This integration test intentionally hits GitHub.
+    if os.getenv("BUILDKITE"):
+        pytest.skip(
+            "Buildkite doesn't have a GITHUB_API_TOKEN so we won't hit the GitHub API"
+        )
+
     repo = "https://github.com/apache/arrow"
     sha = "982023150ccbb06a6f581f6797c017492485b58c"
     tz = dateutil.tz.tzutc()
@@ -116,6 +126,11 @@ def test_get_github_commit_and_fork_point_sha_pull_request(branch, pr_number):
 
 def test_backfill_default_branch_commits():
     # NOTE: This integration test intentionally hits GitHub.
+    if os.getenv("BUILDKITE"):
+        pytest.skip(
+            "Buildkite doesn't have a GITHUB_API_TOKEN so we won't hit the GitHub API"
+        )
+
     repository = "https://github.com/conbench/conbench"
     default_branch = "conbench:main"
     author = "Austin Dickey"

--- a/conbench/tests/entities/test_commit.py
+++ b/conbench/tests/entities/test_commit.py
@@ -256,6 +256,11 @@ def test_parse_commit():
     }
     assert GitHub._parse_commit(commit) == expected
 
+    # test a long message
+    commit["commit"]["message"] = "a" * 500
+    expected["message"] = "a" * 240
+    assert GitHub._parse_commit(commit) == expected
+
 
 def test_parse_commit_no_author():
     path = os.path.join(this_dir, "github_commit_no_author.json")

--- a/migrations/versions/d3515ecea53d_backfill_all_commits.py
+++ b/migrations/versions/d3515ecea53d_backfill_all_commits.py
@@ -86,8 +86,8 @@ def upgrade():
                         repository=repo,
                         parent=commit_info["github"]["parent"],
                         timestamp=commit_info["github"]["date"],
-                        message=commit_info["github"]["message"],
-                        author_name=commit_info["github"]["author_name"],
+                        message=commit_info["github"]["message"][:240],
+                        author_name=commit_info["github"]["author_name"][:90],
                         author_login=commit_info["github"]["author_login"],
                         author_avatar=commit_info["github"]["author_avatar"],
                     )

--- a/migrations/versions/d3515ecea53d_backfill_all_commits.py
+++ b/migrations/versions/d3515ecea53d_backfill_all_commits.py
@@ -77,17 +77,6 @@ def upgrade():
             else:
                 # insert this commit into the db
                 print(f"Inserting sha {sha[:7]} into the db")
-                message = commit_info["github"]["message"]
-                author_name = commit_info["github"]["author_name"]
-                try:
-                    message = message[:240]
-                except:
-                    pass
-                try:
-                    author_name = author_name[:90]
-                except:
-                    pass
-
                 connection.execute(
                     commit_table.insert().values(
                         id=uuid.uuid4().hex,
@@ -97,8 +86,8 @@ def upgrade():
                         repository=repo,
                         parent=commit_info["github"]["parent"],
                         timestamp=commit_info["github"]["date"],
-                        message=message,
-                        author_name=author_name,
+                        message=commit_info["github"]["message"],
+                        author_name=commit_info["github"]["author_name"],
                         author_login=commit_info["github"]["author_login"],
                         author_avatar=commit_info["github"]["author_avatar"],
                     )

--- a/migrations/versions/d3515ecea53d_backfill_all_commits.py
+++ b/migrations/versions/d3515ecea53d_backfill_all_commits.py
@@ -77,6 +77,17 @@ def upgrade():
             else:
                 # insert this commit into the db
                 print(f"Inserting sha {sha[:7]} into the db")
+                message = commit_info["github"]["message"]
+                author_name = commit_info["github"]["author_name"]
+                try:
+                    message = message[:240]
+                except:
+                    pass
+                try:
+                    author_name = author_name[:90]
+                except:
+                    pass
+
                 connection.execute(
                     commit_table.insert().values(
                         id=uuid.uuid4().hex,
@@ -86,8 +97,8 @@ def upgrade():
                         repository=repo,
                         parent=commit_info["github"]["parent"],
                         timestamp=commit_info["github"]["date"],
-                        message=commit_info["github"]["message"][:240],
-                        author_name=commit_info["github"]["author_name"][:90],
+                        message=message,
+                        author_name=author_name,
                         author_login=commit_info["github"]["author_login"],
                         author_avatar=commit_info["github"]["author_avatar"],
                     )


### PR DESCRIPTION
This PR truncates the github message in `d3515ecea53d_backfill_all_commits.py` so it always fits in the database.