### PR TITLE
README and Makefile: first-class common developer workflows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,8 @@ rebuild-expected-api-docs: run-app-in-background
 
 .PHONY: run-app
 run-app:
-	docker compose down && docker compose up --build
+	export DCOMP_CONBENCH_HOST_PORT=127.0.0.1:5000 && \
+		docker compose down && docker compose up --build
 
 
 .PHONY: run-app-in-background

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,15 @@ services:
       dockerfile: Dockerfile
     command: ["gunicorn", "-b", "0.0.0.0:5000", "-w", "5", "conbench:application", "--access-logfile=-", "--error-logfile=-", "--preload"]
     ports:
-      # `docker-compose port app 5000` will return the port on the host that
-      # can be used to reach the internal port 5000. The host port is dynamic
-      # to survive collisions.
-      - "127.0.0.1::5000"
+      # When using the default value `127.0.0.1::5000` (two colons) then the
+      # container-internal port 5000 will be dynamically mapped to a free port
+      # on the host, on the interface represented by 127.0.0.1. In that case,
+      # the command `docker-compose port app 5000` will return the port on the
+      # host. If a definite port on the host is required (which may of course
+      # fail if it's already in use), set the environment variable
+      # DCOMP_CONBENCH_HOST_PORT to e.g. 127.0.0.1:5000 (that tries to bind to
+      # port 5000 on the host).
+      - ${DCOMP_CONBENCH_HOST_PORT:-127.0.0.1:}:5000
     volumes:
       - ${PWD}/_conbench-coverage-dir:/etc/conbench-coverage-dir
     depends_on:
@@ -44,7 +49,6 @@ services:
       interval: 5s
       timeout: 20s
       retries: 5
-
 
   dex:
     image: dexidp/dex:v2.35.3


### PR DESCRIPTION
This change makes `make run-app` useful. I hope.

The README change is to document:

- `make tests`
- `make lint`
- `make run-app`

It also documents that the canonical way to run things is based on container images.

The updated README acknowledges that many workflows require to execute things straight on the host, and provides recommendations for that.

The rendered changes can be looked at here: https://github.com/conbench/conbench/tree/2689b91b20ab5f43d273370ee5233ba5ac9150cf#contributing