### PR TITLE
Skip GH API tests inside buildkite

### DIFF
--- a/.buildkite/conbench-test/pipeline.yml
+++ b/.buildkite/conbench-test/pipeline.yml
@@ -8,7 +8,7 @@ steps:
   - label: "Test"
     key: "test"
     depends_on: "build"
-    command: docker-compose run app pytest -vv conbench/tests/
+    command: docker-compose run -e BUILDKITE=true app pytest -vv conbench/tests/
 
   - label: "Test Migrations"
     key: "test-migrations"


### PR DESCRIPTION
We have a small handful of tests that purposely hit the GitHub API. These work fine in GitHub Actions, because that runner has access to a GITHUB_API_TOKEN, but in Buildkite we're [sometimes](https://buildkite.com/apache-arrow/conbench-test/builds/285#01849b8a-2885-4b64-a22f-bef600ed89dc/85-444) hitting the unauthenticated rate limit.

https://github.com/conbench/conbench/blob/3b543cdc7daa7ecfb19cfa6bb44c6c44bf8ff15f/conbench/tests/entities/test_commit.py#L69-L72

This `skip()` command wasn't working because the Buildkite tests are run using `docker-compose`, and the environment variable wasn't being passed through. This PR passes it through.