### PR TITLE
config: repair TESTING detection

### DIFF
--- a/conbench/config.py
+++ b/conbench/config.py
@@ -84,7 +84,7 @@ class Config:
     # test suite. For now use the FLASK_ENV environment variable to detect
     # this.
     TESTING = False
-    if os.environ.get("FLASK_ENV", "development"):
+    if os.environ.get("FLASK_ENV") == "development":
         TESTING = True
 
 


### PR DESCRIPTION
I was just browsing through Conbench instance logs and did not see the config being logged on INFO level. I expected that after https://github.com/conbench/conbench/pull/489. Found the oversight.