### PR TITLE
api/index.py: fix wipe-db filter

### DIFF
--- a/conbench/api/index.py
+++ b/conbench/api/index.py
@@ -20,12 +20,15 @@ log = logging.getLogger(__name__)
 def docs():
     d = spec.to_dict()
 
-    # In TESTING mode there is a special endpoint that we do not want to mess
-    # with test_docs.
+    # In TESTING mode there is a special endpoint that gets
+    # automatically added to the spec. Cleanly remove it
+    # here (never emit it as part of the API spec) so that
+    # we do not need to bother with complicating approaches
+    # in test_docs.
     if "/api/wipe-db" in d["paths"]:
         del d["paths"]["/api/wipe-db"]
 
-    return f.jsonify(spec.to_dict())
+    return f.jsonify(d)
 
 
 class IndexSerializer:


### PR DESCRIPTION
This is a quick follow-up after https://github.com/conbench/conbench/pull/544/files. Thanks @austin3dickey.

I have not looked into why the tests did not fail before, but this cleanup is good/required anyway.