### PR TITLE
app startup: log sanitized config on INFO level

### DIFF
--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -148,13 +148,22 @@ def dict_or_objattrs_to_nonsensitive_string(obj):
         keys = list(obj.keys())
         values = list(obj.values())
     else:
-        keys = list(dir(obj))
-        values = [getattr(obj, k) for k in keys if not k.startswith("_")]
+        keys = list(k for k in dir(obj) if not k.startswith("_"))
+        values = [getattr(obj, k) for k in keys]
 
     sanitized = {}
 
     # Iterate over all object and class attributes,
     for k, v in zip(keys, values):
+
+        if v is None:
+            # Keep None's as they are in the output.
+            sanitized[k] = v
+            continue
+
+        # Skip if value does not appear to be a string.
+        if not isinstance(v, str):
+            continue
 
         for fragment in sensitive_key_fragments:
             if fragment.lower() in k.lower():

--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -34,10 +34,20 @@ def create_application(config):
         level_sqlalchemy=app.config["LOG_LEVEL_SQLALCHEMY"],
     )
 
-    log.debug(
-        "flask app config:\n%s",
-        json.dumps(app.config, sort_keys=True, default=str, indent=2),
+    # TODO: sanitize sensitive configuration values so that the INFO log of the
+    # app does not contain obvious secrets.
+    log_cfg_msg = "app config object:\n" + json.dumps(
+        app.config, sort_keys=True, default=str, indent=2
     )
+
+    # In non-testing, INFO-log the configuration details. In testing, DEBUG-log
+    # them (in the test suite, the app gets re-initialized for each test).
+    # Note: maybe change the test suite to init the app object only once.
+    if app.config.TESTING:
+        log.debug(log_cfg_msg)
+    else:
+        log.info(log_cfg_msg)
+
     return app
 
 

--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -156,13 +156,10 @@ def dict_or_objattrs_to_nonsensitive_string(obj):
     # Iterate over all object and class attributes,
     for k, v in zip(keys, values):
 
-        if v is None:
-            # Keep None's as they are in the output.
-            sanitized[k] = v
-            continue
-
-        # Skip if value does not appear to be a string.
         if not isinstance(v, str):
+            # Keep Nones and booleans as they are (stringified after all
+            # by json.dumps() below)
+            sanitized[k] = v
             continue
 
         for fragment in sensitive_key_fragments:

--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -156,6 +156,11 @@ def dict_or_objattrs_to_nonsensitive_string(obj):
     # Iterate over all object and class attributes,
     for k, v in zip(keys, values):
 
+        if not isinstance(k, str):
+            # We may get here when `obj` is a dictionary with non-string keys.
+            # Ignore those keys in textual output.
+            continue
+
         if not isinstance(v, str):
             # Keep Nones and booleans as they are (stringified after all
             # by json.dumps() below)

--- a/conbench/api/_google.py
+++ b/conbench/api/_google.py
@@ -1,6 +1,5 @@
 import base64
 import logging
-import os
 import time
 
 import flask as f

--- a/conbench/api/_google.py
+++ b/conbench/api/_google.py
@@ -171,7 +171,7 @@ def conclude_oidc_flow():
     # this legacy hack in place for legacy deployments. This test-specific
     # logic can disappear once INTENDED_BASE_URL becomes required.
     cur_request_url_wo_query = f.request.base_url
-    if os.getenv("FLASK_ENV", "None") != "development":
+    if not Config.TESTING:
         cur_request_url_wo_query = cur_request_url_wo_query.replace(
             "http://", "https://"
         )

--- a/conbench/config.py
+++ b/conbench/config.py
@@ -77,6 +77,15 @@ class Config:
         assert OIDC_CLIENT_ID is not None
         assert OIDC_CLIENT_SECRET is not None
 
+    # Introduce a `Config.TESTING` boolean that application logic can use to
+    # know when code is executed in the context of the test suite. This can be
+    # useful for example for logging more or less detail in the context of the
+    # test suite. For now use the FLASK_ENV environment variable to detect
+    # this.
+    TESTING = False
+    if os.environ.get("FLASK_ENV", "development"):
+        TESTING = True
+
 
 class TestConfig(Config):
     DB_NAME = os.environ.get("DB_NAME", f"{APPLICATION_NAME.lower()}_test")

--- a/conbench/config.py
+++ b/conbench/config.py
@@ -5,6 +5,7 @@ APPLICATION_NAME = "Conbench"
 
 
 class Config:
+
     APPLICATION_NAME = os.environ.get("APPLICATION_NAME", APPLICATION_NAME)
     DB_HOST = os.environ.get("DB_HOST", "localhost")
     DB_NAME = os.environ.get("DB_NAME", f"{APPLICATION_NAME.lower()}_prod")


### PR DESCRIPTION
For now, log two configuration objects of relevance: the app's global config object, and the derived Flask config object. (we seem to mix usage both, and for debugging it's important to have both).

