### PR TITLE
OIDC: carry target URL across flow

### DIFF
--- a/conbench/api/_google.py
+++ b/conbench/api/_google.py
@@ -56,8 +56,8 @@ def gen_oidc_authz_req_url(user_came_from_url: str) -> str:
 
     Scheme, host, port information depend on the deployment and cannot
     generally be determined by the app itself (requires human input). Hence,
-    the least error-prone method is to construct the callback URL via
-    Config.INTENDED_BASE_URL.
+    the most maintainable (controlled, predictable) way to construct the
+    callback URL would be using Config.INTENDED_BASE_URL.
 
     However, Config.INTENDED_BASE_URL is not yet required to be set by Conbench
     operators (as that would break compatibility with legacy deployments). For
@@ -68,12 +68,6 @@ def gen_oidc_authz_req_url(user_came_from_url: str) -> str:
     Further analysis and discussion can be found at
     https://github.com/conbench/conbench/pull/454#issuecomment-1326338524 and
     in https://github.com/conbench/conbench/issues/464
-
-    Technically, a more controlled and predictable way to construct the
-    callback URL would be using Config.INTENDED_BASE_URL. However, as long as
-    that configuration parameter is not required to be set to a meaningful
-    value we should not rely on that yet (breaks compatibility with old
-    deployment configs).
 
     If either redirect URL or the authorization endpoint (at the OP) do not use
     the HTTPS scheme then the oauthlib method `prepare_request_uri()` below is

--- a/conbench/api/_google.py
+++ b/conbench/api/_google.py
@@ -1,16 +1,12 @@
 import json
 import logging
 import time
-
 import urllib.parse
 
 import flask as f
-
-
 import requests
 
 from ..config import Config
-
 
 log = logging.getLogger(__name__)
 

--- a/conbench/api/_google.py
+++ b/conbench/api/_google.py
@@ -1,8 +1,6 @@
 import base64
-import json
 import logging
 import time
-import urllib.parse
 
 import flask as f
 import requests

--- a/conbench/api/_google.py
+++ b/conbench/api/_google.py
@@ -106,7 +106,7 @@ def gen_oidc_authz_req_url(user_came_from_url: str) -> str:
         scope=["openid", "email", "profile"],
         # Additional parameter to carry across the flow. Usually this parameter
         # has a security purpose. For the time being we do not use it for that,
-        # but we use it for communicating `camefrom_encoded` across the flow.
+        # but we use it for communicating the target URL across the flow.
         # Discussion can be found in
         # https://github.com/conbench/conbench/pull/462.
         state=state,
