### PR TITLE
Always upsert commits with github info

### DIFF
--- a/conbench/entities/_entity.py
+++ b/conbench/entities/_entity.py
@@ -1,9 +1,10 @@
 import functools
 import uuid
+from typing import List
 
 import flask as f
 from sqlalchemy import Column, distinct
-from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -93,13 +94,11 @@ class EntityMixin:
         return entity
 
     @classmethod
-    def upsert_do_nothing(cls, data):
-        """Try to insert a row. If there is a conflict, do nothing."""
-        statement = insert(cls).values([data]).on_conflict_do_nothing()
+    def upsert_do_nothing(cls, row_list: List[dict]):
+        """Try to insert rows. If there is a conflict on any row, ignore that row."""
+        statement = postgresql_insert(cls).values(row_list).on_conflict_do_nothing()
         Session.execute(statement)
         Session.commit()
-        # return the row that (now) exists in the database
-        return cls.first(**data)
 
     @classmethod
     def bulk_save_objects(self, bulk):

--- a/conbench/entities/_entity.py
+++ b/conbench/entities/_entity.py
@@ -3,6 +3,7 @@ import uuid
 
 import flask as f
 from sqlalchemy import Column, distinct
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -90,6 +91,15 @@ class EntityMixin:
         entity = cls(**data)
         entity.save()
         return entity
+
+    @classmethod
+    def upsert_do_nothing(cls, data):
+        """Try to insert a row. If there is a conflict, do nothing."""
+        statement = insert(cls).values([data]).on_conflict_do_nothing()
+        Session.execute(statement)
+        Session.commit()
+        # return the row that (now) exists in the database
+        return cls.first(**data)
 
     @classmethod
     def bulk_save_objects(self, bulk):

--- a/conbench/entities/commit.py
+++ b/conbench/entities/commit.py
@@ -67,7 +67,7 @@ class Commit(Base, EntityMixin):
 
     @staticmethod
     def create_github_context(sha, repository: str, github: dict):
-        return Commit.create(
+        return Commit.upsert_do_nothing(
             {
                 "sha": sha,
                 "branch": github["branch"],
@@ -228,14 +228,9 @@ def backfill_default_branch_commits(
     for commit_info in commits_to_try:
         commit_info["github"]["branch"] = default_branch
         commit_info["github"]["fork_point_sha"] = commit_info["sha"]
-        try:
-            commit = Commit.create_github_context(**commit_info)
+        commit = Commit.create_github_context(**commit_info)
+        if commit:
             backfilled_commits.append(commit)
-        except Exception as e:
-            if "commit_index" in str(e):
-                print(f"Commit {commit_info['sha']} already existed in the database")
-            else:
-                raise
 
     return backfilled_commits
 

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -65,7 +65,12 @@ class Run(Base, EntityMixin):
             )
             if github:
                 commit = Commit.create_github_context(sha, repository, github)
-                backfill_default_branch_commits(repository, commit)
+                try:
+                    backfill_default_branch_commits(repository, commit)
+                except Exception as e:
+                    # no matter what happened during backfilling, we want to return a
+                    # successful status code because the commit was created
+                    print(f"Could not backfill default branch commits due to: {e}")
             elif sha or repository:
                 commit = Commit.create_unknown_context(sha, repository)
             else:

--- a/conbench/tests/entities/test_commit.py
+++ b/conbench/tests/entities/test_commit.py
@@ -18,6 +18,30 @@ from ...tests.api import _fixtures
 this_dir = os.path.abspath(os.path.dirname(__file__))
 
 
+def test_create_github_context():
+    """Upserting should work correctly."""
+    fake_github_info = {
+        "branch": "branch",
+        "fork_point_sha": "fork_point_sha",
+        "parent": "parent",
+        "date": datetime.datetime(2022, 11, 21),
+        "message": "message",
+        "author_name": "author_name",
+        "author_login": "author_login",
+        "author_avatar": "author_avatar",
+    }
+
+    commit = Commit.create_github_context(
+        sha="sha", repository="repository", github=fake_github_info
+    )
+    assert commit.id
+
+    commit_2 = Commit.create_github_context(
+        sha="sha", repository="repository", github=fake_github_info
+    )
+    assert commit == commit_2
+
+
 def test_repository_to_name():
     expected = "apache/arrow"
     assert repository_to_name(None) == ""


### PR DESCRIPTION
Fixes #441. See discussion there.

This PR changes `Commit.create_github_context()` to use an upsert instead of an insert, so there's no chance of the unique constraint on (repository, sha) causing a database transaction rollback. Before this PR, when `Commit.create_github_context()` was used in `backfill_default_branch_commits()`, it was wrapped in a try/except, but the rollbacks could still affect other pending operations on the server.

This PR also wraps the usage of `backfill_default_branch_commits()` inside of `Run.create()` in a try/except, because as discussed, we shouldn't return a 500 if the run was created but commits weren't backfilled.

After this PR, we shouldn't see any 500s due to commit backfills anymore.