### PR TITLE
conbench cli: show result timing overview

### DIFF
--- a/conbench/cli.py
+++ b/conbench/cli.py
@@ -2,14 +2,12 @@ import json
 import logging
 import math
 
-
 import click
 import sigfig
 
 from . import __version__
 from .runner import LIST, REGISTRY
 from .util import register_benchmarks
-
 
 log = logging.getLogger(__name__)
 

--- a/requirements-cli.txt
+++ b/requirements-cli.txt
@@ -5,3 +5,4 @@ py-cpuinfo
 pytest>=7.0.0
 PyYAML
 requests
+sigfig


### PR DESCRIPTION
I work on building a new benchmark. While doing so I want to be able to easily compare the timing information for various cases/scenarios run by a single `conbench` cli invocation. For example, when I do `conbench dataset-serialize --all true --iterations=6 nyctaxi_multi_parquet_s3` then when the entire process completes, I was looking for timing summary across all the cases/scenarios run. So that it's easier for me to actually iterate on/develop the benchmark method.

With the pragmatic code in this PR, I got for example the following output, which helped me make decisions:

```
$ conbench dataset-serialize --all true --iterations=6 nyctaxi_multi_parquet_s3

[...]

[221213-19:50:00.354] [283214] [conbench.cli] INFO: result timing overview:

format: parquet, selectivity: 1pc
    --> min: 0.469 s    mean±SE: (0.49 ± 0.01) s
format: arrow, selectivity: 1pc
    --> min: 0.0468 s   mean±SE: (0.0502 ± 0.0009) s
format: ipc, selectivity: 1pc
    --> min: 0.0479 s   mean±SE: (0.054 ± 0.002) s
format: feather, selectivity: 1pc
    --> min: 0.0581 s   mean±SE: (0.061 ± 0.001) s
format: csv, selectivity: 1pc
    --> min: 0.410 s    mean±SE: (0.435 ± 0.009) s
format: parquet, selectivity: 10pc
    --> min: 2.22 s     mean±SE: (2.26 ± 0.01) s
format: arrow, selectivity: 10pc
    --> min: 0.154 s    mean±SE: (0.162 ± 0.002) s
format: ipc, selectivity: 10pc
    --> min: 0.189 s    mean±SE: (0.22 ± 0.02) s
format: feather, selectivity: 10pc
    --> min: 0.171 s    mean±SE: (0.20 ± 0.01) s
format: csv, selectivity: 10pc
    --> min: 3.78 s     mean±SE: (3.94 ± 0.05) s
```