@@ -118,10 +118,14 @@ def gen_oidc_authz_req_url(user_came_from_url: str) -> str:
 def conclude_oidc_flow():
     """
     Note(JP): I'd prefer to have this part of the flow implemented with the
-    help of a more appropriate library than oauthlib. oauthlib is old and was
-    mainly intended to build identity providers. It's difficult to use its
-    primitives in a correct, secure way, and the outcome is hard to read and
-    maintain.
+    help of a more appropriate library than oauthlib. oauthlib is a generic
+    OAuth2 library and mainly intended to build identity providers. It's
+    difficult to use its primitives in a correct, secure way, and the outcome
+    is hard to read and maintain.
+
+    Relevant docs:
+    https://oauthlib.readthedocs.io/en/latest/oauth2/clients/baseclient.html
+    https://oauthlib.readthedocs.io/en/latest/oauth2/clients/webapplicationclient.html
 
     After all, I think in the current implementation we're doing more HTTP
     requests than necessary (we should be OK with just getting an ID token,
@@ -150,6 +154,8 @@ def conclude_oidc_flow():
             oidc_provider_config["token_endpoint"],
             authorization_response=f.request.url,
             redirect_url=f.request.base_url,
+            # Note(JP): the code arg is not documented at
+            # https://oauthlib.readthedocs.io/en/latest/oauth2/clients/baseclient.html
             # code=f.request.args.get("code"),
         )
     except Exception as exc:

--- a/conbench/api/_google.py
+++ b/conbench/api/_google.py
@@ -191,6 +191,9 @@ def conclude_oidc_flow():
         data=body,
     ).json()
 
+    # For the consumer of this 2-tuple: expect `user_came_from_url` to always
+    # be a string. It has length 0 in case no target URL was communicated or if
+    # there was a decoding issue along the way.
     return user_came_from_url, userinfo
 
 

--- a/conbench/api/_google.py
+++ b/conbench/api/_google.py
@@ -118,6 +118,22 @@ def gen_oidc_authz_req_url(user_came_from_url: str) -> str:
 
 
 def conclude_oidc_flow():
+    """
+    Note(JP): I'd prefer to have this part of the flow implemented with the
+    help of a more appropriate library than oauthlib. oauthlib is old and was
+    mainly intended to build identity providers. It's difficult to use its
+    primitives in a correct, secure way, and the outcome is hard to read and
+    maintain.
+
+    After all, I think in the current implementation we're doing more HTTP
+    requests than necessary (we should be OK with just getting an ID token,
+    maybe do not need to do the /userinfo request).
+
+    In the current iteration it's about adding some code comments, and about
+    covering what we have in tests. It will then be easier to potentially
+    transition to a different library.
+    """
+
     client, oidc_provider_config = get_oidc_client()
     _, client_id, client_secret = get_oidc_config()
 

--- a/conbench/api/_google.py
+++ b/conbench/api/_google.py
@@ -197,7 +197,6 @@ def conclude_oidc_flow():
     log.debug("access token response: %s, %s", token_response, token_response.text)
 
     try:
-        # client.parse_request_body_response(json.dumps(token_response.json()))
         # Expect token_response.text to be a JSON document
         client.parse_request_body_response(token_response.text)
     except Exception as exc:

--- a/conbench/api/auth.py
+++ b/conbench/api/auth.py
@@ -81,8 +81,9 @@ class GoogleAPI(ApiEndpoint):
         # Read query parameter `target`. Assume that the value is the URL that
         # the user actually wanted to visit before they were redirected to the
         # login page. `f.request.args` holds parsed URL query parameters.
-        user_came_from_url = ""
+        user_came_from_url = None
         if "target" in f.request.args:
+            # Rely on Flask to do have done one level of URL-decoding
             user_came_from_url = f.request.args.get("target")
             log.info(f"api/google/, {user_came_from_url=}")
 

--- a/conbench/api/auth.py
+++ b/conbench/api/auth.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 
 import flask as f
@@ -8,6 +9,9 @@ from ..api import _google, rule
 from ..api._docs import spec
 from ..api._endpoint import ApiEndpoint
 from ..api.users import User
+
+
+log = logging.getLogger(__name__)
 
 
 class LoginSchema(marshmallow.Schema):
@@ -80,6 +84,7 @@ class GoogleAPI(ApiEndpoint):
         user_came_from_url = ""
         if "target" in f.request.args:
             user_came_from_url = f.request.args.get("target")
+            log.info(f"api/google/, {user_came_from_url=}")
 
         return f.redirect(_google.gen_oidc_authz_req_url(user_came_from_url))
 

--- a/conbench/api/auth.py
+++ b/conbench/api/auth.py
@@ -74,7 +74,14 @@ class GoogleAPI(ApiEndpoint):
           - Authentication
         """
 
-        return f.redirect(_google.auth_google_user())
+        # Read query parameter `target`. Assume that the value is the URL that
+        # the user actually wanted to visit before they were redirected to the
+        # login page. `f.request.args` holds parsed URL query parameters.
+        user_came_from_url = ""
+        if "target" in f.request.args:
+            user_came_from_url = f.request.args.get("target")
+
+        return f.redirect(_google.auth_google_user(user_came_from_url))
 
 
 class CallbackAPI(ApiEndpoint):
