### PR TITLE
github actions: invoke test runner with docker-compose approach

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -37,12 +37,14 @@ jobs:
       - name: Start PostgreSQL DB
         run: |
           docker-compose run --detach db
+      # Run `alembic upgrade head` via docker-compose so that it is within
+      # the network that the DB is also in, reachable via DNS name `db`
       - name: Migrations
         run: |
-          alembic upgrade head
+          docker-compose run app alembic upgrade head
         env:
           DB_USERNAME: "postgres"
-          DB_HOST: "localhost"
+          DB_HOST: "db"
           DB_PASSWORD: "postgres"
           DB_NAME: "conbench_test"
           DB_PORT: "5432"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -55,7 +55,8 @@ jobs:
           docker-compose down && \
           docker-compose build app && \
           docker-compose run app coverage run \
-            --data-file=/etc/conbench-coverage-datafile --source conbench -m pytest -vv -s --durations=20 conbench/tests/
+            --data-file=/etc/conbench-coverage-dir/.coverage --source conbench \
+              -m pytest -vv -s -k test_dynamic_callback_url --durations=20 conbench/tests/
         env:
           DB_USERNAME: postgres
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -40,13 +40,15 @@ jobs:
       - name: Lint (isort)
         run: |
           isort --check .
-      - name: Run tests, generate coverage report
+      - name: Run tests, generate coverage data
         run: |
           docker-compose down && \
           docker-compose build app && \
           docker-compose run app coverage run \
             --source conbench \
-              -m pytest -vv -s -k test_dynamic_callback_url --durations=20 conbench/tests/ \ &&
+              -m pytest -vv -s -k test_dynamic_callback_url --durations=20 conbench/tests/
+      - name: Convert coverage data to LCOV
+        run: |
           docker-compose run app coverage lcov -o /etc/conbench-coverage-dir/coverage.lcov
       - name: Publish coverage
         uses: coverallsapp/github-action@master

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -55,7 +55,7 @@ jobs:
           docker-compose down && \
           docker-compose build app && \
           docker-compose run app coverage run \
-            --data-file=/etc/conbench-coverage-datafile --source conbench -m pytest -vv -s --durations=20 conbench/tests/ && \
+            --data-file=/etc/conbench-coverage-datafile --source conbench -m pytest -vv -s --durations=20 conbench/tests/
         env:
           DB_USERNAME: postgres
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -24,6 +24,12 @@ jobs:
         with:
           options: --check --diff
           src: .
+      - name: Install flake8, isort
+        run: pip install flake8 isort
+      - name: Lint (flake8)
+        run: flake8
+      - name: Lint (isort)
+        run: isort --check .
       - name: Start PostgreSQL DB
         run: docker-compose run --detach db
       # Run `alembic upgrade head` via docker-compose so that it is within
@@ -32,12 +38,6 @@ jobs:
         run: docker-compose run -e CREATE_ALL_TABLES app alembic upgrade head
         env:
           CREATE_ALL_TABLES: false
-      - name: Install flake8, isort
-        run: pip install flake8 isort
-      - name: Lint (flake8)
-        run: flake8
-      - name: Lint (isort)
-        run: isort --check .
       - name: Run tests, generate coverage data
         run: |
           docker-compose down && \

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -55,17 +55,14 @@ jobs:
           docker-compose down && \
           docker-compose build app && \
           docker-compose run app coverage run \
-            --data-file=/etc/conbench-coverage-dir/.coverage --source conbench \
-              -m pytest -vv -s -k test_dynamic_callback_url --durations=20 conbench/tests/
+            --source conbench \
+              -m pytest -vv -s -k test_dynamic_callback_url --durations=20 conbench/tests/ \ &&
+          docker-compose run app coverage lcov -o /etc/conbench-coverage-dir/coverage.lcov
       - name: Publish coverage
-        run: |
-          docker-compose run \
-            -e GITHUB_TOKEN \
-            -e COVERAGE_FILE \
-            app coveralls --service=github
-        env:
-          COVERAGE_FILE: /etc/conbench-coverage-dir/.coverage
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: _conbench-coverage-dir/coverage.lcov
       - name: Test benchclients
         run: |
           pytest -vv benchclients/python/tests

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -57,19 +57,11 @@ jobs:
           docker-compose run app coverage run \
             --data-file=/etc/conbench-coverage-dir/.coverage --source conbench \
               -m pytest -vv -s -k test_dynamic_callback_url --durations=20 conbench/tests/
