### PR TITLE
tests: cover oidc flow against dex

### DIFF
--- a/.buildkite/conbench-test/pipeline.yml
+++ b/.buildkite/conbench-test/pipeline.yml
@@ -8,7 +8,7 @@ steps:
   - label: "Test"
     key: "test"
     depends_on: "build"
-    command: docker-compose run -e BUILDKITE=true app pytest -vv conbench/tests/
+    command: docker-compose run -e BUILDKITE=true app pytest -vv -s conbench/tests/
 
   - label: "Test Migrations"
     key: "test-migrations"

--- a/conbench/api/_google.py
+++ b/conbench/api/_google.py
@@ -61,7 +61,7 @@ def auth_google_user():
     be found at
     https://github.com/conbench/conbench/pull/454#issuecomment-1326338524
 
-    Technically, a more controlled and precitable way to construct the callback
+    Technically, a more controlled and predictable way to construct the callback
     URL would be using Config.INTENDED_BASE_URL. However, as long as that
     configuration parameter is not required to be set to a meaningful value we
     should not rely on that yet (breaks compatibility with old deployment

--- a/conbench/api/_google.py
+++ b/conbench/api/_google.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 import time
 
 import flask as f

--- a/conbench/api/_google.py
+++ b/conbench/api/_google.py
@@ -12,10 +12,10 @@ log = logging.getLogger(__name__)
 
 
 def get_oidc_config():
-    client_id = os.environ.get("GOOGLE_CLIENT_ID", None)
-    client_secret = os.environ.get("GOOGLE_CLIENT_SECRET", None)
+    # Rely on three config parameters to be set in a meaningful way:
+    # Config.OIDC_ISSUER_URL, Config.OIDC_CLIENT_ID,Config.OIDC_CLIENT_SECRET
     discovery_url = Config.OIDC_ISSUER_URL + "/.well-known/openid-configuration"
-    return discovery_url, client_id, client_secret
+    return discovery_url, Config.OIDC_CLIENT_ID, Config.OIDC_CLIENT_SECRET
 
 
 def get_oidc_client():

--- a/conbench/api/auth.py
+++ b/conbench/api/auth.py
@@ -97,8 +97,8 @@ class CallbackAPI(ApiEndpoint):
             )
 
         email = google_user["email"]
