### PR TITLE
makefile: cmd to recreate expected api docs

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -66,3 +66,8 @@ jobs:
       - name: Test benchconnect
         run: |
           pytest -vv benchconnect
+      # This is to confirm that commonly used developer commands still work
+      - name: Test dev commands
+        run: |
+          make rebuild-expected-api-docs
+

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
+# Note(JP): we will have to figure out which of these targets will transition
+# to be 'public interface', i.e. used by developers. Those should only
+# conservatively be changed (in terms of naming and behavior). Other Makefile
+# targets might be considered 'private interface', to make things in CI simpler
+# -- those targets can change at will, often and brutally (their names, their
+# meaning, and their implementation)
 
-
-
+# This is used by CI for running the test suite. Documentation should encourage
+# developers to run this command locally, too.
 .PHONY: tests
 tests:
 	docker-compose down && \
@@ -12,12 +18,14 @@ tests:
 	coverage run --source conbench \
 		-m pytest -vv -s --durations=20 conbench/tests/
 
+
 # For developers, these commands may and should modify local files if possible.
 .PHONY: lint
 lint:
 	flake8
 	isort .
 	black --diff .
+
 
 # Run by CI, these commands should not modify files, but only check compliance.
 .PHONY: lint-ci
@@ -27,3 +35,17 @@ lint-ci:
 	black --check --diff .
 
 
+.PHONY: rebuild-expected-api-docs
+rebuild-expected-api-docs: run-app-in-background
+	echo "using $(shell docker-compose port app 5000) to reach app"
+	curl --silent --show-error --fail --retry 10 \
+		--retry-all-errors --retry-delay 1 --retry-max-time 30 \
+			http://$(shell docker-compose port app 5000)/api/docs.json > _new_api_docs.json
+	docker compose down
+	python -c "import json; print(str(json.loads(open('_new_api_docs.json').read())))" > _new_api_docs.py
+	black _new_api_docs.py
+	mv -f _new_api_docs.py ./conbench/tests/api/_expected_docs.py
+
+.PHONY: run-app-in-background
+run-app-in-background:
+	docker compose up --build --wait --detach

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ rebuild-expected-api-docs: run-app-in-background
 	python -c "import json; print(str(json.loads(open('_new_api_docs.json').read())))" > _new_api_docs.py
 	black _new_api_docs.py
 	mv -f _new_api_docs.py ./conbench/tests/api/_expected_docs.py
+	git diff ./conbench/tests/api/_expected_docs.py
+
 
 .PHONY: run-app-in-background
 run-app-in-background:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,3 +64,5 @@ services:
       interval: 2s
       timeout: 5s
       retries: 5
+    ports:
+      - "5432:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,15 @@
-
-version: '3.5'
+version: "3.9"
 services:
   app:
     build:
       context: .
       dockerfile: Dockerfile
     command: ["gunicorn", "-b", "0.0.0.0:5000", "-w", "5", "conbench:application", "--access-logfile=-", "--error-logfile=-", "--preload"]
+    ports:
+      # `docker-compose port app 5000` will return the port on the host that
+      # can be used to reach the internal port 5000. The host port is dynamic
+      # to survive collisions.
+      - "127.0.0.1::5000"
     volumes:
       - ${PWD}/_conbench-coverage-dir:/etc/conbench-coverage-dir
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,12 @@ services:
       GOOGLE_CLIENT_SECRET: AnotherStaticSecret
       CONBENCH_OIDC_ISSUER_URL: http://dex:5556/dex-for-conbench
       CONBENCH_INTENDED_BASE_URL: http://127.0.0.1:5000/
+    healthcheck:
+      test: "curl -sfS http://0.0.0.0:5000/api/ping/"
+      interval: 5s
+      timeout: 20s
+      retries: 5
+
 
   dex:
     image: dexidp/dex:v2.35.3
@@ -55,6 +61,6 @@ services:
       POSTGRES_PASSWORD: "postgres"
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
-      interval: 10s
+      interval: 2s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
This PR brings a number of subtle, but important changes in `docker-compose.yml` towards a new command `make rebuild-expected-api-docs`.

The commit messages should be insightful.

Tested locally:
```
± make rebuild-expected-api-docs
docker compose up --build --wait --detach
[+] Building 2.5s (13/13) FINISHED                                                                                                            
 => [internal] load build definition from Dockerfile                                                                                     0.0s
 => => transferring dockerfile: 91B                                                                                                      0.0s
 => [internal] load .dockerignore                                                                                                        0.0s
 => => transferring context: 2B                                                                                                          0.0s
 => [internal] load metadata for docker.io/library/python:3.10                                                                           0.0s
 => [1/8] FROM docker.io/library/python:3.10                                                                                             0.0s
 => [internal] load build context                                                                                                        0.1s
 => => transferring context: 645.70kB                                                                                                    0.0s
 => CACHED [2/8] COPY requirements-build.txt /tmp/                                                                                       0.0s
 => CACHED [3/8] COPY requirements-test.txt /tmp/                                                                                        0.0s
 => CACHED [4/8] RUN pip install -r /tmp/requirements-build.txt                                                                          0.0s
 => CACHED [5/8] RUN pip install -r /tmp/requirements-test.txt                                                                           0.0s
 => CACHED [6/8] WORKDIR /app                                                                                                            0.0s
 => [7/8] ADD . /app                                                                                                                     0.1s
 => [8/8] RUN pip install .                                                                                                              1.3s
 => exporting to image                                                                                                                   0.9s
 => => exporting layers                                                                                                                  0.9s
 => => writing image sha256:986c955f4d742959ed340359734c28a02f57df0720fa8ebe83153586687356b0                                             0.0s 
 => => naming to docker.io/library/conbench-app                                                                                          0.0s 
                                                                                                                                              
Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them                                          
[+] Running 4/4
 ⠿ Network conbench_default  Created                                                                                                     0.1s
 ⠿ Container conbench-db-1   Healthy                                                                                                     2.7s
 ⠿ Container conbench-dex-1  Healthy                                                                                                     1.2s
 ⠿ Container conbench-app-1  Healthy                                                                                                     6.1s
echo "using 127.0.0.1:49198 to reach app"
using 127.0.0.1:49198 to reach app
curl --silent --show-error --fail --retry 10 \
	--retry-all-errors --retry-delay 1 --retry-max-time 30 \
		http://127.0.0.1:49198/api/docs.json > _new_api_docs.json
docker compose down
[+] Running 4/4
 ⠿ Container conbench-app-1  Removed                                                                                                     1.3s
 ⠿ Container conbench-db-1   Removed                                                                                                     0.4s
 ⠿ Container conbench-dex-1  Removed                                                                                                     0.2s
 ⠿ Network conbench_default  Removed                                                                                                     0.2s
python -c "import json; print(str(json.loads(open('_new_api_docs.json').read())))" > _new_api_docs.py
black _new_api_docs.py
reformatted _new_api_docs.py

All done! ✨ 🍰 ✨
1 file reformatted.
mv -f _new_api_docs.py ./conbench/tests/api/_expected_docs.py
git diff ./conbench/tests/api/_expected_docs.py
```