### PR TITLE
access control: retain target URL as query parm when redirecting to the login page

### DIFF
--- a/conbench/app/_endpoint.py
+++ b/conbench/app/_endpoint.py
@@ -1,14 +1,11 @@
 import logging
 import os
+from typing import Optional
 
 import flask as f
 import flask.views
 import flask_login
-
 from flask import Response
-
-
-from typing import Optional
 
 log = logging.getLogger(__name__)
 

--- a/conbench/app/batches.py
+++ b/conbench/app/batches.py
@@ -34,8 +34,9 @@ class BatchPlot(AppEndpoint, ContextMixin):
         )
 
     def get(self, batch_id):
-        if self.public_data_off():
-            return self.redirect("app.login")
+        resp = self.authorize_or_terminate()
+        if resp is not None:
+            return resp
 
         benchmarks, response = self._get_benchmarks(batch_id)
         if response.status_code != 200:

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -147,8 +147,9 @@ class Benchmark(AppEndpoint, BenchmarkMixin, RunMixin, TimeSeriesPlotMixin):
         )
 
     def get(self, benchmark_id):
-        if self.public_data_off():
-            return self.redirect("app.login")
+        resp = self.authorize_or_terminate()
+        if resp is not None:
+            return resp
 
         benchmark, run = self._get_benchmark_and_run(benchmark_id)
         return self.page(benchmark, run, DeleteForm())
@@ -204,8 +205,9 @@ class BenchmarkList(AppEndpoint, ContextMixin):
         )
 
     def get(self):
-        if self.public_data_off():
-            return self.redirect("app.login")
+        resp = self.authorize_or_terminate()
+        if resp is not None:
+            return resp
 
         benchmarks, response = self._get_benchmarks()
         if response.status_code != 200:

--- a/conbench/app/compare.py
+++ b/conbench/app/compare.py
@@ -138,8 +138,9 @@ class Compare(AppEndpoint, BenchmarkMixin, RunMixin, TimeSeriesPlotMixin):
         return plot
 
     def get(self, compare_ids):
-        if self.public_data_off():
-            return self.redirect("app.login")
+        resp = self.authorize_or_terminate()
+        if resp is not None:
+            return resp
 
         threshold = f.request.args.get("threshold")
         threshold_z = f.request.args.get("threshold_z")

--- a/conbench/app/index.py
+++ b/conbench/app/index.py
@@ -19,8 +19,9 @@ class Index(AppEndpoint, RunMixin):
         )
 
     def get(self):
-        if self.public_data_off():
-            return self.redirect("app.login")
+        resp = self.authorize_or_terminate()
+        if resp is not None:
+            return resp
 
         runs = self.get_display_runs()
         return self.page(runs)

--- a/conbench/app/runs.py
+++ b/conbench/app/runs.py
@@ -43,8 +43,9 @@ class Run(AppEndpoint, ContextMixin, RunMixin, TimeSeriesPlotMixin):
         )
 
     def get(self, run_id):
-        if self.public_data_off():
-            return self.redirect("app.login")
+        resp = self.authorize_or_terminate()
+        if resp is not None:
+            return resp
 
         contender_run, baseline_run = self.get_display_run(run_id), None
         if contender_run:

--- a/conbench/tests/app/_asserts.py
+++ b/conbench/tests/app/_asserts.py
@@ -1,6 +1,5 @@
 import logging
 import re
-
 import urllib.parse
 
 from ...tests.api import _fixtures

--- a/conbench/tests/app/_asserts.py
+++ b/conbench/tests/app/_asserts.py
@@ -1,7 +1,12 @@
+import logging
 import re
+
+import urllib.parse
 
 from ...tests.api import _fixtures
 from ...tests.helpers import _create_fixture_user, create_random_user
+
+log = logging.getLogger(__name__)
 
 
 class AppEndpointTest:
@@ -142,11 +147,56 @@ class GetEnforcer(Enforcer):
         new_id = self._create(client)
         entity_url = self.url.format(new_id)
 
+        # expect this to be a relative url with a trailing slash, example:
+        # /batches/7b2fdd9f929d47b9960152090d47f8e6/
+        log.debug("entity url: %s", entity_url)
+
         monkeypatch.setenv("BENCHMARKS_DATA_PUBLIC", "off")
         self.logout(client)
-        response = client.get(entity_url, follow_redirects=True)
-        assert new_id.encode() not in response.data
-        assert b"Sign In - conbench-for-pytest" in response.data, response.data
+
+        r = client.get(entity_url, follow_redirects=False)
+
+        # Confirm this to be a redirect response.
+        assert r.status_code == 302, f"unexpected resp: {r.text}"
+
+        # Inspect the URL that we redirect the user agent to.
+        loc_url = r.headers.get("location")
+        log.debug("response Location header: %s", loc_url)
+        res = urllib.parse.urlparse(loc_url)
+        log.debug("loc url components: %s", res)
+
+        # Confirm that there is a query part, and that it roughly looks like
+        # desired.
+        assert res.query.startswith("target=")
+
+        # Now inspect the exact structure of the URL query string.
+        qargs = res = urllib.parse.parse_qs(res.query)
+        log.info("loc url query decoded: %s", qargs)
+        assert "target" in qargs
+        assert len(qargs["target"]) == 1
+        target_url = qargs["target"][0]
+        assert target_url.startswith(entity_url)
+
+        # I have seen the authorizer logic to append `?` to the target URL.
+        # That is an empty query section, i.e. a noop, i.e. it's fine. Right?
+        assert target_url in [entity_url, entity_url + "?"]
+
+        # There might be more redirects here, e.g. from / to /login/
+        r2 = client.get(r.headers.get("location"), follow_redirects=True)
+
+        # Note(JP): I have disabled this assertion. It was confirming that the
+        # entitity ID (as in for example
+        # /batches/7b2fdd9f929d47b9960152090d47f8e6) would not appear in the
+        # response body in the final response after all redirects after access
+        # control. This started to fail with enabled SSO because this ID is
+        # then part of the non-sensitive target URL and therefore appears in
+        # the `href` of the button/link for SSO flow initiation. If the goal of
+        # this assertion was to make sure that no entity details _other than_
+        # the entity ID end up showing up on the login page, then this needs to
+        # be reworked.
+        # assert new_id.encode() not in r2.data
+
+        assert b"Sign In - conbench-for-pytest" in r2.data, r2.data
 
     def test_unknown(self, client):
         self.authenticate(client)


### PR DESCRIPTION
This only affects the `/app/<>` routes so far (i.e. not the API routes). I think that's a good choice. 

Together with the previous work in https://github.com/conbench/conbench/pull/462 this should have the synergy effect of  satisfying #411.

More holistic testing is needed to cover the _entire_ flow.