@@ -90,15 +97,16 @@ class CallbackAPI(ApiEndpoint):
         """
 
         try:
-            google_user = _google.get_google_user()
+            user_came_from_url, oidc_user = _google.conclude_oidc_flow()
         except Exception as e:
             self.abort_400_bad_request(
                 f"OpenID Connect single sign-on flow failed: {e}."
             )
 
-        email = google_user["email"]
-        given = google_user.get("given_name", "")
-        family = google_user.get("family_name", "")
+        email = oidc_user["email"]
+        given = oidc_user.get("given_name", "")
+        family = oidc_user.get("family_name", "")
+
         user = User.first(email=email)
         if user is None:
             data = {
@@ -108,6 +116,10 @@ class CallbackAPI(ApiEndpoint):
             }
             user = User.create(data)
         flask_login.login_user(user)
+
+        if len(user_came_from_url):
+            return f.redirect(user_came_from_url)
+
         return self.redirect("app.index")
 
 

--- a/conbench/api/auth.py
+++ b/conbench/api/auth.py
@@ -10,7 +10,6 @@ from ..api._docs import spec
 from ..api._endpoint import ApiEndpoint
 from ..api.users import User
 
-
 log = logging.getLogger(__name__)
 
 

--- a/conbench/api/auth.py
+++ b/conbench/api/auth.py
@@ -81,7 +81,7 @@ class GoogleAPI(ApiEndpoint):
         if "target" in f.request.args:
             user_came_from_url = f.request.args.get("target")
 
-        return f.redirect(_google.auth_google_user(user_came_from_url))
+        return f.redirect(_google.gen_oidc_authz_req_url(user_came_from_url))
 
 
 class CallbackAPI(ApiEndpoint):

--- a/conbench/app/auth.py
+++ b/conbench/app/auth.py
@@ -58,8 +58,8 @@ class Login(AppEndpoint):
             title="Sign In",
             form=form,
             sso=show_sso_button,
-            # If `target_url_after_login`` is Falsy (e.g. emtpy string) then
-            # expect template to _not_ add a query parameter anywhere. Note
+            # If `target_url_after_login` is Falsy (e.g. emtpy string) then
+            # expect template to not add a query parameter to the login link.
             target_url_after_login=target_url_after_login,
         )
 

--- a/conbench/app/auth.py
+++ b/conbench/app/auth.py
@@ -1,5 +1,5 @@
-import os
 import logging
+import os
 from typing import Optional
 
 import flask as f

--- a/conbench/app/auth.py
+++ b/conbench/app/auth.py
@@ -1,4 +1,5 @@
 import os
+import logging
 from typing import Optional
 
 import flask as f
@@ -11,6 +12,8 @@ from ..app import rule
 from ..app._endpoint import AppEndpoint
 from ..config import Config
 from ..entities.user import User
+
+log = logging.getLogger(__name__)
 
 
 class Logout(AppEndpoint):
@@ -76,6 +79,7 @@ class Login(AppEndpoint):
         user_came_from_url = ""
         if "target" in f.request.args:
             user_came_from_url = f.request.args.get("target")
+            log.debug("render login page. target param: %s", user_came_from_url)
 
         if flask_login.current_user.is_authenticated:
             # Redirect to target if set? Might create infinite redirect loop.

--- a/conbench/app/auth.py
+++ b/conbench/app/auth.py
@@ -72,13 +72,14 @@ class Login(AppEndpoint):
 
         # Read query parameter `target`. Assume that the value is the URL that
         # the user actually wanted to visit before they were redirected to the
-        # login page. `f.request.args` holds parsed URL query parameters.
+        # login page. `f.request.args` holds parsed (i.e. URL-decoded) URL
+        # query parameters.
         user_came_from_url = ""
         if "target" in f.request.args:
             user_came_from_url = f.request.args.get("target")
 
         if flask_login.current_user.is_authenticated:
-            # redirect to target if set?
+            # Redirect to target if set? Might create infinite redirect loop.
             return self.redirect("app.index")
 
         return self.page(self.form(), target=user_came_from_url)

--- a/conbench/app/auth.py
+++ b/conbench/app/auth.py
@@ -37,6 +37,8 @@ class Login(AppEndpoint):
             title="Sign In",
             form=form,
             sso=sso,
+            # If `target` is Falsy (e.g. emtpy string) then expect
+            # template to _not_ add a query parameter anywhere.
             target=target,
         )
 
@@ -72,12 +74,16 @@ class Login(AppEndpoint):
             if response.status_code == 204:
                 # TODO: remove this last query from frontend
                 user = User.first(email=form.email.data)
+                # NOTE(JP): this is the second time that we call
+                # `flask_login.login_user` while the actual user agent waits
+                # for an HTTP response.
                 flask_login.login_user(user, remember=form.remember_me.data)
                 return self.redirect("app.index")
             else:
                 self.flash("Invalid email or password.", "danger")
 
-        return self.page(form)
+        # TODO: set `target` parameter.
+        return self.page(form, target="")
 
 
 class RegistrationForm(flask_wtf.FlaskForm):

--- a/conbench/app/auth.py
+++ b/conbench/app/auth.py
@@ -29,7 +29,7 @@ class LoginForm(flask_wtf.FlaskForm):
 class Login(AppEndpoint):
     form = LoginForm
 
-    def page(self, form, target_url_after_login: Optional[str]):
+    def page(self, form, target_url_after_login: Optional[str] = None):
         """
         `target_url_after_login` is meant to carry an absolute or relative URL,
         the target to redirect the user to after login was successful.
