### PR TITLE
Introduce Makefile, clarify that Conbench wants Python 3.10

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -19,17 +19,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - name: Lint (black)
-        uses: psf/black@stable
-        with:
-          options: --check --diff
-          src: .
-      - name: Install flake8, isort
-        run: pip install flake8 isort
-      - name: Lint (flake8)
-        run: flake8
-      - name: Lint (isort)
-        run: isort --check .
+      - name: Install linting dependencies
+        run: pip install flake8 isort black
+      - name: Lint
+        run: make lint-ci
       - name: Start PostgreSQL DB
         run: docker-compose run --detach db
       # Run `alembic upgrade head` via docker-compose so that it is within
@@ -39,15 +32,9 @@ jobs:
         env:
           CREATE_ALL_TABLES: false
       - name: Run tests, generate coverage data
-        run: |
-          docker-compose down && \
-          docker-compose build app && \
-          docker-compose run \
-            -e COVERAGE_FILE=/etc/conbench-coverage-dir/.coverage \
-            -e CI=true \
-            app \
-            coverage run --source conbench \
-              -m pytest -vv -s --durations=20 conbench/tests/
+        # This is expected to create /etc/conbench-coverage-dir/.coverage
+        # in the `app` service container.
+        run: make tests
       - name: Convert coverage data to LCOV
         run: |
           docker-compose run -e COVERAGE_FILE=/etc/conbench-coverage-dir/.coverage app \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.10
 
 COPY requirements-build.txt /tmp/
 COPY requirements-test.txt /tmp/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+
+
+
+.PHONY: tests
+tests:
+	docker-compose down && \
+	docker-compose build app && \
+	docker-compose run \
+	-e COVERAGE_FILE=/etc/conbench-coverage-dir/.coverage \
+	-e CI=true \
+	app \
+	coverage run --source conbench \
+		-m pytest -vv -s --durations=20 conbench/tests/
+
+# For developers, these commands may and should modify local files if possible.
+.PHONY: lint
+lint:
+	flake8
+	isort .
+	black --diff .
+
+# Run by CI, these commands should not modify files, but only check compliance.
+.PHONY: lint-ci
+lint-ci:
+	flake8
+	isort --check .
+	black --check --diff .
+
+

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ repository, and the results are hosted on the
     $ python3 -m venv conbench
     $ source conbench/bin/activate
 
+Note that the CPython version that Conbench is tested with in CI and that it is recommended to be deployed with is currently the latest 3.10.x release, as also defined in `Dockerfile` at the root of this repository.
+
 
 ### Clone repository
     (conbench) $ cd ~/workspace/


### PR DESCRIPTION
Context:

https://github.com/conbench/conbench/issues/503
https://github.com/conbench/conbench/issues/501

I am already excited about doing `make lint` before committing and/or pushing.

This is also a great step forward towards additional documentation for "the recommended way to run tests", relating to https://github.com/conbench/conbench/pull/468.

The existing documentation is good for fine-grained usage of the test runner (which may involve running only a subset, etc). However, it's also important that we can document something like: "CI uses `make tests`, and you should run that locally, too".