-        env:
-          DB_USERNAME: postgres
-          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OAUTHLIB_INSECURE_TRANSPORT: 1
-          GOOGLE_CLIENT_ID: conbench-test-client
-          GOOGLE_CLIENT_SECRET: AnotherStaticSecret
-          CONBENCH_LOG_LEVEL_STDERR: DEBUG
-          CONBENCH_OIDC_ISSUER_URL: http://dex:5556/dex-for-conbench
       - name: Publish coverage
         run: |
-          cp _conbench-coverage-dir/.coverage .coverage && \
-          coveralls --service=github
+          docker-compose run app coveralls --service=github
         env:
+          COVERAGE_FILE: /etc/conbench-coverage-dir/.coverage
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Test benchclients
         run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -34,12 +34,22 @@ jobs:
       #     docker-compose run -e CREATE_ALL_TABLES app alembic upgrade head
       #   env:
       #     CREATE_ALL_TABLES: false
-      - name: Lint (flake8)
-        run: |
-          flake8
-      - name: Lint (isort)
-        run: |
-          isort --check .
+      # - name: Install dependencies
+      #   run: |
+      #     pip install --no-deps \
+      #       -e benchadapt/python \
+      #       -e benchrun/python \
+      #       -e benchconnect && \
+      #     pip install \
+      #       -U --upgrade-strategy eager \
+      #       -e .[dev] \
+      #       -e benchclients/python
+      # - name: Lint (flake8)
+      #   run: |
+      #     flake8
+      # - name: Lint (isort)
+      #   run: |
+      #     isort --check .
       - name: Run tests, generate coverage data
         run: |
           docker-compose down && \
@@ -55,16 +65,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: _conbench-coverage-dir/coverage.lcov
-      - name: Install dependencies
-        run: |
-          pip install --no-deps \
-            -e benchadapt/python \
-            -e benchrun/python \
-            -e benchconnect && \
-          pip install \
-            -U --upgrade-strategy eager \
-            -e .[dev] \
-            -e benchclients/python
       - name: Test benchclients
         run: |
           pytest -vv benchclients/python/tests

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -24,16 +24,6 @@ jobs:
         with:
           options: --check --diff
           src: .
-      - name: Install dependencies
-        run: |
-          pip install --no-deps \
-            -e benchadapt/python \
-            -e benchrun/python \
-            -e benchconnect && \
-          pip install \
-            -U --upgrade-strategy eager \
-            -e .[dev] \
-            -e benchclients/python
       # - name: Start PostgreSQL DB
       #   run: |
       #     docker-compose run --detach db
@@ -63,6 +53,16 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: _conbench-coverage-dir/coverage.lcov
+      - name: Install dependencies
+        run: |
+          pip install --no-deps \
+            -e benchadapt/python \
+            -e benchrun/python \
+            -e benchconnect && \
+          pip install \
+            -U --upgrade-strategy eager \
+            -e .[dev] \
+            -e benchclients/python
       - name: Test benchclients
         run: |
           pytest -vv benchclients/python/tests

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -46,7 +46,7 @@ jobs:
           docker-compose build app && \
           docker-compose run -e COVERAGE_FILE=/etc/conbench-coverage-dir/.coverage app \
             coverage run --source conbench \
-              -m pytest -vv -s --durations=20 conbench/tests/
+              -m pytest -vv -s -k test_users -k test_plots --durations=20 conbench/tests/
       - name: Convert coverage data to LCOV
         run: |
           docker-compose run -e COVERAGE_FILE=/etc/conbench-coverage-dir/.coverage app \

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -67,7 +67,7 @@ jobs:
           CONBENCH_OIDC_ISSUER_URL: http://dex:5556/dex-for-conbench
       - name: Publish coverage
         run: |
-          cp _conbench-coverage-datafile .coverage && \
+          cp _conbench-coverage-dir/.coverage .coverage && \
           coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -41,7 +41,7 @@ jobs:
       # the network that the DB is also in, reachable via DNS name `db`
       - name: Migrations
         run: |
-          docker-compose run app alembic upgrade head
+          docker-compose run -e CREATE_ALL_TABLES app alembic upgrade head
         env:
           CREATE_ALL_TABLES: false
       - name: Lint (flake8)

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -36,7 +36,7 @@ jobs:
       #     CREATE_ALL_TABLES: false
       - name: Install flake8, isort
         run: pip install flake8 isort
-       - name: Lint (flake8)
+      - name: Lint (flake8)
         run: flake8
       - name: Lint (isort)
         run: isort --check .

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -34,22 +34,12 @@ jobs:
       #     docker-compose run -e CREATE_ALL_TABLES app alembic upgrade head
       #   env:
       #     CREATE_ALL_TABLES: false
