### PR TITLE
devprod: mount local checkout into container

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -75,5 +75,5 @@ jobs:
             export CONBENCH_BASE_URL=http://$(docker compose port app 5000) && \
             make db-populate && make db-populate
           make teardown-app
-
+          make test-run-app-dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,11 @@ COPY requirements-test.txt /tmp/
 RUN pip install -r /tmp/requirements-build.txt
 RUN pip install -r /tmp/requirements-test.txt
 
+# This Dockerfile currently defines the image used for production environments.
+# It also contains all test dependencies and most CI dependencies because it's
+# currently also being used to run CI tasks. For production, it's important
+# that the `app` directory is baked in, containing current Conbench code. For
+# local development, /app may be overridden to be a volume-mount.
 WORKDIR /app
 ADD . /app
 RUN pip install .

--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,8 @@ run-app:
 
 # A copy of `make run-app`, but with the `docker-compose.dev.yml` extension
 # That mounts the local checkout into the Conbench container.
-.PHONY: run-app-mount
-run-app-mount:
+.PHONY: run-app-dev
+run-app-dev:
 	export DCOMP_CONBENCH_HOST_PORT=127.0.0.1:5000 && \
 		docker compose down && \
 			docker compose -f docker-compose.yml -f docker-compose.dev.yml \

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ run-app-bg:
 # exit code 0 once the app appears to be healthy. At this point we can run
 # the teardown which is also expected to return with code 0.
 .PHONY: test-run-app-dev
-test-run-app-bg:
+test-run-app-dev:
 	docker compose down
 	docker compose -f docker-compose.yml -f docker-compose.dev.yml \
 		up --build --wait --detach

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ tests:
 
 
 # For developers, these commands may and should modify local files if possible.
+# This requires the dependencies to be available on the host, in the terminal
+# that this target is executed in.
 .PHONY: lint
 lint:
 	flake8
@@ -57,6 +59,16 @@ db-populate:
 run-app:
 	export DCOMP_CONBENCH_HOST_PORT=127.0.0.1:5000 && \
 		docker compose down && docker compose up --build
+
+
+# A copy of `make run-app`, but with the `docker-compose.dev.yml` extension
+# That mounts the local checkout into the Conbench container.
+.PHONY: run-app-mount
+run-app-mount:
+	export DCOMP_CONBENCH_HOST_PORT=127.0.0.1:5000 && \
+		docker compose down && \
+			docker compose -f docker-compose.yml -f docker-compose.dev.yml \
+				up --build
 
 
 .PHONY: run-app-bg

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,28 @@
 # -- those targets can change at will, often and brutally (their names, their
 # meaning, and their implementation)
 
+# The use case that this target mainly has in mind: starting the application
+# locally to play around with this. This is not primarily meant for
+# _development_.
+.PHONY: run-app
+run-app:
+	export DCOMP_CONBENCH_HOST_PORT=127.0.0.1:5000 && \
+		docker compose down && docker compose up --build
+
+
+# This removes state by removing containers. That means that the next `make
+# run-app` invocation will start with fresh container state.
+.PHONY: teardown-app
+teardown-app:
+	docker compose down --remove-orphans
+
+
+# This requries dependencies to be set up in host env
+.PHONY: db-populate
+db-populate:
+	python -m conbench.tests.populate_local_conbench
+
+
 # This is used by CI for running the test suite. Documentation should encourage
 # developers to run this command locally, too.
 .PHONY: tests
@@ -16,6 +38,16 @@ tests:
 		app \
 		coverage run --source conbench \
 			-m pytest -vv -s --durations=20 conbench/tests/
+
+
+# Similar to `make run-app`, but with the `docker-compose.dev.yml` extension
+# That mounts the local checkout into the Conbench container.
+.PHONY: run-app-dev
+run-app-dev:
+	export DCOMP_CONBENCH_HOST_PORT=127.0.0.1:5000 && \
+		docker compose down && \
+			docker compose -f docker-compose.yml -f docker-compose.dev.yml \
+				up --build
 
 
 # For developers, these commands may and should modify local files if possible.
@@ -49,35 +81,19 @@ rebuild-expected-api-docs: run-app-bg
 	git diff ./conbench/tests/api/_expected_docs.py
 
 