How this looks on my machine:
```
[221202-13:18:32.499] [1] [conbench] DEBUG: Flask app config object:
{
  "APPLICATION_NAME": "Conbench",
  "APPLICATION_ROOT": "/",
  "BOOTSTRAP_CDN_FORCE_SSL": false,
  "BOOTSTRAP_LOCAL_SUBDOMAIN": null,
  "BOOTSTRAP_QUERYSTRING_REVVING": true,
  "BOOTSTRAP_SERVE_LOCAL": false,
  "BOOTSTRAP_USE_MINIFIED": true,
  "CREATE_ALL_TABLES": true,
  "DB_HOST": "db",
  "DB_NAME": "postgres",
  "DB_PASSWORD": "*******res",
  "DB_PORT": "5432",
  "DB_USERNAME": "postgres",
  "DEBUG": true,
  "DISTRIBUTION_COMMITS": 100,
  "ENV": "development",
  "EXPLAIN_TEMPLATE_LOADING": false,
  "INTENDED_BASE_URL": "http://127.0.0.1:5000/",
  "JSONIFY_MIMETYPE": null,
  "JSONIFY_PRETTYPRINT_REGULAR": null,
  "JSON_AS_ASCII": null,
  "JSON_SORT_KEYS": null,
  "LOG_LEVEL_FILE": null,
  "LOG_LEVEL_SQLALCHEMY": "WARNING",
  "LOG_LEVEL_STDERR": "DEBUG",
  "MAX_CONTENT_LENGTH": null,
  "MAX_COOKIE_SIZE": 4093,
  "OIDC_CLIENT_ID": "conbench-test-client",
  "OIDC_CLIENT_SECRET": "*******ret",
  "OIDC_ISSUER_URL": "http://dex:5556/dex-for-conbench",
  "PERMANENT_SESSION_LIFETIME": "31 days, 0:00:00",
  "PREFERRED_URL_SCHEME": "http",
  "PROPAGATE_EXCEPTIONS": null,
  "REGISTRATION_KEY": "*******ode",
  "SECRET_KEY": "******* TV",
  "SEND_FILE_MAX_AGE_DEFAULT": null,
  "SERVER_NAME": null,
  "SESSION_COOKIE_DOMAIN": null,
  "SESSION_COOKIE_HTTPONLY": true,
  "SESSION_COOKIE_NAME": "session",
  "SESSION_COOKIE_PATH": null,
  "SESSION_COOKIE_SAMESITE": null,
  "SESSION_COOKIE_SECURE": false,
  "SESSION_REFRESH_EACH_REQUEST": true,
  "SQLALCHEMY_DATABASE_URI": "postgresql://postgres:postgres@db:5432/postgres",
  "TEMPLATES_AUTO_RELOAD": null,
  "TESTING": true,
  "TRAP_BAD_REQUEST_ERRORS": null,
  "TRAP_HTTP_EXCEPTIONS": false,
  "USE_X_SENDFILE": false
}

Conbench config object:
{
  "APPLICATION_NAME": "Conbench",
  "CREATE_ALL_TABLES": true,
  "DB_HOST": "db",
  "DB_NAME": "postgres",
  "DB_PASSWORD": "*******res",
  "DB_PORT": "5432",
  "DB_USERNAME": "postgres",
  "DISTRIBUTION_COMMITS": 100,
  "INTENDED_BASE_URL": "http://127.0.0.1:5000/",
  "LOG_LEVEL_FILE": null,
  "LOG_LEVEL_SQLALCHEMY": "WARNING",
  "LOG_LEVEL_STDERR": "DEBUG",
  "OIDC_CLIENT_ID": "conbench-test-client",
  "OIDC_CLIENT_SECRET": "*******ret",
  "OIDC_ISSUER_URL": "http://dex:5556/dex-for-conbench",
  "REGISTRATION_KEY": "*******ode",
  "SECRET_KEY": "******* TV",
  "SQLALCHEMY_DATABASE_URI": "postgresql://postgres:postgres@db:5432/postgres",
  "TESTING": true
}
```
