### PR TITLE
get_github_commit(): clarify interface, expect rate limiting errs in tests

### DIFF
--- a/conbench/entities/commit.py
+++ b/conbench/entities/commit.py
@@ -1,6 +1,6 @@
 import functools
-import logging
 import json
+import logging
 import os
 from datetime import datetime
 from typing import List
@@ -18,7 +18,6 @@ from ..entities._entity import (
     Nullable,
     generate_uuid,
 )
-
 
 log = logging.getLogger(__name__)
 

--- a/conbench/entities/commit.py
+++ b/conbench/entities/commit.py
@@ -185,10 +185,6 @@ def get_github_commit(repository: str, pr_number: str, branch: str, sha: str) ->
     # GitHub HTTP API failed, e.g. with a 4xx rate limiting response.
     commit = github.get_commit(name, sha)
 
-    # Note(JP): I think with current err handling this cannot happen anymore.
-    if commit is None:
-        return {}
-
     if branch:
         commit["branch"] = branch
     elif pr_number:

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -86,7 +86,12 @@ class Run(Base, EntityMixin):
                 except Exception as e:
                     # no matter what happened during backfilling, we want to return a
                     # successful status code because the commit was created
-                    print(f"Could not backfill default branch commits due to: {e}")
+                    log.info(
+                        "Could not backfill default branch commits. Error "
+                        "during backfill_default_branch_commits():  %s",
+                        e,
+                    )
+
             elif sha or repository:
                 commit = Commit.create_unknown_context(sha, repository)
             else:

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -24,7 +24,6 @@ from ..entities.hardware import (
     MachineSchema,
 )
 
-
 log = logging.getLogger(__name__)
 
 

--- a/conbench/tests/entities/test_commit.py
+++ b/conbench/tests/entities/test_commit.py
@@ -29,7 +29,8 @@ def backfill_default_branch_commits_ign_rate_limit(*args, **kwargs):
         log.info("exc during backfill_default_branch_commits(): %s", exc)
         if "API rate limit" in str(exc):
             pytest.skip("GitHub API rate limit seen, skip test")
-        raise
+        else:
+            raise
 
 
 def test_upsert_do_nothing():
@@ -123,7 +124,8 @@ def test_get_github_commit_and_fork_point_sha(branch):
         log.info("exc during get_github_commit(): %s", exc)
         if "API rate limit" in str(exc):
             pytest.skip("GitHub API rate limit seen, skip test")
-        raise
+        else:
+            raise
 
     assert result == expected
 
@@ -163,7 +165,8 @@ def test_get_github_commit_and_fork_point_sha_pull_request(branch, pr_number):
         log.info("exc during get_github_commit(): %s", exc)
         if "API rate limit" in str(exc):
             pytest.skip("GitHub API rate limit seen, skip test")
-        raise
+        else:
+            raise
 
     assert result == expected
 

--- a/conbench/tests/entities/test_commit.py
+++ b/conbench/tests/entities/test_commit.py
@@ -1,7 +1,6 @@
-import logging
-
 import datetime
 import json
+import logging
 import os
 
 import dateutil

--- a/conbench/tests/entities/test_commit.py
+++ b/conbench/tests/entities/test_commit.py
@@ -148,7 +148,7 @@ def test_get_github_commit_and_fork_point_sha_pull_request(branch, pr_number):
         "fork_point_sha": "780e95c512d63bbea1e040af0eb44a0bf63c4d72",
     }
     try:
-        result = get_github_commit(repo, branch=branch, sha=sha, pr_number=None)
+        result = get_github_commit(repo, branch=branch, sha=sha, pr_number=pr_number)
     except Exception as exc:
         log.info("exc during get_github_commit(): %s", exc)
         if "API rate limit" in str(exc):

--- a/conbench/tests/entities/test_commit.py
+++ b/conbench/tests/entities/test_commit.py
@@ -27,7 +27,7 @@ def backfill_default_branch_commits_ign_rate_limit(*args, **kwargs):
         return backfill_default_branch_commits(*args, **kwargs)
     except Exception as exc:
         log.info("exc during backfill_default_branch_commits(): %s", exc)
-        if "API rate limit" in str(exc):
+        if "403 Client Error" in str(exc):
             pytest.skip("GitHub API rate limit seen, skip test")
         else:
             raise
@@ -122,7 +122,7 @@ def test_get_github_commit_and_fork_point_sha(branch):
         result = get_github_commit(repo, branch=branch, sha=sha, pr_number=None)
     except Exception as exc:
         log.info("exc during get_github_commit(): %s", exc)
-        if "API rate limit" in str(exc):
+        if "403 Client Error" in str(exc):
             pytest.skip("GitHub API rate limit seen, skip test")
         else:
             raise
@@ -163,7 +163,7 @@ def test_get_github_commit_and_fork_point_sha_pull_request(branch, pr_number):
         result = get_github_commit(repo, branch=branch, sha=sha, pr_number=pr_number)
     except Exception as exc:
         log.info("exc during get_github_commit(): %s", exc)
-        if "API rate limit" in str(exc):
+        if "403 Client Error" in str(exc):
             pytest.skip("GitHub API rate limit seen, skip test")
         else:
             raise


### PR DESCRIPTION
Motivated by https://github.com/conbench/conbench/issues/556 where CI suffered from rate limiting errors during GitHub HTTP API usage.

At the high level this patch

- changes and clarifies the interface of `get_github_commit()`
- adjusts error handling code in `run.py` to use that interface
- adjusts to expect rate limiting errs, and to not fail in this case

Update: analogue treatment for `backfill_default_branch_commits()`: expect errors.

If we decide that this approach is too relaxed for _testing_ I think the clarification of interfaces and the slightly improved error handling is still valuable.