-      # - name: Install dependencies
-      #   run: |
-      #     pip install --no-deps \
-      #       -e benchadapt/python \
-      #       -e benchrun/python \
-      #       -e benchconnect && \
-      #     pip install \
-      #       -U --upgrade-strategy eager \
-      #       -e .[dev] \
-      #       -e benchclients/python
-      # - name: Lint (flake8)
-      #   run: |
-      #     flake8
-      # - name: Lint (isort)
-      #   run: |
-      #     isort --check .
+      - name: Install flake8, isort
+        run: pip install flake8 isort
+       - name: Lint (flake8)
+        run: flake8
+      - name: Lint (isort)
+        run: isort --check .
       - name: Run tests, generate coverage data
         run: |
           docker-compose down && \

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -36,7 +36,7 @@ jobs:
             -e benchclients/python
       - name: Start PostgreSQL DB
         run: |
-          docker compose run db
+          docker compose up db
       - name: Migrations
         run: |
           alembic upgrade head

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -43,11 +43,7 @@ jobs:
         run: |
           docker-compose run app alembic upgrade head
         env:
-          DB_USERNAME: "postgres"
-          DB_HOST: "db"
-          DB_PASSWORD: "postgres"
-          DB_NAME: "conbench_test"
-          DB_PORT: "5432"
+          CREATE_ALL_TABLES: false
       - name: Lint (flake8)
         run: |
           flake8

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -34,9 +34,9 @@ jobs:
             -U --upgrade-strategy eager \
             -e .[dev] \
             -e benchclients/python
-      - name: Start PostgreSQL DB
-        run: |
-          docker-compose run --detach db
+      # - name: Start PostgreSQL DB
+      #   run: |
+      #     docker-compose run --detach db
       # Run `alembic upgrade head` via docker-compose so that it is within
       # the network that the DB is also in, reachable via DNS name `db`
       # - name: Migrations

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -54,12 +54,13 @@ jobs:
         run: |
           docker-compose down && \
           docker-compose build app && \
-          docker-compose run app coverage run \
-            --source conbench \
-              -m pytest -vv -s -k test_dynamic_callback_url --durations=20 conbench/tests/
+          docker-compose run -e COVERAGE_FILE=/etc/conbench-coverage-dir/.coverage app \
+            coverage run --source conbench \
+              -m pytest -vv -s --durations=20 conbench/tests/
       - name: Convert coverage data to LCOV
         run: |
-          docker-compose run app coverage lcov -o /etc/conbench-coverage-dir/coverage.lcov
+          docker-compose run -e COVERAGE_FILE=/etc/conbench-coverage-dir/.coverage app \
+            coverage lcov -o /etc/conbench-coverage-dir/coverage.lcov
       - name: Publish coverage
         uses: coverallsapp/github-action@master
         with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -36,7 +36,7 @@ jobs:
             -e benchclients/python
       - name: Start PostgreSQL DB
         run: |
-          docker compose up db
+          docker-compose run --detach db
       - name: Migrations
         run: |
           alembic upgrade head

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,16 +12,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:11
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: conbench_test
-        ports:
-          - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - name: Checkout conbench
         uses: actions/checkout@v3
@@ -44,6 +34,9 @@ jobs:
             -U --upgrade-strategy eager \
             -e .[dev] \
             -e benchclients/python
+      - name: Start PostgreSQL DB
+        run: |
+          docker compose run db
       - name: Migrations
         run: |
           alembic upgrade head
@@ -59,14 +52,23 @@ jobs:
       - name: Lint (isort)
         run: |
           isort --check .
-      - name: Run tests
+      - name: Run tests, generate coverage report
         run: |
-          coverage run --source conbench -m pytest -vv --durations=20 conbench/tests/
+          docker-compose down && \
+          docker-compose build app && \
+          docker-compose run app coverage run \
+            --data-file=/etc/conbench-coverage-datafile --source conbench -m pytest -vv -s --durations=20 conbench/tests/ && \
         env:
           DB_USERNAME: postgres
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OAUTHLIB_INSECURE_TRANSPORT: 1
+          GOOGLE_CLIENT_ID: conbench-test-client
+          GOOGLE_CLIENT_SECRET: AnotherStaticSecret
+          CONBENCH_LOG_LEVEL_STDERR: DEBUG
+          CONBENCH_OIDC_ISSUER_URL: http://dex:5556/dex-for-conbench
       - name: Publish coverage
         run: |
