### PR TITLE
OIDC: fix #464: hard-code scheme again (do not use WSGI info)

### DIFF
--- a/conbench/api/_docs.py
+++ b/conbench/api/_docs.py
@@ -5,6 +5,17 @@ import apispec_webframeworks.flask
 from ..api import _examples as ex
 from ..config import Config
 
+
+# `api_server_url` is used for populating the 'Servers' dropdown in the
+# Swagger/OpenAPI docs website. The default value is tailored to the Flask
+# development HTTP server defaults (non-TLS, binds on 127.0.0.1, port 5000).
+# Can be adjusted via the `--host` and `--port` command line flags when
+# invoking `flask run`.
+api_server_url = "http://127.0.0.1:5000/"
+if Config.INTENDED_BASE_URL is not None:
+    api_server_url = Config.INTENDED_BASE_URL
+
+
 spec = apispec.APISpec(
     title=Config.APPLICATION_NAME,
     version="1.0.0",
@@ -13,7 +24,7 @@ spec = apispec.APISpec(
         apispec_webframeworks.flask.FlaskPlugin(),
         apispec.ext.marshmallow.MarshmallowPlugin(),
     ],
-    servers=[{"url": Config.INTENDED_BASE_URL}],
+    servers=[{"url": api_server_url}],
 )
 
 

--- a/conbench/api/_docs.py
+++ b/conbench/api/_docs.py
@@ -5,7 +5,6 @@ import apispec_webframeworks.flask
 from ..api import _examples as ex
 from ..config import Config
 
-
 # `api_server_url` is used for populating the 'Servers' dropdown in the
 # Swagger/OpenAPI docs website. The default value is tailored to the Flask
 # development HTTP server defaults (non-TLS, binds on 127.0.0.1, port 5000).

--- a/conbench/api/_google.py
+++ b/conbench/api/_google.py
@@ -55,17 +55,20 @@ def auth_google_user():
         http://127.0.0.1:5000/api/google/callback
         https://conbench.ursa.dev/api/google/callback
 
-    Flask's url_for(..., _external=True, ...) constructs the base URL using
-    scheme, host, port information from the currently incoming HTTP request (in
-    particular from the HOST header field). Further analysis and discussion can
-    be found at
-    https://github.com/conbench/conbench/pull/454#issuecomment-1326338524
+    Scheme, host, port information depend on the deployment and cannot
+    generally be determined by the app itself (requires human input). Hence,
+    the least error-prone method is to construct the callback URL is via
+    Config.INTENDED_BASE_URL.
 
-    Technically, a more controlled and predictable way to construct the callback
-    URL would be using Config.INTENDED_BASE_URL. However, as long as that
-    configuration parameter is not required to be set to a meaningful value we
-    should not rely on that yet (breaks compatibility with old deployment
-    configs).
+    However, Config.INTENDED_BASE_URL is not yet required to be set by Conbench
+    operators (as that would break compatibility with legacy deployments). For
+    those deployments, keep using Flask's url_for(..., _external=True,
+    https=true) to construct the base URL using the host from the currently
+    incoming HTTP request (from the HOST header field). Keep hard-coding the
+    scheme to HTTPS, otherwise those legacy environments may break, too.
+    Further analysis and discussion can be found at
+    https://github.com/conbench/conbench/pull/454#issuecomment-1326338524 and
+    in https://github.com/conbench/conbench/issues/464
 
     If either redirect URL or the authorization endpoint (at the OP) do not use
     the HTTPS scheme then the oauthlib method `prepare_request_uri()` below is