-# This requries dependencies to be set up in host env
-.PHONY: db-populate
-db-populate:
-	python -m conbench.tests.populate_local_conbench
-
-
-.PHONY: run-app
-run-app:
-	export DCOMP_CONBENCH_HOST_PORT=127.0.0.1:5000 && \
-		docker compose down && docker compose up --build
-
-
-# A copy of `make run-app`, but with the `docker-compose.dev.yml` extension
-# That mounts the local checkout into the Conbench container.
-.PHONY: run-app-dev
-run-app-dev:
-	export DCOMP_CONBENCH_HOST_PORT=127.0.0.1:5000 && \
-		docker compose down && \
-			docker compose -f docker-compose.yml -f docker-compose.dev.yml \
-				up --build
-
-
 .PHONY: run-app-bg
 run-app-bg:
 	docker compose up --build --wait --detach
 
 
-# This removes state by removing containers. That means that the next `make
-# run-app` invocation will start with fresh container state.
-.PHONY: teardown-app
-teardown-app:
-	docker compose down --remove-orphans
+# This is here for the purpose of testing most of `run-app-dev` in CI. A copy
+# of `run-app-dev` but not requiring a specific port on the host, and using
+# --wait and --detach. That means that `docker compose up...` will return with
+# exit code 0 once the app appears to be healthy. At this point we can run
+# the teardown which is also expected to return with code 0.
+.PHONY: test-run-app-dev
+test-run-app-bg:
+	docker compose down
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml \
+		up --build --wait --detach
+	docker compose down

--- a/conbench/db.py
+++ b/conbench/db.py
@@ -100,7 +100,21 @@ def log_after_retry_attempt(retry_state: tenacity.RetryCallState):
 def create_all():
     from .entities._entity import Base
 
-    Base.metadata.create_all(engine)
+    # Gunicorn without --preload runs create_all() in potentially multiple
+    # runners. That's fine, and only one of them can 'win' the DB creation
+    # prize.
+    try:
+        Base.metadata.create_all(engine)
+    except sqlalchemy.exc.IntegrityError as exc:
+        if "already exists" in str(exc):
+            log.info(
+                "db.create_all(): ignore sqlalchemy.exc.IntegrityError. "
+                "Probably concurrent create_all() execution. Err: %s",
+                str(exc),
+            )
+        else:
+            raise
+
     engine.dispose()
 
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,20 @@
+# Extends the docker-compose.yml.
+# Use this via e.g.
+#     docker compose -f docker-compose.yml -f docker-compose.dev.yml
+services:
+  app:
+    # Add --reload to command, to reload on file change. Remove --preload
+    # to make this more robust
+    command: [
+      "gunicorn",
+      "-b", "0.0.0.0:5000",
+      "-w", "2",
+      "conbench:application",
+      "--access-logfile=-",
+      "--error-logfile=-",
+      "--reload"
+      ]
+    volumes:
+      # Left-hand path: relative to this compose file. Mount the directory
+      # that this compose file resided in as `/app` into the container.
+      - .:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   app:
     build:
       context: .
+      # Note that currently this Dockerfile defines the image that' used for
+      # Conbench production environments.
       dockerfile: Dockerfile
     command: ["gunicorn", "-b", "0.0.0.0:5000", "-w", "5", "conbench:application", "--access-logfile=-", "--error-logfile=-", "--preload"]
     ports:


### PR DESCRIPTION
This introduces a new Makefile target which invokes the docker-compose machinery in a special way, using an extension config on top of the normal config.

That extension config has instructions to mount the local checkout dir (the root of the Conbench repo) into the Conbench container image, at `/app`.

This patch also overrides the gunicorn command/settings.

I reduced the number of workers from 5 to 2 (not just 1, so that during local dev one can also see some concurrency issues that would otherwise happen in prod).

Found one concurrency issue: `db.create_all()` was not guarded against concurrent execution. This did not happen so far because gunicorn was started with `--preload`. I removed `--preload` to make the reload-upon-file-change more complete (init code changes would otherwise _not_ lead to auto-reload).

Why not always mount local checkout into /app when doing `make app-run`? Maybe that would have been easier and also possible. But then, `make app-run` is not really testing the contents of the container image defined by Dockerfile
(which is the image that's being used in prod).  I feel like mounting the local checkout into the container image is special enough of a use case to get its own Makefile target. So far I thought of `make run-app` to be mainly for users who 'just' want to try out the app locally. 

Like `make app-run`, this target is not to be tested in CI trivially because it launches a long-running process. Thinking about adding a commit to test this in CI, but for today I think merging this w/o test is good enough. Testing locally that this works.