+          cp _conbench-coverage-datafile .coverage && \
           coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -59,7 +59,10 @@ jobs:
               -m pytest -vv -s -k test_dynamic_callback_url --durations=20 conbench/tests/
       - name: Publish coverage
         run: |
-          docker-compose run app coveralls --service=github
+          docker-compose run \
+            -e GITHUB_TOKEN \
+            -e COVERAGE_FILE \
+            app coveralls --service=github
         env:
           COVERAGE_FILE: /etc/conbench-coverage-dir/.coverage
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -39,11 +39,11 @@ jobs:
           docker-compose run --detach db
       # Run `alembic upgrade head` via docker-compose so that it is within
       # the network that the DB is also in, reachable via DNS name `db`
-      - name: Migrations
-        run: |
-          docker-compose run -e CREATE_ALL_TABLES app alembic upgrade head
-        env:
-          CREATE_ALL_TABLES: false
+      # - name: Migrations
+      #   run: |
+      #     docker-compose run -e CREATE_ALL_TABLES app alembic upgrade head
+      #   env:
+      #     CREATE_ALL_TABLES: false
       - name: Lint (flake8)
         run: |
           flake8

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -56,6 +56,16 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: _conbench-coverage-dir/coverage.lcov
+      - name: Install dependencies
+        run: |
+          pip install --no-deps \
+            -e benchadapt/python \
+            -e benchrun/python \
+            -e benchconnect && \
+          pip install \
+            -U --upgrade-strategy eager \
+            -e .[dev] \
+            -e benchclients/python
       - name: Test benchclients
         run: |
           pytest -vv benchclients/python/tests

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -24,16 +24,14 @@ jobs:
         with:
           options: --check --diff
           src: .
-      # - name: Start PostgreSQL DB
-      #   run: |
-      #     docker-compose run --detach db
+      - name: Start PostgreSQL DB
+        run: docker-compose run --detach db
       # Run `alembic upgrade head` via docker-compose so that it is within
       # the network that the DB is also in, reachable via DNS name `db`
-      # - name: Migrations
-      #   run: |
-      #     docker-compose run -e CREATE_ALL_TABLES app alembic upgrade head
-      #   env:
-      #     CREATE_ALL_TABLES: false
+      - name: Migrations
+        run: docker-compose run -e CREATE_ALL_TABLES app alembic upgrade head
+        env:
+          CREATE_ALL_TABLES: false
       - name: Install flake8, isort
         run: pip install flake8 isort
       - name: Lint (flake8)
@@ -46,7 +44,7 @@ jobs:
           docker-compose build app && \
           docker-compose run -e COVERAGE_FILE=/etc/conbench-coverage-dir/.coverage app \
             coverage run --source conbench \
-              -m pytest -vv -s -k test_users -k test_plots --durations=20 conbench/tests/
+              -m pytest -vv -s --durations=20 conbench/tests/
       - name: Convert coverage data to LCOV
         run: |
           docker-compose run -e COVERAGE_FILE=/etc/conbench-coverage-dir/.coverage app \

--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -62,6 +62,7 @@ def _init_application(application):
     # Do not create all tables when running alembic migrations in
     # production (CREATE_ALL_TABLES=false) using k8s migration job
     if Config.CREATE_ALL_TABLES:
+        log.debug("Config.CREATE_ALL_TABLES appears to be set, call create_all()")
         create_all()
 
     application.register_blueprint(app, url_prefix="/")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,8 @@ services:
       FLASK_DEBUG: "true"
       REGISTRATION_KEY: "code"
       SECRET_KEY: "Person, woman, man, camera, TV"
+      # Default log level is INFO, change to DEBUG as needed.
+      # CONBENCH_LOG_LEVEL_STDERR: DEBUG
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       context: .
       dockerfile: Dockerfile
     command: ["gunicorn", "-b", "0.0.0.0:5000", "-w", "5", "conbench:application", "--access-logfile=-", "--error-logfile=-", "--preload"]
+    volumes:
+      - ${PWD}/_conbench-coverage-datafile:/etc/conbench-coverage-datafile
     environment:
       APPLICATION_NAME: "Conbench"
       DB_USERNAME: "postgres"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       FLASK_ENV: "development"
       REGISTRATION_KEY: "code"
       SECRET_KEY: "Person, woman, man, camera, TV"
+      CREATE_ALL_TABLES
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,23 +9,22 @@ services:
     volumes:
       - ${PWD}/_conbench-coverage-datafile:/etc/conbench-coverage-datafile
     environment:
