### PR TITLE
tests: speedup: empty tables instead of drop_all/create_all

### DIFF
--- a/conbench/db.py
+++ b/conbench/db.py
@@ -1,6 +1,5 @@
 import functools
 import logging
-import time
 
 import sqlalchemy.exc
 import tenacity

--- a/conbench/db.py
+++ b/conbench/db.py
@@ -1,9 +1,13 @@
+import functools
 import logging
+import time
 
 import sqlalchemy.exc
 import tenacity
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
+
+from .config import Config
 
 engine = None
 session_maker = sessionmaker(future=True)
@@ -24,6 +28,50 @@ def configure_engine(url):
         connect_args={"options": "-c timezone=utc -c statement_timeout=30s"},
     )
     session_maker.configure(bind=engine)
+
+
+# compute this only once.
+@functools.cache
+def get_tables_in_cleanup_order():
+    # We need to remove rows from the many-to-many tables first to avoid
+    # foreign key violations.
+
+    from .entities._entity import Base as delarative_base
+
+    tables = delarative_base.metadata.sorted_tables
+
+    sort_by_name = ["benchmark_result", "run"]
+
+    tabledict = {t.name: t for t in tables}
+    sorted_tables = []
+    for name in sort_by_name:
+        # find table with that name, destructure `tabledict`. Assume that
+        # `sort_by_name` only contains known table names.
+        sorted_tables.append(tabledict.pop(name))
+
+    unsorted_tables = list(tabledict.values())
+
+    # Stich both lists together.
+    return sorted_tables + unsorted_tables
+
+
+def empty_db_tables():
+    """
+    For speeding up the test suite.
+
+    Make sure that all tables are empty. A drop_all()/create_all() is a little
+    slower than deleting individual table contents, especially when not using
+    an in-memory database, as of the file system operations.
+    """
+    if not Config.TESTING:
+        log.warning("empty_db_tables() called in non-testing mode, skip")
+        return
+
+    tables = get_tables_in_cleanup_order()
+
+    for table in tables:
+        Session.execute(table.delete())
+        log.debug("deleted table: %s", table)
 
 
 def log_after_retry_attempt(retry_state: tenacity.RetryCallState):

--- a/conbench/tests/conftest.py
+++ b/conbench/tests/conftest.py
@@ -2,17 +2,26 @@ import pytest
 
 from .. import create_application
 from ..config import TestConfig
-from ..db import Session, configure_engine, create_all, drop_all
+from ..db import Session, configure_engine, create_all, drop_all, empty_db_tables
 
 pytest.register_assert_rewrite("conbench.tests.api._asserts")
 pytest.register_assert_rewrite("conbench.tests.app._asserts")
 
 
-@pytest.fixture(autouse=True)
-def create_db():
+# Session-scope fixture, i.e. run this _once_ per test suite.
+@pytest.fixture(scope="session")
+def create_db_tables():
     configure_engine(TestConfig.SQLALCHEMY_DATABASE_URI)
     drop_all()
     create_all()
+
+
+# Run this once per test, i.e. this can get expensive and contribute
+# significantly to the duration of the test suite. `empty_db_tables()` is meant
+# to be faster than drop_all()/create_all().
+@pytest.fixture(autouse=True)
+def clear_db_state_between_tests():
+    empty_db_tables()
 
 
 @pytest.fixture


### PR DESCRIPTION
commit msg:
```
This is based on prior experience.
In my local environment that speeds up the test
suite duration from ~120 seconds to ~80 seconds.

In GHA the test suite takes considerably longer
(~300 seconds), and the same relative speedup
would be be a noticable wall time win.
```