### PR TITLE
Revert "config: introduce CONBENCH_OIDC_ISSUER_URL, oidc code cleanup"

### DIFF
--- a/conbench/api/_google.py
+++ b/conbench/api/_google.py
@@ -1,72 +1,44 @@
 import json
-import logging
 import os
-import time
 
 import flask as f
 import requests
 
-from ..config import Config
 
-log = logging.getLogger(__name__)
-
-# Rely on INTENDED_BASE_URL to have a trailing slash.
-OIDC_CALLBACK_URL = Config.INTENDED_BASE_URL + "api/google/callback"
-
-
-def get_oidc_config():
+def get_google_config():
     client_id = os.environ.get("GOOGLE_CLIENT_ID", None)
     client_secret = os.environ.get("GOOGLE_CLIENT_SECRET", None)
-    discovery_url = Config.OIDC_ISSUER_URL + "/.well-known/openid-configuration"
+    discovery_url = "https://accounts.google.com/.well-known/openid-configuration"
     return discovery_url, client_id, client_secret
 
 
-def get_oidc_client():
+def get_google_client():
     from oauthlib.oauth2 import WebApplicationClient
 
-    discovery_url, client_id, _ = get_oidc_config()
-
-    # Pragmatic healing for transient errors. Better: cache OP config across
-    # login requests. Also, if we want to retry here in the future: consider
-    # using tenacity.
-    for attempt in range(4):
-        try:
-            oidc_provider_config = requests.get(discovery_url).json()
-            break
-        except requests.exceptions.RequestException as exc:
-            log.info("err getting OP config (attempt %s): %s -- retry", attempt, exc)
-            time.sleep(2)
-
+    discovery_url, client_id, _ = get_google_config()
+    google = requests.get(discovery_url).json()
     client = WebApplicationClient(client_id)
-    return client, oidc_provider_config
+    return client, google
 
 
 def auth_google_user():
-    client, oidc_provider_config = get_oidc_client()
-
-    # http://127.0.0.1:5000/api/google/callback
-    # redirect_uri = f.url_for("api.callback", _external=True, _scheme="https")
-
-    # If either redirect URL or the authorization endpoint (at the OP) do not
-    # use the HTTPS scheme then the function below is expected to throw
-    # `InsecureTransportError`. For testing, this can be changed by setting
-    # the environment variable OAUTHLIB_INSECURE_TRANSPORT.
-
+    client, google = get_google_client()
+    redirect_uri = f.url_for("api.callback", _external=True, _scheme="https")
     return client.prepare_request_uri(
-        oidc_provider_config["authorization_endpoint"],
-        redirect_uri=OIDC_CALLBACK_URL,
+        google["authorization_endpoint"],
+        redirect_uri=redirect_uri,
         scope=["openid", "email", "profile"],
     )
 
 
 def get_google_user():
-    client, oidc_provider_config = get_oidc_client()
-    _, client_id, client_secret = get_oidc_config()
+    client, google = get_google_client()
+    _, client_id, client_secret = get_google_config()
 
     token_url, headers, body = client.prepare_token_request(
-        oidc_provider_config["token_endpoint"],
-        authorization_response=f.request.url,  # .replace("http://", "https://"),
-        redirect_url=f.request.base_url,  # replace("http://", "https://"),
+        google["token_endpoint"],
+        authorization_response=f.request.url.replace("http://", "https://"),
+        redirect_url=f.request.base_url.replace("http://", "https://"),
         code=f.request.args.get("code"),
     )
     token_response = requests.post(
@@ -77,7 +49,7 @@ def get_google_user():
     )
     client.parse_request_body_response(json.dumps(token_response.json()))
 
-    uri, headers, body = client.add_token(oidc_provider_config["userinfo_endpoint"])
+    uri, headers, body = client.add_token(google["userinfo_endpoint"])
     return requests.get(
         uri,
         headers=headers,

--- a/conbench/api/auth.py
+++ b/conbench/api/auth.py
@@ -92,9 +92,7 @@ class CallbackAPI(ApiEndpoint):
         try:
             google_user = _google.get_google_user()
         except Exception as e:
-            self.abort_400_bad_request(
-                f"OpenID Connect single sign-on flow failed: {e}."
-            )
+            self.abort_400_bad_request(f"Google SSO failed {e}.")
 
         email = google_user["email"]
         given = google_user["given_name"]

--- a/conbench/config.py
+++ b/conbench/config.py
@@ -53,22 +53,6 @@ class Config:
     LOG_LEVEL_FILE = None
     LOG_LEVEL_SQLALCHEMY = "WARNING"
 
-    # If `OIDC_ISSUER_URL` is after all `None`: disable OpenID Connect (OIDC)
-    # single sign-on. If this is not `None` then it must be a valid OIDC issuer
-    # notation (that is, a URL).
-    OIDC_ISSUER_URL = os.environ.get("CONBENCH_OIDC_ISSUER_URL", None)
-    if OIDC_ISSUER_URL is not None:
-        assert OIDC_ISSUER_URL.startswith("http")
-        # Remove all trailing slashes.
-        OIDC_ISSUER_URL = OIDC_ISSUER_URL.rstrip("/")
-    else:
-        # legacy config support: when CONBENCH_OIDC_ISSUER_URL is set in the
-        # environment it takes precedence. If it is not set and if
-        # GOOGLE_CLIENT_ID is set in the environment then set issuer to
-        # "https://accounts.google.com"
-        if "GOOGLE_CLIENT_ID" in os.environ:
-            OIDC_ISSUER_URL = "https://accounts.google.com"
-
 
 class TestConfig(Config):
     DB_NAME = os.environ.get("DB_NAME", f"{APPLICATION_NAME.lower()}_test")


### PR DESCRIPTION
Reverts conbench/conbench#454.

That PR introduced this line:

https://github.com/conbench/conbench/blob/5eb4325b3fef675cf62a613eb0b3dba904fb8cf5/conbench/api/_google.py#L14

which, for instances with SSO and no `INTENDED_BASE_URL` set, breaks the authentication flow. We can restore this PR once those instances set an `INTENDED_BASE_URL`.