-      - APPLICATION_NAME: "Conbench"
-      - DB_USERNAME: "postgres"
+      APPLICATION_NAME: "Conbench"
+      DB_USERNAME: "postgres"
       # From the docker-compose docs: "By default Compose sets up a single
       # network for your app. Each container for a service joins the default
       # network and is both reachable by other containers on that network, and
       # discoverable by them at a hostname identical to the container name."
       # That is why the DNS name `db` works.
-      - DB_HOST: "db"
-      - DB_PASSWORD: "postgres"
-      - DB_NAME: "postgres"
-      - DB_PORT: "5432"
-      - FLASK_APP: "conbench"
-      - FLASK_ENV: "development"
-      - FLASK_DEBUG: "true"
-      - REGISTRATION_KEY: "code"
-      - SECRET_KEY: "Person, woman, man, camera, TV"
-      - CREATE_ALL_TABLES
+      DB_HOST: "db"
+      DB_PASSWORD: "postgres"
+      DB_NAME: "postgres"
+      DB_PORT: "5432"
+      FLASK_APP: "conbench"
+      FLASK_ENV: "development"
+      FLASK_DEBUG: "true"
+      REGISTRATION_KEY: "code"
+      SECRET_KEY: "Person, woman, man, camera, TV"
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: Dockerfile
     command: ["gunicorn", "-b", "0.0.0.0:5000", "-w", "5", "conbench:application", "--access-logfile=-", "--error-logfile=-", "--preload"]
     volumes:
-      - ${PWD}/_conbench-coverage-datafile:/etc/conbench-coverage-datafile
+      - ${PWD}/_conbench-coverage-dir:/etc/conbench-coverage-dir
     environment:
       APPLICATION_NAME: "Conbench"
       DB_USERNAME: "postgres"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,17 +9,23 @@ services:
     volumes:
       - ${PWD}/_conbench-coverage-datafile:/etc/conbench-coverage-datafile
     environment:
-      APPLICATION_NAME: "Conbench"
-      DB_USERNAME: "postgres"
-      DB_HOST: "db"
-      DB_PASSWORD: "postgres"
-      DB_NAME: "postgres"
-      DB_PORT: "5432"
-      FLASK_APP: "conbench"
-      FLASK_ENV: "development"
-      REGISTRATION_KEY: "code"
-      SECRET_KEY: "Person, woman, man, camera, TV"
-      CREATE_ALL_TABLES
+      - APPLICATION_NAME: "Conbench"
+      - DB_USERNAME: "postgres"
+      # From the docker-compose docs: "By default Compose sets up a single
+      # network for your app. Each container for a service joins the default
+      # network and is both reachable by other containers on that network, and
+      # discoverable by them at a hostname identical to the container name."
+      # That is why the DNS name `db` works.
+      - DB_HOST: "db"
+      - DB_PASSWORD: "postgres"
+      - DB_NAME: "postgres"
+      - DB_PORT: "5432"
+      - FLASK_APP: "conbench"
+      - FLASK_ENV: "development"
+      - FLASK_DEBUG: "true"
+      - REGISTRATION_KEY: "code"
+      - SECRET_KEY: "Person, woman, man, camera, TV"
+      - CREATE_ALL_TABLES
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
As part of https://github.com/conbench/conbench/pull/455 I spent a couple of hours trying to change the way we run tests in GitHub Actions. I have now split out this work into this separate PR.

Instead of running `pytest` directly in the GHA container the goal was to use `docker-compose` to run `pytest` _in_ the `app` container as defined by `docker-compose.yml`. That is to make use of the dependency management that docker-compose provides, which is for now a good thing to have when introducing Dex as a new (containerized) test dependency that needs to be reachable under a predictable DNS name.

As part of making this change the biggest challenge was to not break the coverage data workflow. I ran into the same wall multiple times and almost gave up (the commit history shows the difficulties, I suppose), but after all I think the coverage data flow is now the same as before.

What's new in terms of coverage report information flow:

- We let the pytest test runner in the `app` container write the coverage data to a particular location in that container file system.
- We then invoke `coverage lcov` in the same container to write the coverage data in the so-called LCOV file format to a file that is accessible from the 'host', under `$(pwd)/_conbench-coverage-dir/coverage.lcov`.
- We use the GitHub action called `coverallsapp/github-action` (seems to be rather popular) actually submit the report -- with the input parameter titled `path-to-lcov`, pointing to said LCOV file.