@@ -74,7 +77,14 @@ def auth_google_user():
     """
 
     client, oidc_provider_config = get_oidc_client()
-    abs_oidc_callback_url = f.url_for("api.callback", _external=True)
+
+    # INTENDED_BASE_URL takes precedence.
+    if Config.INTENDED_BASE_URL is not None:
+        abs_oidc_callback_url = Config.INTENDED_BASE_URL + "api/google/callback"
+    else:
+        # Fallback method for legacy deployments that do not set
+        # INTENDED_BASE_URL. Code path is not executed by the test suite.
+        abs_oidc_callback_url = f.url_for("api.callback", _external=True, https=True)
 
     return client.prepare_request_uri(
         oidc_provider_config["authorization_endpoint"],

--- a/conbench/api/_google.py
+++ b/conbench/api/_google.py
@@ -57,7 +57,7 @@ def auth_google_user():
 
     Scheme, host, port information depend on the deployment and cannot
     generally be determined by the app itself (requires human input). Hence,
-    the least error-prone method is to construct the callback URL is via
+    the least error-prone method is to construct the callback URL via
     Config.INTENDED_BASE_URL.
 
     However, Config.INTENDED_BASE_URL is not yet required to be set by Conbench

--- a/conbench/config.py
+++ b/conbench/config.py
@@ -28,25 +28,22 @@ class Config:
     # The base URL (scheme, DNS name, path prefix) that regular HTTP clients
     # are expected to use for reaching the HTTP server exposing the app.
     # Depends on the deployment and cannot generally be determined by the app
-    # itself (requires human input). The default value is tailored to the Flask
-    # development HTTP server defaults (non-TLS, binds on 127.0.0.1, port
-    # 5000). Can be adjusted via the `--host` and `--port` command line flags
-    # when invoking `flask run`. Three interesting scenarios:
-    # - local dev setup with default listen address: no action needed
+    # itself (requires human input). Three interesting scenarios:
     # - local dev setup with custom listen address: user should set meaningful
     #   value
     # - prod/staging setup: user should set meaningful value such as for
     #   example https://conbench.ursa.dev/
     #
-    # Currently used for populating the 'Servers' dropdown in the
-    # Swagger/OpenAPI docs website.
-    INTENDED_BASE_URL = os.environ.get(
-        "CONBENCH_INTENDED_BASE_URL", "http://127.0.0.1:5000/"
-    )
+    # In the future it may be wise to require this to be set by the user,
+    # especially for enabling single sign-on. Until then, the default value of
+    # `None` is used by business logic to detect when this value was not
+    # provided, for supporting legacy configuration environments.
+    INTENDED_BASE_URL = os.environ.get("CONBENCH_INTENDED_BASE_URL", None)
+
     # Require trailing slash towards tidy URL generation.
     # Note: might want to catch bad input via e.g.
     # https://validators.readthedocs.io/en/latest/#module-validators.url
-    if not INTENDED_BASE_URL.endswith("/"):
+    if INTENDED_BASE_URL and not INTENDED_BASE_URL.endswith("/"):
         INTENDED_BASE_URL += "/"
 
     LOG_LEVEL_STDERR = os.environ.get("CONBENCH_LOG_LEVEL_STDERR", "INFO")

--- a/conbench/config.py
+++ b/conbench/config.py
@@ -25,19 +25,18 @@ class Config:
     # to recalculate history.
     DISTRIBUTION_COMMITS = int(os.environ.get("DISTRIBUTION_COMMITS", 100))
 
-    # The base URL (scheme, DNS name, path prefix) that regular HTTP clients
-    # are expected to use for reaching the HTTP server exposing the app.
-    # Depends on the deployment and cannot generally be determined by the app
-    # itself (requires human input). Three interesting scenarios:
-    # - local dev setup with custom listen address: user should set meaningful
-    #   value
-    # - prod/staging setup: user should set meaningful value such as for
-    #   example https://conbench.ursa.dev/
+    # `INTENDED_BASE_URL` is the base URL (scheme, DNS name, path prefix) that
+    # regular HTTP clients are expected to use for reaching the HTTP server
+    # exposing the app. Depends on the deployment and cannot generally be
+    # determined by the app itself (requires human input). Meaningful values
+    # may look like
     #
-    # In the future it may be wise to require this to be set by the user,
-    # especially for enabling single sign-on. Until then, the default value of
-    # `None` is used by business logic to detect when this value was not
-    # provided, for supporting legacy configuration environments.
+    #    https://conbench.ursa.dev/  or  http://127.0.0.1:9000/
+    #
+    # In the future, it may be wise to require this parameter to be set by the
+    # operator (especially for enabling single sign-on). Until then, the
+    # default value of `None` is used within app logic to detect when this
+    # value was not provided, for supporting legacy configuration environments.
     INTENDED_BASE_URL = os.environ.get("CONBENCH_INTENDED_BASE_URL", None)
 
     # Require trailing slash towards tidy URL generation.

--- a/conbench/tests/app/test_auth.py
+++ b/conbench/tests/app/test_auth.py
@@ -144,27 +144,6 @@ class TestLoginOIDC(_asserts.AppEndpointTest):
         r = client.get("/login/", follow_redirects=True)
         assert "Google Login" in r.text
 
-    def test_dynamic_callback_url(self, client):
-        """This test is mainly for demonstration purposes how the dynamic
-        OIDC callback URL construction works. One important bit that it covers
-        though is that all three parts of the base url are dynamically
-        constructed: scheme, host, port.
-
-        OIDC callback URL construction does not need to stay dynamic. If we
-        decide to make it static (based on INTENDED_BASE_URL) then this test
-        here can be removed.
-        """
-        r0 = client.get("http://foobar:7000/api/google/")
-        authorization_request_url = r0.headers["location"]
-        data = parse_qs(authorization_request_url)
-        assert "redirect_uri" in data
-        assert "foobar:7000" in data["redirect_uri"][0]
-
-        # Now check that scheme is dynamic, too.
-        data = parse_qs(client.get("https://foo/api/google/").headers["location"])
-        assert "redirect_uri" in data
-        assert "https://foo" in data["redirect_uri"][0]
-
     def test_oidc_flow_against_dex(self, client):
 
         # TODO: parse this 'initiate flow URL' from the HTML login page, i.e.

--- a/conbench/tests/app/test_auth.py
+++ b/conbench/tests/app/test_auth.py
@@ -1,5 +1,5 @@
 import logging
-from urllib.parse import parse_qs, urljoin
+from urllib.parse import urljoin
 
 import requests
 from bs4 import BeautifulSoup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       GOOGLE_CLIENT_ID: conbench-test-client
       GOOGLE_CLIENT_SECRET: AnotherStaticSecret
       CONBENCH_OIDC_ISSUER_URL: http://dex:5556/dex-for-conbench
+      CONBENCH_INTENDED_BASE_URL: http://127.0.0.1:5000/
 
   dex:
     image: dexidp/dex:v2.35.3


### PR DESCRIPTION
See #464.

The approach I opted for here required changing the default value of `Config.INTENDED_BASE_URL`, and also results in `f.url_for("api.callback", _external=True, https=True)` _not_ being covered by the test suite. Those are two reasons for why I initially decided against this approach when working on https://github.com/conbench/conbench/pull/457.

However, #464 has shown that we really need to keep the behavior of `f.url_for("api.callback", _external=True, https=True)` to keep legacy environments working.

This is now the third iteration. The confusion, complexity, error-proneness around this will decrease once we require `INTENDED_BASE_URL` to be set by Conbench operators.

