### PR TITLE
config: make INTENDED_BASE_URL required

### DIFF
--- a/conbench/config.py
+++ b/conbench/config.py
@@ -73,12 +73,6 @@ class ConfigClass:
     def __init__(self):
         self.OIDC_ISSUER_URL = self._get_oidc_issuer_url_from_env_or_exit()
 
-class TestConfig(Config):
-    DB_NAME = os.environ.get("DB_NAME", f"{APPLICATION_NAME.lower()}_test")
-    SQLALCHEMY_DATABASE_URI = (
-        f"postgresql://{Config.DB_USERNAME}:{Config.DB_PASSWORD}"
-        f"@{Config.DB_HOST}:{Config.DB_PORT}/{DB_NAME}"
-    )
     def _get_oidc_issuer_url_from_env_or_exit(self) -> Optional[str]:
         """Return `None` or a string.
 

--- a/conbench/config.py
+++ b/conbench/config.py
@@ -18,7 +18,12 @@ class ConfigClass:
     SQLALCHEMY_DATABASE_URI = (
         f"postgresql://{DB_USERNAME}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
     )
+
+    # When this appears to be `true` then the application initialization phase
+    # executes code that _attempts_ to create all database tables. That code
+    # does not error out when it finds that the database tables already exist.
     CREATE_ALL_TABLES = os.environ.get("CREATE_ALL_TABLES", "true") == "true"
+
     # An integer number of commits to use when calculating
     # statistics. The default is 100; larger numbers will lead to more false negatives,
     # especially after large changes. We recommend leaving it as the default. Previously

--- a/conbench/config.py
+++ b/conbench/config.py
@@ -77,6 +77,9 @@ class ConfigClass:
         """
         ibu = os.environ.get("CONBENCH_INTENDED_BASE_URL", None)
 
+        if ibu is None:
+            sys.exit("enviroment: CONBENCH_INTENDED_BASE_URL is required but not set")
+
         # Strip leading and trailing whitespace.
         ibu = ibu.strip()
 
@@ -91,7 +94,7 @@ class ConfigClass:
 
         return ibu
 
-    def _get_oidc_issuer_url_from_env_or_exit(self) -> Optional[str]:
+    def _get_oidc_issuer_url_from_env_or_exit(self) -> str:
         """Return `None` or a string.
 
         If `OIDC_ISSUER_URL` is after all `None`: disable OpenID Connect (OIDC)

--- a/conbench/config.py
+++ b/conbench/config.py
@@ -1,12 +1,11 @@
 import getpass
 import os
 
-APPLICATION_NAME = "Conbench"
 
 
 class Config:
 
-    APPLICATION_NAME = os.environ.get("APPLICATION_NAME", APPLICATION_NAME)
+    APPLICATION_NAME = os.environ.get("APPLICATION_NAME", "Conbench")
     DB_HOST = os.environ.get("DB_HOST", "localhost")
     DB_NAME = os.environ.get("DB_NAME", f"{APPLICATION_NAME.lower()}_prod")
     DB_PASSWORD = os.environ.get("DB_PASSWORD", "postgres")

--- a/conbench/config.py
+++ b/conbench/config.py
@@ -1,7 +1,6 @@
 import getpass
 import os
 import sys
-
 from typing import Optional
 
 

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -1275,7 +1275,7 @@
             },
         },
     },
-    "info": {"title": "Conbench", "version": "1.0.0"},
+    "info": {"title": "conbench-for-pytest", "version": "1.0.0"},
     "openapi": "3.0.2",
     "paths": {
         "/api/": {

--- a/conbench/tests/app/_asserts.py
+++ b/conbench/tests/app/_asserts.py
@@ -115,7 +115,7 @@ class ListEnforcer(Enforcer):
         self.logout(client)
         response = client.get(self.url, follow_redirects=True)
         assert new_id.encode() not in response.data
-        assert b"Sign In - Conbench" in response.data, response.data
+        assert b"Sign In - conbench-for-pytest" in response.data, response.data
 
 
 class GetEnforcer(Enforcer):
@@ -146,16 +146,16 @@ class GetEnforcer(Enforcer):
         self.logout(client)
         response = client.get(entity_url, follow_redirects=True)
         assert new_id.encode() not in response.data
-        assert b"Sign In - Conbench" in response.data, response.data
+        assert b"Sign In - conbench-for-pytest" in response.data, response.data
 
     def test_unknown(self, client):
         self.authenticate(client)
         unknown_url = self.url.format("unknown")
         response = client.get(unknown_url, follow_redirects=True)
         if getattr(self, "redirect_on_unknown", True):
-            assert b"Home - Conbench" in response.data, response.data
+            assert b"Home - conbench-for-pytest" in response.data, response.data
         else:
-            title = "{} - Conbench".format(self.title).encode()
+            title = "{} - conbench-for-pytest".format(self.title).encode()
             assert title in response.data, response.data
 
 

--- a/conbench/tests/app/test_hardware.py
+++ b/conbench/tests/app/test_hardware.py
@@ -27,7 +27,7 @@ class TestHardware(_asserts.AppEndpointTest):
         self.authenticate(client)
         response = client.get(f"/hardware/{hardware_id}/")
         self.assert_page(response, "Hardware")
-        assert "Hardware - Conbench".encode() in response.data
+        assert "Hardware - conbench-for-pytest".encode() in response.data
 
     def test_hardware_get_unauthenticated(self, client):
         self.create_benchmark(client)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - dex
       - db
     environment:
-      APPLICATION_NAME: "Conbench"
+      APPLICATION_NAME: "conbench-for-pytest"
       DB_USERNAME: "postgres"
       # From the docker-compose docs: "By default Compose sets up a single
       # network for your app. Each container for a service joins the default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       dockerfile: Dockerfile
     command: ["alembic", "upgrade", "head"]
     environment:
-      APPLICATION_NAME: "Conbench"
+      APPLICATION_NAME: "conbench-for-pytest"
       CREATE_ALL_TABLES: "false"
       DB_USERNAME: "postgres"
       DB_HOST: "db"
@@ -72,6 +72,7 @@ services:
       FLASK_ENV: "development"
       REGISTRATION_KEY: "code"
       SECRET_KEY: "Person, woman, man, camera, TV"
+      CONBENCH_INTENDED_BASE_URL: http://127.0.0.1:5000/
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
A few more changes on this PR.

For example, this changes the `Config` object being an instantiated class object instead of just being a class constructor. See commit messages for more detail.