-        given = google_user["given_name"]
-        family = google_user["family_name"]
+        given = google_user.get("given_name", "")
+        family = google_user.get("family_name", "")
         user = User.first(email=email)
         if user is None:
             data = {

--- a/conbench/config.py
+++ b/conbench/config.py
@@ -81,6 +81,7 @@ class Config:
         assert OIDC_CLIENT_ID is not None
         assert OIDC_CLIENT_SECRET is not None
 
+
 class TestConfig(Config):
     DB_NAME = os.environ.get("DB_NAME", f"{APPLICATION_NAME.lower()}_test")
     SQLALCHEMY_DATABASE_URI = (

--- a/conbench/config.py
+++ b/conbench/config.py
@@ -69,6 +69,17 @@ class Config:
         if "GOOGLE_CLIENT_ID" in os.environ:
             OIDC_ISSUER_URL = "https://accounts.google.com"
 
+    # Note that GOOGLE_CLIENT_ID/GOOGLE_CLIENT_SECRET are the legacy env vars
+    # previously used for enabling OIDC SSO. Keep using these env vars for now.
+    OIDC_CLIENT_ID = os.environ.get("GOOGLE_CLIENT_ID", None)
+    OIDC_CLIENT_SECRET = os.environ.get("GOOGLE_CLIENT_SECRET", None)
+
+    # Require client ID and client secret to be set if issuer is configured.
+    # Those three parameters are all required for an OIDC authorization code
+    # flow.
+    if OIDC_ISSUER_URL is not None:
+        assert OIDC_CLIENT_ID is not None
+        assert OIDC_CLIENT_SECRET is not None
 
 class TestConfig(Config):
     DB_NAME = os.environ.get("DB_NAME", f"{APPLICATION_NAME.lower()}_test")

--- a/conbench/tests/app/test_auth.py
+++ b/conbench/tests/app/test_auth.py
@@ -146,11 +146,19 @@ class TestLoginOIDC(_asserts.AppEndpointTest):
 
     def test_oidc_flow_against_dex(self, client):
 
-        # r = client.get("/login/", follow_redirects=True)
-        # TODO: parse this from the HTML doc
-        # initiate_flow_url = "http://127.0.0.1:5000/api/google/"
-        # follow_redirects=True)
-        r0 = client.get("/api/google/")
+        # TODO: parse this 'initiate flow URL' from the HTML login page, i.e.
+        # from the button/ link that people would actually click. If that is a
+        # _relative_ href then construct an absolute URL from it (see below).
+
+        # As long as `client` is the Flask test client we do not use an actual
+        # HTTP client/server interaction. The URL here must be specified in
+        # absolute terms because the request handler uses scheme, host, port to
+        # dynamically generate the OIDC callback URL. We could set any scheme
+        # and host, but we want to match the allow-listed callback URL that Dex
+        # is aware of. That is is currently set to
+        # http://127.0.0.1:5000/api/google/callback -- see
+        # containders/dex/config.yml
+        r0 = client.get("http://127.0.0.1:5000/api/google/")
 
         # `r0` is meant to be a redirect response, redirecting to the identity
         # provider. Extract the full URL we've been redirected to. The URL

--- a/conbench/tests/app/test_auth.py
+++ b/conbench/tests/app/test_auth.py
@@ -1,5 +1,5 @@
 import logging
-from urllib.parse import urljoin, parse_qs
+from urllib.parse import parse_qs, urljoin
 
 import requests
 from bs4 import BeautifulSoup

--- a/conbench/tests/app/test_auth.py
+++ b/conbench/tests/app/test_auth.py
@@ -1,5 +1,5 @@
 import logging
-from urllib.parse import urljoin
+from urllib.parse import urljoin, parse_qs
 
 import requests
 from bs4 import BeautifulSoup
@@ -143,6 +143,27 @@ class TestLoginOIDC(_asserts.AppEndpointTest):
     def test_login_page_shows_sso_link(self, client):
         r = client.get("/login/", follow_redirects=True)
         assert "Google Login" in r.text
+
+    def test_dynamic_callback_url(self, client):
+        """This test is mainly for demonstration purposes how the dynamic
+        OIDC callback URL construction works. One important bit that it covers
+        though is that all three parts of the base url are dynamically
+        constructed: scheme, host, port.
+
+        OIDC callback URL construction does not need to stay dynamic. If we
+        decide to make it static (based on INTENDED_BASE_URL) then this test
+        here can be removed.
+        """
+        r0 = client.get("http://foobar:7000/api/google/")
+        authorization_request_url = r0.headers["location"]
+        data = parse_qs(authorization_request_url)
+        assert "redirect_uri" in data
+        assert "foobar:7000" in data["redirect_uri"][0]
+
+        # Now check that scheme is dynamic, too.
+        data = parse_qs(client.get("https://foo/api/google/").headers["location"])
+        assert "redirect_uri" in data
+        assert "https://foo" in data["redirect_uri"][0]
 
     def test_oidc_flow_against_dex(self, client):
 

--- a/conbench/tests/app/test_auth.py
+++ b/conbench/tests/app/test_auth.py
@@ -166,7 +166,7 @@ class TestLoginOIDC(_asserts.AppEndpointTest):
         # we expect it to send a login page in the response. That login
         # page shows an email/password login form. Extract form submission
         # endpoint URL from login page. It's a relative URL.
-        assert r1.status_code == 200
+        assert r1.status_code == 200, f"bad response: {r1.text}"
         rel_login_post_url = parse_login_page(r1.text)
         log.info("rel_login_post_url: %s", rel_login_post_url)
 

--- a/conbench/tests/app/test_auth.py
+++ b/conbench/tests/app/test_auth.py
@@ -1,5 +1,13 @@
+import logging
+from urllib.parse import urljoin
+
+import requests
+from bs4 import BeautifulSoup
+
 from ...config import TestConfig
 from ...tests.app import _asserts
+
+log = logging.getLogger(__name__)
 
 
 class TestRegister(_asserts.AppEndpointTest):
@@ -129,3 +137,124 @@ class TestLogout(_asserts.AppEndpointTest):
         # cannot get users page after
         response = client.get("/users/", follow_redirects=True)
         self.assert_login_page(response)
+
+
+class TestLoginOIDC(_asserts.AppEndpointTest):
+    def test_login_page_shows_sso_link(self, client):
+        r = client.get("/login/", follow_redirects=True)
+        assert "Google Login" in r.text
+
+    def test_oidc_flow_against_dex(self, client):
+
+        # r = client.get("/login/", follow_redirects=True)
+        # TODO: parse this from the HTML doc
+        # initiate_flow_url = "http://127.0.0.1:5000/api/google/"
+        # follow_redirects=True)
+        r0 = client.get("/api/google/")
+
+        # `r0` is meant to be a redirect response, redirecting to the identity
+        # provider. Extract the full URL we've been redirected to. The URL
+        # represents a so-called authorization request, with all the parameters
+        # for that request being encoded in the URL query parameters
+        authorization_request_url = r0.headers["location"]
+        log.info(f"{authorization_request_url=}")
+
+        # Emit authorization request against identity provider.
+        r1 = requests.get(authorization_request_url)
+
+        # We are not yet logged in to the identity provider which is why
+        # we expect it to send a login page in the response. That login
+        # page shows an email/password login form. Extract form submission
+        # endpoint URL from login page. It's a relative URL.
+        assert r1.status_code == 200
+        rel_login_post_url = parse_login_page(r1.text)
+        log.info("rel_login_post_url: %s", rel_login_post_url)
+
+        # Construct absolute form submission endpoing URL. urljoin() will
+        # pick only scheme and DNS name from the authorization_request_url
+        # because the rel_login_post_url is expected to start with a slash.
+        login_post_url = urljoin(authorization_request_url, rel_login_post_url)
+
+        # Defined in Dex' static configuration document.
+        login_form_data = {
+            "login": "admin@example.com",
+            "password": "password",
+        }
+
+        log.info("login_post_url: %s", login_post_url)
+        log.info("login_form_data: %s", login_form_data)
+        r2 = requests.post(login_post_url, data=login_form_data)
+        log.info("response to POSTing credentials: %s", r2.status_code)
+
+        # When bad credentials are provided the response status code is
+        # still 200, with this text in the HTML doc:
+        assert "Invalid Email Address and password" not in r2.text
+
+        # `r2.text` is expected to be an HTML document containing the
+        # consent form. Parse the document and POST the form data to the
+        # same endpoint that served it.
+        consent_form_data = parse_consent_review_page(r2.text)
+
+        # Extract the full URL for the endpoint that served the consent
+        # form from the previous response.
+        consent_post_url = r2.url
+
+        log.info("consent_post_url: %s", consent_post_url)
+        log.info("consent_form_data: %s", consent_form_data)
+        log.info("post consent form")
+        r3 = requests.post(
+            consent_post_url, data=consent_form_data, allow_redirects=False
+        )
+
+        # Upon success, the response emitted by Dex redirects back to the
+        # relying party (Conbench) which (in the back-channel) communicates
+        # with the OP (Dex) and eventually emits the authentication proof
+        assert str(r3.status_code).startswith("3")
+        callback_request_url = r3.headers["location"]
+        log.info(f"{callback_request_url=}")
+
+        # In this test suite the web application is not exposed by a real HTTP
+        # server. It can only be reached with the test client `client` -- which
+        # seems to deal fine with the absolute nature of
+        # `callback_request_url`.
+        r4 = client.get(callback_request_url)
+        log.info(r4.headers)
+
+        # Confirm that the api has returned authentication proof.
+        assert "set-cookie" in r4.headers
+        assert "session" in r4.headers["set-cookie"]
+
+
+def parse_login_page(html):
+    """Parse HTML, extract all info required for form submission.
+    If the `connectors` enumeration in Dex' config.yaml is empty, then this
+    landing page presents a form. If it is not empty, then this landing page
+    requires selecting one of the connectors. Rely on no connectors being
+    defined.
+    """
+    page = BeautifulSoup(html, features="lxml")
+
+    # Dex emits just a relative POST URL in the login HTML doc.
+    rel_post_url = page.find("form")["action"]
+
+    return rel_post_url
+
+
+def parse_consent_review_page(html):
+    """Parse HTML, extract all info required for form submission.
+    Form example:
+            <form method="post">
+            <input type="hidden" name="req" value="vinfxhadooorlhxikzae"/>
+            <input type="hidden" name="approval" value="approve">
+            <button type="submit" class="dex-btn theme-btn--success">
+                <span class="dex-btn-text">Grant Access</span>
+            </button>
+            </form>
+    """
+    page = BeautifulSoup(html, features="lxml")
+    form_data = {
+        "approval": "approve",
+        "req": page.find("input", attrs={"name": "req"})["value"],
+    }
+
+    return form_data

--- a/conbench/tests/containers/dex/config.yml
+++ b/conbench/tests/containers/dex/config.yml
@@ -1,0 +1,48 @@
+# issuer: http://127.0.0.1:5556/dex-for-conbench
+# The DNS name `dex` is provided by e.g. docker-compose
+issuer: http://dex:5556/dex-for-conbench
+# will expose http://127.0.0.1:5556/dex/.well-known/openid-configuration
+
+storage:
+  type: sqlite3
+  # config:
+  #   file: /dex-conbench-tests.db
+
+web:
+  http: 0.0.0.0:5556
+  # https: 0.0.0.0:8900
+  # tlsCert: /dexcerts/server.crt
+  # tlsKey: /dexcerts/server.key
+
+# Also support the implicit flow (tested) and hybrid flows (untested)
+oauth2:
+  responseTypes: ["code", "token", "id_token"]
+
+staticClients:
+- id: conbench-test-client
+  redirectURIs:
+  - 'http://127.0.0.1:5000/api/google/callback'
+  name: 'Conbench RP, running for unit tests'
+  secret: AnotherStaticSecret
+
+enablePasswordDB: true
+
+# If this option isn't choosen users may be added through the gRPC API.
+staticPasswords:
+- email: "admin@example.com"
+  # bcrypt hash of the string "password"
+  hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+  username: "admin"
+  userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+
+- email: "user2@example.com"
+  # bcrypt hash of the string "password"
+  hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+  username: "user2"
+  userID: "08a8684b-db88-4b73-90a9-3cd1661f5467"
+
+- email: "user3@example.com"
+  # bcrypt hash of the string "password"
+  hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+  username: "user3"
+  userID: "08a8684b-db88-4b73-90a9-3cd1661f5468"

--- a/conbench/tests/containers/dex/config.yml
+++ b/conbench/tests/containers/dex/config.yml
@@ -14,7 +14,10 @@ web:
   # tlsCert: /dexcerts/server.crt
   # tlsKey: /dexcerts/server.key
 
-# Also support the implicit flow (tested) and hybrid flows (untested)
+# Technically, only `code` is needed for the so-called authorization code flow
+# where the RP fetches the ID Token from the OP via the so-called backchannel.
+# If we ever want to support the implicit flow, that's where the id_token scope
+# comes in handy.
 oauth2:
   responseTypes: ["code", "token", "id_token"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ services:
     command: ["gunicorn", "-b", "0.0.0.0:5000", "-w", "5", "conbench:application", "--access-logfile=-", "--error-logfile=-", "--preload"]
     volumes:
       - ${PWD}/_conbench-coverage-dir:/etc/conbench-coverage-dir
+    depends_on:
+      - dex
+      - db
     environment:
       APPLICATION_NAME: "Conbench"
       DB_USERNAME: "postgres"
@@ -27,9 +30,17 @@ services:
       SECRET_KEY: "Person, woman, man, camera, TV"
       # Default log level is INFO, change to DEBUG as needed.
       # CONBENCH_LOG_LEVEL_STDERR: DEBUG
-    depends_on:
-      db:
-        condition: service_healthy
+      OAUTHLIB_INSECURE_TRANSPORT: 1
+      GOOGLE_CLIENT_ID: conbench-test-client
+      GOOGLE_CLIENT_SECRET: AnotherStaticSecret
+      CONBENCH_OIDC_ISSUER_URL: http://dex:5556/dex-for-conbench
+
+  dex:
+    image: dexidp/dex:v2.35.3
+    volumes:
+      - ${PWD}/conbench/tests/containers/dex/config.yml:/etc/dex/config.docker.yaml
+    ports:
+      - "5556:5556"
 
   db:
     image: library/postgres:12.4

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -12,7 +12,6 @@ flask-swagger-ui
 Flask-WTF
 gitpython
 gunicorn
-lxml
 marshmallow
 numpy
 oauthlib

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -12,6 +12,7 @@ flask-swagger-ui
 Flask-WTF
 gitpython
 gunicorn
+lxml
 marshmallow
 numpy
 oauthlib

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,4 +4,5 @@ coverage
 coveralls
 flake8
 isort
+lxml
 pytest>=7.0.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,5 @@
 black
+bs4
 coverage
 coveralls
 flake8


### PR DESCRIPTION
This introduces [Dex](https://dexidp.io/docs/) as a test dependency. I have had quite a bit of success in the past testing single sign-on and related features using Dex, we even put it into one of our products. It's pretty mature and (compared to other identity providers like Shibboleth or Keycloak etc) rather simple. The docker image is small, the configuration interface is rather neat. 

Using that dependency I have added a test which exercises the complete OIDC flow from the user agent's point of view. That kind of test is super valuable, will certainly help preventing regressions in subsequent feature work.