### PR TITLE
buildkite: disable conbench-deploy trigger

### DIFF
--- a/.buildkite/conbench-test/pipeline.yml
+++ b/.buildkite/conbench-test/pipeline.yml
@@ -26,10 +26,3 @@ steps:
     command: "exit 0"
     concurrency: 1
     concurrency_group: "conbench-deploy"
-
-  - label: "Deploy"
-    depends_on: "concurrency-gate"
-    trigger: "conbench-deploy"
-    if: build.branch == 'main'
-    build:
-      commit: "$BUILDKITE_COMMIT"


### PR DESCRIPTION
Quoting the commit msg:
```
Effectively, this disables auto-deploy
to conbench.ursa.dev upon a merge-to-main.

In more specific terms, this disables
triggering the pipeline

  apache-arrow/conbench-deploy

at the end of pipeline

  apache-arrow/conbench-test

(when the branch name is `main`).

What's not visible in this commit is
that we add a new build trigger for
another buildkite pipeline that will
deploy after merge-to-main into a
more appropriate staging environment.
```