### PR TITLE
devprod: add /api/wipe-db endpoint

### DIFF
--- a/conbench/api/index.py
+++ b/conbench/api/index.py
@@ -18,6 +18,13 @@ log = logging.getLogger(__name__)
 
 @api.route("/docs.json")
 def docs():
+    d = spec.to_dict()
+
+    # In TESTING mode there is a special endpoint that we do not want to mess
+    # with test_docs.
+    if "/api/wipe-db" in d["paths"]:
+        del d["/api/wipe-db"]
+
     return f.jsonify(spec.to_dict())
 
 

--- a/conbench/api/index.py
+++ b/conbench/api/index.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 
 import flask as f
 import flask_login
@@ -9,7 +10,10 @@ from .. import __version__
 from ..api import api, rule
 from ..api._docs import spec
 from ..api._endpoint import ApiEndpoint
-from ..db import Session
+from ..config import Config
+from ..db import Session, empty_db_tables
+
+log = logging.getLogger(__name__)
 
 
 @api.route("/docs.json")

--- a/conbench/api/index.py
+++ b/conbench/api/index.py
@@ -95,4 +95,19 @@ def register_api(view, endpoint, url):
 
 register_api(PingAPI, "ping", "/ping/")
 register_api(IndexAPI, "index", "/")
+
+
+# Register this API endpoint only in testing mode.
+if Config.TESTING:
+
+    @api.route("/wipe-db", methods=("GET",))
+    def wipe_db():
+        """
+        For local development / developer productivity.
+        """
+        log.info("clear DB tables")
+        empty_db_tables()
+        return "200 OK", 200
+
+
 spec.components.schema("Ping", schema=PingSchema)

--- a/conbench/api/index.py
+++ b/conbench/api/index.py
@@ -23,7 +23,7 @@ def docs():
     # In TESTING mode there is a special endpoint that we do not want to mess
     # with test_docs.
     if "/api/wipe-db" in d["paths"]:
-        del d["/api/wipe-db"]
+        del d["paths"]["/api/wipe-db"]
 
     return f.jsonify(spec.to_dict())
 

--- a/conbench/db.py
+++ b/conbench/db.py
@@ -72,6 +72,9 @@ def empty_db_tables():
         Session.execute(table.delete())
         log.debug("deleted table: %s", table)
 
+    Session.commit()
+    log.debug("all deletions committed: %s", table)
+
 
 def log_after_retry_attempt(retry_state: tenacity.RetryCallState):
     log.info(

--- a/conbench/tests/api/test_index.py
+++ b/conbench/tests/api/test_index.py
@@ -29,3 +29,8 @@ class TestAPI(_asserts.ApiEndpointTest):
         assert set(data) == {"date", "conbench_version", "alembic_version"}
         assert str(datetime.datetime.today().year) in data["date"]
         assert data["conbench_version"] == __version__
+
+    def test_wipe(self, client):
+        # This endpoint is here for convenience in local development/testing.
+        response = client.get("/api/wipe-db")
+        assert response.status_code == 200


### PR DESCRIPTION
This is motivated by https://github.com/conbench/conbench/issues/531. During local development it may be convenient to have an API endpoint that one can hit with the browser and/or curl. Tested this locally. Also added a test case.

README update follows.

CC @sayantikabanik 