### PR TITLE
Allow all robots so we can fix incorrect Google search results for conbench

### DIFF
--- a/conbench/app/robots.py
+++ b/conbench/app/robots.py
@@ -5,7 +5,7 @@ from ..app._endpoint import AppEndpoint
 
 text = """
 User-Agent: *
-Disallow: /
+Allow: /
 """
 
 

--- a/conbench/tests/app/test_robots.py
+++ b/conbench/tests/app/test_robots.py
@@ -1,6 +1,6 @@
 expected_text = """
 User-Agent: *
-Disallow: /
+Allow: /
 """
 
 


### PR DESCRIPTION
Googling `conbench` returns this:

![image](https://user-images.githubusercontent.com/5522472/203132850-2a66bc1e-0312-4ba9-9d58-1511eb7d087c.png)

I disallowed robots about a year ago because they were causing all sorts of load on public conbench.
I am allowing robots again to see if this will fix an issue with google results showing broken link