### PR TITLE
Pass CI=true to GHA tests

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -42,7 +42,10 @@ jobs:
         run: |
           docker-compose down && \
           docker-compose build app && \
-          docker-compose run -e COVERAGE_FILE=/etc/conbench-coverage-dir/.coverage app \
+          docker-compose run \
+            -e COVERAGE_FILE=/etc/conbench-coverage-dir/.coverage \
+            -e CI=true \
+            app \
             coverage run --source conbench \
               -m pytest -vv -s --durations=20 conbench/tests/
       - name: Convert coverage data to LCOV

--- a/conbench/entities/hardware.py
+++ b/conbench/entities/hardware.py
@@ -190,13 +190,7 @@ class MachineCreate(marshmallow.Schema):
 class ClusterCreate(marshmallow.Schema):
     name = marshmallow.fields.String(required=True)
     info = marshmallow.fields.Dict(required=True)
-    optional_info = marshmallow.fields.Dict(
-        required=True,
-        metadata={
-            "description": "Additional optional information about the cluster, which is not likely to impact the "
-            "benchmark performance (e.g. region, settings like logging type, etc)."
-        },
-    )
+    optional_info = marshmallow.fields.Dict(required=True)
 
 
 class MachineSchema:

--- a/conbench/entities/hardware.py
+++ b/conbench/entities/hardware.py
@@ -190,7 +190,13 @@ class MachineCreate(marshmallow.Schema):
 class ClusterCreate(marshmallow.Schema):
     name = marshmallow.fields.String(required=True)
     info = marshmallow.fields.Dict(required=True)
-    optional_info = marshmallow.fields.Dict(required=True)
+    optional_info = marshmallow.fields.Dict(
+        required=True,
+        metadata={
+            "description": "Additional optional information about the cluster, which is not likely to impact the "
+            "benchmark performance (e.g. region, settings like logging type, etc)."
+        },
+    )
 
 
 class MachineSchema:


### PR DESCRIPTION
In [this PR](https://github.com/conbench/conbench/pull/463#issuecomment-1331464712) we found that CI was not failing when the expected OpenAPI docs did not match the actual generated docs. 

This is because #459 changed the tests to run inside docker-compose, so the `CI=true` environment variable was not set anymore -- so the test assumed we were running locally, manually changed `_expected_docs.py`, and succeeded.