@@ -84,6 +84,9 @@ class Login(AppEndpoint):
         return self.page(self.form(), target_url_after_login=user_came_from_url)
 
     def post(self):
+        """
+        Note: redirect-to-target-after-login not yet implemented
+        """
         if flask_login.current_user.is_authenticated:
             return self.redirect("app.index")
 
@@ -97,12 +100,12 @@ class Login(AppEndpoint):
                 # `flask_login.login_user` while the actual user agent waits
                 # for an HTTP response.
                 flask_login.login_user(user, remember=form.remember_me.data)
+
                 return self.redirect("app.index")
             else:
                 self.flash("Invalid email or password.", "danger")
 
-        # TODO: set `target` parameter.
-        return self.page(form, target="")
+        return self.page(form)
 
 
 class RegistrationForm(flask_wtf.FlaskForm):

--- a/conbench/app/auth.py
+++ b/conbench/app/auth.py
@@ -2,6 +2,7 @@ import os
 
 import flask_login
 import flask_wtf
+import flask as f
 import wtforms as w
 import wtforms.validators as v
 
@@ -45,9 +46,19 @@ class Login(AppEndpoint):
         }
 
     def get(self):
+
+        # Read query parameter `target`. Assume that the value is the URL that
+        # the user actually wanted to visit before they were redirected to the
+        # login page. `f.request.args` holds parsed URL query parameters.
+        user_came_from_url = ""
+        if "target" in f.request.args:
+            user_came_from_url = f.request.args.get("target")
+
         if flask_login.current_user.is_authenticated:
+            # redirect to target if set?
             return self.redirect("app.index")
-        return self.page(self.form())
+
+        return self.page(self.form(), target=user_came_from_url)
 
     def post(self):
         if flask_login.current_user.is_authenticated:

--- a/conbench/app/auth.py
+++ b/conbench/app/auth.py
@@ -81,7 +81,7 @@ class Login(AppEndpoint):
             # Redirect to target if set? Might create infinite redirect loop.
             return self.redirect("app.index")
 
-        return self.page(self.form(), target=user_came_from_url)
+        return self.page(self.form(), target_url_after_login=user_came_from_url)
 
     def post(self):
         if flask_login.current_user.is_authenticated:

--- a/conbench/app/auth.py
+++ b/conbench/app/auth.py
@@ -1,12 +1,11 @@
 import os
+from typing import Optional
 
+import flask as f
 import flask_login
 import flask_wtf
-import flask as f
 import wtforms as w
 import wtforms.validators as v
-
-from typing import Optional
 
 from ..app import rule
 from ..app._endpoint import AppEndpoint

--- a/conbench/app/auth.py
+++ b/conbench/app/auth.py
@@ -28,14 +28,16 @@ class LoginForm(flask_wtf.FlaskForm):
 class Login(AppEndpoint):
     form = LoginForm
 
-    def page(self, form):
-        sso = os.environ.get("GOOGLE_CLIENT_ID", None) is not None
+    def page(self, form, target: str):
+        # sso = os.environ.get("GOOGLE_CLIENT_ID", None) is not None
+        sso = True
         return self.render_template(
             "login.html",
             application=Config.APPLICATION_NAME,
             title="Sign In",
             form=form,
             sso=sso,
+            target=target,
         )
 
     def data(self, form):

