### PR TITLE
duration measurements: use monotonic time source

### DIFF
--- a/benchrun/python/benchrun/_benchmark.py
+++ b/benchrun/python/benchrun/_benchmark.py
@@ -141,9 +141,9 @@ class Iteration(abc.ABC):
         error = None
         try:
             self.before_each(case=case)
-            start_time = time.time()
+            start_time = time.monotonic()
             self.run(case=case)
-            end_time = time.time()
+            end_time = time.monotonic()
             self.after_each(case=case)
             elapsed_time = end_time - start_time
         except Exception as e:

--- a/conbench/runner.py
+++ b/conbench/runner.py
@@ -359,9 +359,9 @@ class Conbench(Connection, MixinPython, MixinR):
                 # iteration to avoid doubling memory
                 del output
 
-            iteration_start = time.time()
+            iteration_start = time.monotonic()
             output = f()
-            times.append(time.time() - iteration_start)
+            times.append(time.monotonic() - iteration_start)
 
             gc.enable()
 

--- a/conbench/util.py
+++ b/conbench/util.py
@@ -42,9 +42,9 @@ class Connection:
             if not self.session:
                 self.session = requests.Session()
                 self.session.mount("https://", adapter)
-            start = time.time()
+            start = time.monotonic()
             response = self.session.post(url, json=data)
-            print("Time to POST", url, time.time() - start)
+            print("Time to POST", url, time.monotonic() - start)
             if response.status_code != expected:
                 self._unexpected_response("POST", response, url)
         except requests.exceptions.ConnectionError:


### PR DESCRIPTION
See #528.

I used `grep` to find all those places in this repo where we take two `time.time()` samples for calculating a duration.