### PR TITLE
db create_all: apply retrying strategy for test env

### DIFF
--- a/conbench/db.py
+++ b/conbench/db.py
@@ -1,12 +1,9 @@
 import logging
 
-
 import sqlalchemy.exc
+import tenacity
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
-
-import tenacity
-
 
 engine = None
 session_maker = sessionmaker(future=True)

--- a/conbench/db.py
+++ b/conbench/db.py
@@ -1,9 +1,19 @@
+import logging
+
+
+import sqlalchemy.exc
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
+
+import tenacity
+
 
 engine = None
 session_maker = sessionmaker(future=True)
 Session = scoped_session(session_maker)
+
+
+log = logging.getLogger(__name__)
 
 
 def configure_engine(url):
@@ -19,6 +29,27 @@ def configure_engine(url):
     session_maker.configure(bind=engine)
 
 
+def log_after_retry_attempt(retry_state: tenacity.RetryCallState):
+    log.info(
+        "result after attempt %s for %s: %s",
+        retry_state.attempt_number,
+        str(retry_state.fn),
+        str(retry_state.outcome.exception()),
+    )
+
+
+# `create_all()` below can fail with an `OperationalError` when the database
+# isn't yet reachable. Can happen when web app and database are launched at
+# about the same time (likely to happen only in dev environment). Apply a
+# retrying strategy.
+@tenacity.retry(
+    retry=tenacity.retry_if_exception_type(sqlalchemy.exc.OperationalError),
+    stop=tenacity.stop_after_attempt(10),
+    wait=tenacity.wait_fixed(1),
+    before=tenacity.before_log(log, logging.DEBUG),
+    after=log_after_retry_attempt,
+    reraise=True,
+)
 def create_all():
     from .entities._entity import Base
 

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -23,4 +23,5 @@ pytest>=7.0.0
 python-dotenv
 PyYAML
 requests
+tenacity
 SQLAlchemy<2


### PR DESCRIPTION
As described in https://github.com/conbench/conbench/issues/449 the docker-compose-managed 'readiness' checks are difficult to see through. Currently I run tests locally via

```
docker-compose down && \
   docker-compose build app && \
   docker-compose run app pytest -k TestXXXX -s conbench/tests
```

Rarely, that results in Postgres not yet accepting connections when the first `create_all()` is issued, resulting in a `sqlalchemy.exc.OperationalError` crashing the test suite.

Instead of figuring out how to make the container startup order/timing more robust in the context of docker-compose, I am embracing the principle where we try to auto-heal transient issues pragmatically, in the spirit of [this](https://stackoverflow.com/a/47714157).

https://github.com/jd/tenacity is the successor of https://github.com/rholder/retrying.

Example for log msgs when auto-healing this worked, with the DEBUG log level:
```
[221123-13:13:01.785] [1] [conbench.db] DEBUG: Starting call to 'conbench.db.create_all', this is the 1st time calling it.
[221123-13:13:01.786] [1] [conbench.db] INFO: result after attempt 1 for <function create_all at 0x7f2b94df0af0>: (psycopg2.OperationalError) connection to server at "db" (172.29.0.3), port 5432 failed: Connection refused
	Is the server running on that host and accepting TCP/IP connections?

(Background on this error at: https://sqlalche.me/e/14/e3q8)
[221123-13:13:02.787] [1] [conbench.db] DEBUG: Starting call to 'conbench.db.create_all', this is the 2nd time calling it.
```