### PR TITLE
Add benchadapt to benchconnect deps

### DIFF
--- a/benchconnect/requirements.txt
+++ b/benchconnect/requirements.txt
@@ -1,2 +1,3 @@
+benchadapt@git+https://github.com/conbench/conbench.git@main#subdirectory=benchadapt/python
 benchclients@git+https://github.com/conbench/conbench.git@main#subdirectory=benchclients/python
 click


### PR DESCRIPTION
Apparently I forgot to add benchadapt to the benchconnect dependencies; it needs it for the `BenchmarkResult` and `BenchmarkRun` objects. CI didn't show this because we install everything together in one env, which is what it needs anyway, but when users try to install it with pipx per the README, it won't have what it needs.