### PR TITLE
config: introduce CONBENCH_OIDC_ISSUER_URL, oidc code cleanup

### DIFF
--- a/conbench/api/_google.py
+++ b/conbench/api/_google.py
@@ -1,44 +1,72 @@
 import json
+import logging
 import os
+import time
 
 import flask as f
 import requests
 
+from ..config import Config
 
-def get_google_config():
+log = logging.getLogger(__name__)
+
+# Rely on INTENDED_BASE_URL to have a trailing slash.
+OIDC_CALLBACK_URL = Config.INTENDED_BASE_URL + "api/google/callback"
+
+
+def get_oidc_config():
     client_id = os.environ.get("GOOGLE_CLIENT_ID", None)
     client_secret = os.environ.get("GOOGLE_CLIENT_SECRET", None)
-    discovery_url = "https://accounts.google.com/.well-known/openid-configuration"
+    discovery_url = Config.OIDC_ISSUER_URL + "/.well-known/openid-configuration"
     return discovery_url, client_id, client_secret
 
 
-def get_google_client():
+def get_oidc_client():
     from oauthlib.oauth2 import WebApplicationClient
 
-    discovery_url, client_id, _ = get_google_config()
-    google = requests.get(discovery_url).json()
+    discovery_url, client_id, _ = get_oidc_config()
+
+    # Pragmatic healing for transient errors. Better: cache OP config across
+    # login requests. Also, if we want to retry here in the future: consider
+    # using tenacity.
+    for attempt in range(4):
+        try:
+            oidc_provider_config = requests.get(discovery_url).json()
+            break
+        except requests.exceptions.RequestException as exc:
+            log.info("err getting OP config (attempt %s): %s -- retry", attempt, exc)
+            time.sleep(2)
+
     client = WebApplicationClient(client_id)
-    return client, google
+    return client, oidc_provider_config
 
 
 def auth_google_user():
-    client, google = get_google_client()
-    redirect_uri = f.url_for("api.callback", _external=True, _scheme="https")
+    client, oidc_provider_config = get_oidc_client()
+
+    # http://127.0.0.1:5000/api/google/callback
+    # redirect_uri = f.url_for("api.callback", _external=True, _scheme="https")
+
+    # If either redirect URL or the authorization endpoint (at the OP) do not
+    # use the HTTPS scheme then the function below is expected to throw
+    # `InsecureTransportError`. For testing, this can be changed by setting
+    # the environment variable OAUTHLIB_INSECURE_TRANSPORT.
+
     return client.prepare_request_uri(
-        google["authorization_endpoint"],
-        redirect_uri=redirect_uri,
+        oidc_provider_config["authorization_endpoint"],
+        redirect_uri=OIDC_CALLBACK_URL,
         scope=["openid", "email", "profile"],
     )
 
 
 def get_google_user():
-    client, google = get_google_client()
-    _, client_id, client_secret = get_google_config()
+    client, oidc_provider_config = get_oidc_client()
+    _, client_id, client_secret = get_oidc_config()
 
     token_url, headers, body = client.prepare_token_request(
-        google["token_endpoint"],
-        authorization_response=f.request.url.replace("http://", "https://"),
-        redirect_url=f.request.base_url.replace("http://", "https://"),
+        oidc_provider_config["token_endpoint"],
+        authorization_response=f.request.url,  # .replace("http://", "https://"),
+        redirect_url=f.request.base_url,  # replace("http://", "https://"),
         code=f.request.args.get("code"),
     )
     token_response = requests.post(
@@ -49,7 +77,7 @@ def get_google_user():
     )
     client.parse_request_body_response(json.dumps(token_response.json()))
 
-    uri, headers, body = client.add_token(google["userinfo_endpoint"])
+    uri, headers, body = client.add_token(oidc_provider_config["userinfo_endpoint"])
     return requests.get(
         uri,
         headers=headers,

--- a/conbench/api/auth.py
+++ b/conbench/api/auth.py
@@ -92,7 +92,9 @@ class CallbackAPI(ApiEndpoint):
         try:
             google_user = _google.get_google_user()
         except Exception as e:
-            self.abort_400_bad_request(f"OpenID Connect single sign-on flow failed: {e}.")
+            self.abort_400_bad_request(
+                f"OpenID Connect single sign-on flow failed: {e}."
+            )
 
         email = google_user["email"]
         given = google_user["given_name"]

--- a/conbench/api/auth.py
+++ b/conbench/api/auth.py
@@ -92,7 +92,7 @@ class CallbackAPI(ApiEndpoint):
         try:
             google_user = _google.get_google_user()
         except Exception as e:
-            self.abort_400_bad_request(f"Google SSO failed {e}.")
+            self.abort_400_bad_request(f"OpenID Connect single sign-on flow failed: {e}.")
 
         email = google_user["email"]
         given = google_user["given_name"]

--- a/conbench/config.py
+++ b/conbench/config.py
@@ -53,6 +53,22 @@ class Config:
     LOG_LEVEL_FILE = None
     LOG_LEVEL_SQLALCHEMY = "WARNING"
 
+    # If `OIDC_ISSUER_URL` is after all `None`: disable OpenID Connect (OIDC)
+    # single sign-on. If this is not `None` then it must be a valid OIDC issuer
+    # notation (that is, a URL).
+    OIDC_ISSUER_URL = os.environ.get("CONBENCH_OIDC_ISSUER_URL", None)
+    if OIDC_ISSUER_URL is not None:
+        assert OIDC_ISSUER_URL.startswith("http")
+        # Remove all trailing slashes.
+        OIDC_ISSUER_URL = OIDC_ISSUER_URL.rstrip("/")
+    else:
+        # legacy config support: when CONBENCH_OIDC_ISSUER_URL is set in the
+        # environment it takes precedence. If it is not set and if
+        # GOOGLE_CLIENT_ID is set in the environment then set issuer to
+        # "https://accounts.google.com"
+        if "GOOGLE_CLIENT_ID" in os.environ:
+            OIDC_ISSUER_URL = "https://accounts.google.com"
+
 
 class TestConfig(Config):
     DB_NAME = os.environ.get("DB_NAME", f"{APPLICATION_NAME.lower()}_test")


### PR DESCRIPTION
What we did so far with "Google SSO" was actually a standards-compliant OpenID Connect (OIDC) single sign-on flow. That's cool.

OIDC is a standard on top of OAuth2. There's a plethora of identity providers (Saas, etc) that can serve as an OIDC provider.

An OIDC provider is identified by its issuer URL, or just the issuer. In case of Google, the issuer is `https://accounts.google.com`

So -- an OpenID Connect (OIDC) issuer URL precisely identifies an OIDC identity provider. Make this configurable, for testing and more flexible deployments.

This PR tries to explicitly support the legacy/current config scenario where the environment shows a `GOOGLE_CLIENT_ID` (and secret) -- which has so far implied that in the corresponding deployment we want to use `https://accounts.google.com` as issuer. 

This PR also touches on a few variable names etc to make the code less gooogly and more openidy, and to help towards better readability.