--- a/conbench/templates/login.html
+++ b/conbench/templates/login.html
@@ -12,7 +12,11 @@
   <p>New user? <a href="{{ url_for('app.register') }}">Sign Up</a></p>
   {% if sso %}
   <hr>
-  <a href="{{ url_for('api.google') }}">Google Login</a>
+    {% if target %}
+    <a href="{{ url_for('api.google', target=target) }}">Google Login</a>
+    {% else %}
+    <a href="{{ url_for('api.google' ) }}">Google Login</a>
+    {% endif %}
   {% endif %}
 </div>
 

--- a/conbench/templates/login.html
+++ b/conbench/templates/login.html
@@ -15,7 +15,7 @@
     {# Dynamically add `target` URL query parameter. `url_for()` is documented
     with "unknown keys are appended as query string arguments". I think
     that url_for() automatically performs URL-encoding. #}
-    {% if target %}
+    {% if target_url_after_login %}
     <a href="{{ url_for('api.google', target=target_url_after_login) }}">Google Login</a>
     {% else %}
     <a href="{{ url_for('api.google' ) }}">Google Login</a>

--- a/conbench/templates/login.html
+++ b/conbench/templates/login.html
@@ -12,8 +12,11 @@
   <p>New user? <a href="{{ url_for('app.register') }}">Sign Up</a></p>
   {% if sso %}
   <hr>
+    {# Dynamically add `target` URL query parameter. `url_for()` is documented
+    with "unknown keys are appended as query string arguments". I think
+    that url_for() automatically performs URL-encoding. #}
     {% if target %}
-    <a href="{{ url_for('api.google', target=target) }}">Google Login</a>
+    <a href="{{ url_for('api.google', target=target_url_after_login) }}">Google Login</a>
     {% else %}
     <a href="{{ url_for('api.google' ) }}">Google Login</a>
     {% endif %}

--- a/conbench/tests/app/test_auth.py
+++ b/conbench/tests/app/test_auth.py
@@ -142,12 +142,19 @@ class TestLogout(_asserts.AppEndpointTest):
 
 class TestLoginOIDC(_asserts.AppEndpointTest):
     def test_login_page_shows_sso_link(self, client):
-        # In the test suite, this is currently expected to show because
-        # GOOGLE_CLIENT_ID is set.
+        # In the test suite the "Google Login" link is currently expected to
+        # show because GOOGLE_CLIENT_ID is set. Note that this label should
+        # change into something more generic or into a value configured by the
+        # operator.
         r = client.get("/login/", follow_redirects=True)
-        # Note that this label should change into something more generig or
-        # into a value configured by the operator.
         assert "Google Login" in r.text
+
+    def test_login_link_carries_target_param(self, client):
+        # When rendering the login page with a `target` query parameter, expect
+        # the same parameter to be added to the rendered SSO login link,
+        # example: <a href="/api/google/?target=bubaz">Google Login</a>
+        r = client.get("/login/?target=bubaz")
+        assert "target=bubaz" in r.text
 
     @pytest.mark.parametrize(
         "target_url",

--- a/conbench/tests/app/test_auth.py
+++ b/conbench/tests/app/test_auth.py
@@ -1,10 +1,9 @@
 import logging
 from urllib.parse import urljoin
 
-import requests
 import pytest
+import requests
 from bs4 import BeautifulSoup
-
 
 from ...config import TestConfig
 from ...tests.app import _asserts

--- a/conbench/tests/app/test_auth.py
+++ b/conbench/tests/app/test_auth.py
@@ -166,10 +166,16 @@ class TestLoginOIDC(_asserts.AppEndpointTest):
         if target_url is None:
             r0 = client.get("http://127.0.0.1:5000/api/google/")
         else:
-            r0 = client.get(f"http://127.0.0.1:5000/api/google?target={target_url}")
+            # The slash before the question mark is required, otherwise Flask
+            # will emit a 308 redirect to the slashy version first.
+            r0 = client.get(f"http://127.0.0.1:5000/api/google/?target={target_url}")
 
         # `r0` is meant to be a redirect response, redirecting to the identity
-        # provider. Extract the full URL we've been redirected to. The URL
+        # provider.  The redirect is expected to be delivered via a 302
+        # response.
+        assert r0.status_code == 302, f"unexpected response: {r0.text}"
+
+        # Extract the full URL we've been redirected to. The URL
         # represents a so-called authorization request, with all the parameters
         # for that request being encoded in the URL query parameters
         authorization_request_url = r0.headers["location"]

--- a/conbench/tests/app/test_auth.py
+++ b/conbench/tests/app/test_auth.py
@@ -142,7 +142,11 @@ class TestLogout(_asserts.AppEndpointTest):
 
 class TestLoginOIDC(_asserts.AppEndpointTest):
     def test_login_page_shows_sso_link(self, client):
+        # In the test suite, this is currently expected to show because
+        # GOOGLE_CLIENT_ID is set.
         r = client.get("/login/", follow_redirects=True)
+        # Note that this label should change into something more generig or
+        # into a value configured by the operator.
         assert "Google Login" in r.text
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Context: https://github.com/conbench/conbench/issues/411

This patch introduces the concept of a target URL, which is the URL that the user actually wanted to visit before they were required to log in. 

Information flow:
- If the login page is GET with a specific query parameter (`?target=<target-url>`), then the HTML template renders the SSO button/link on the login page so that it _also_ carries a query parameter with the value `<target-url>`.
- If the SSO flow is initiated with that very query parameter, then the information is retained across the flow, i.e. pushed back and forth as part of the OIDC flow in the so-called `state` parameter. 


### Discussion: (mis)usage of the `state` parameter in the so-called authorization code flow?

The security implications of the `state` parameter in the context of OpenID Connect can be quite severe, and vary depending on the exact conditions and flow type used. There is a plethora of confusing content on the Internet, and so I always like to go back to the specification.

The specification for the so-called authorization code flow lives here: https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth

In the authorization code flow the so-called access token and ID token are never seen by the user agent, but only by the relying party (conbench backend).

In the spec for that flow we see that the `state` parameter is "only" `RECOMMENDED`, not required:

> RECOMMENDED. Opaque value used to maintain state between the request and the callback. Typically, Cross-Site Request Forgery (CSRF, XSRF) mitigation is done by cryptographically binding the value of this parameter with a browser cookie.

Whether or not it's a good place to store a redirect URL, _instead of_ "cryptographically binding the value of this parameter with a browser cookie"?

From https://auth0.com/docs/secure/attack-protection/state-parameters#csrf-attacks:

>  You can use the state parameter to encode an application state that will put the user where they were before the authentication process started. 


from https://stackoverflow.com/questions/26132066/what-is-the-purpose-of-the-state-parameter-in-oauth-authorization-request:

> The developers of ckanext-oauth2 use the state parameter also to store info about the previously visited page, to redirect the user back there after login, e.g.: {"came_from": "/dashboard"}

From https://www.oauth.com/oauth2-servers/server-side-apps/authorization-code/:


> The state parameter serves two functions. When the user is redirected back to your app, whatever value you include as the state will also be included in the redirect. This gives your app a chance to persist data between the user being directed to the authorization server and back again, such as using the state parameter as a session key. This may be used to indicate what action in the app to perform after authorization is complete, for example, indicating which of your app’s pages to redirect to after authorization.

> The state parameter also serves as a CSRF protection mechanism if it contains a random value per request. When the user is redirected back to your app, double check that the state value matches what you set it to originally.


from https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow:

> A value included in the request that is also returned in the token response. It can be a string of any content that you wish. A randomly generated unique value is typically used for preventing cross-site request forgery attacks. The value can also encode information about the user's state in the app before the authentication request occurred. For instance, it could encode the page or view they were on.

---------------

If we don't use the `state` parameter for security purposes -- why not simply persist a cookie storing the 'target URL' -- it would be sent _with_ the final callback? Well, reliably linking cookie state and login flow would need some basic state management (such as manual cookie deletion). The `state` parameter provides after all a _simple_ way to carry information across the flow -- *non-securely* (if carried around w/o a cryptographic signature).


