### PR TITLE
oidc: introduce parse_state_from_authorization_response(), fix state parser

### DIFF
--- a/conbench/api/_google.py
+++ b/conbench/api/_google.py
@@ -4,11 +4,9 @@ import time
 
 import flask as f
 import requests
-
 from oauthlib.oauth2 import WebApplicationClient
 
 from ..config import Config
-
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
The business logic in the callback endpoint became spaghetti code. Factor this part of the work out in its own function.

The two input parameters are now documented nicely, also via type annotations. At the heart this patch includes a change from `parse_request_uri_response(f.request.url)` to `parse_request_uri_response(cur_request_url_abs)` which addresses an oauthlib `insecure_transport` error (see code comments for a better explanation)