### PR TITLE
fix bug in migration script

### DIFF
--- a/migrations/versions/4d8d67396f79_clean_commits.py
+++ b/migrations/versions/4d8d67396f79_clean_commits.py
@@ -77,8 +77,8 @@ def upgrade():
                 {
                     "parent": commit_details.get("parent"),
                     "timestamp": commit_details.get("date"),
-                    "message": commit_details.get("message"),
-                    "author_name": commit_details.get("author_name"),
+                    "message": commit_details.get("message") or "",
+                    "author_name": commit_details.get("author_name") or "",
                     "author_login": commit_details.get("author_login"),
                     "author_avatar": commit_details.get("author_avatar"),
                     "fork_point_sha": fork_point_sha,


### PR DESCRIPTION
I forgot `message` and `author_name` are not nullable.