### PR TITLE
Enable toggling step changes in webapp

### DIFF
--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import bokeh.plotting
 import dateutil
-from bokeh.models import Spacer
+from bokeh.models import Spacer, Span
 
 from ..hacks import sorted_data
 from ..units import formatter_for_unit
@@ -401,6 +401,32 @@ def time_series_plot(history, benchmark, run, height=380, width=1100):
             legend_label="current benchmark (min)",
             name="benchmark",
         )
+
+    # visually separate out distribution changes
+    dist_change_in_legend = False
+    for result in history:
+        if result["change_annotations"].get("begins_distribution_change", False):
+            p.add_layout(
+                Span(
+                    location=dateutil.parser.isoparse(result["timestamp"]),
+                    dimension="height",
+                    line_color="purple",
+                    line_dash="dashed",
+                    line_alpha=0.5,
+                )
+            )
+
+            if not dist_change_in_legend:
+                # hack: add a dummy line so it appears on the legend
+                p.line(
+                    [dateutil.parser.isoparse(result["timestamp"])] * 2,
+                    [result["mean"]] * 2,
+                    legend_label="distribution change",
+                    line_color="purple",
+                    line_dash="dashed",
+                    line_alpha=0.5,
+                )
+                dist_change_in_legend = True
 
     hover_renderers = [
         scatter_mean_over_time,

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -362,6 +362,13 @@ class BenchmarkResultSerializer:
 CHANGE_ANNOTATIONS_DESC = """Post-analysis annotations about this BenchmarkResult that
 give details about whether it represents a change, outlier, etc. in the overall
 distribution of BenchmarkResults.
+
+Currently-recognized keys that change Conbench behavior:
+
+- `begins_distribution_change` (bool) - Is this result the first result of a sufficiently
+"different" distribution than the result on the previous commit (for the same
+hardware/case/context)? That is, when evaluating whether future results are regressions
+or improvements, should we treat data from before this result as incomparable?
 """
 
 

--- a/conbench/templates/benchmark-entity.html
+++ b/conbench/templates/benchmark-entity.html
@@ -24,6 +24,13 @@
 <br />
 
 <div class="row">
+  <div class="col-md-8">
+    {{ wtf.quick_form(update_form, id="update-form", button_map={'toggle_distribution_change': update_button_color}) }}
+  </div>
+</div>
+<br>
+
+<div class="row">
   <div class="col-md-6">
     <ul class="list-group">
       <li class="list-group-item active">Benchmark</li>
@@ -213,7 +220,7 @@
 
 <div class="row">
   <div class="col-md-8">
-    {{ wtf.quick_form(form, id="benchmark-form", button_map={'delete': 'primary'}) }}
+    {{ wtf.quick_form(delete_form, id="delete-form", button_map={'delete': 'danger'}) }}
   </div>
 </div>
 
@@ -227,12 +234,12 @@
 
 <script type="text/javascript">
   $(document).ready(function ($) {
-    $("#benchmark-form").find("#delete").attr("type", "button");
-    $("#benchmark-form").find("#delete").attr("data-toggle", "modal");
-    $("#benchmark-form").find("#delete").attr("data-target", "#confirm-delete");
-    $("#benchmark-form").find("#delete").attr("data-form-id", "#benchmark-form");
-    $("#benchmark-form").find("#delete").attr("data-href", "{{ url_for('app.benchmark', benchmark_id=benchmark.id) }}");
-    $("#benchmark-form").find("#delete").attr("data-message", "<ul><li>Delete benchmark: <strong>{{ benchmark.id }}</strong></li></ul>");
+    $("#delete-form").find("#delete").attr("type", "button");
+    $("#delete-form").find("#delete").attr("data-toggle", "modal");
+    $("#delete-form").find("#delete").attr("data-target", "#confirm-delete");
+    $("#delete-form").find("#delete").attr("data-form-id", "#delete-form");
+    $("#delete-form").find("#delete").attr("data-href", "{{ url_for('app.benchmark', benchmark_id=benchmark.id) }}");
+    $("#delete-form").find("#delete").attr("data-message", "<ul><li>Delete benchmark: <strong>{{ benchmark.id }}</strong></li></ul>");
   });
 
   {% if plot_history %}

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -978,7 +978,7 @@
                 "properties": {
                     "batch_id": {"type": "string"},
                     "change_annotations": {
-                        "description": "Post-analysis annotations about this BenchmarkResult that\ngive details about whether it represents a change, outlier, etc. in the overall\ndistribution of BenchmarkResults.\n",
+                        "description": 'Post-analysis annotations about this BenchmarkResult that\ngive details about whether it represents a change, outlier, etc. in the overall\ndistribution of BenchmarkResults.\n\nCurrently-recognized keys that change Conbench behavior:\n\n- `begins_distribution_change` (bool) - Is this result the first result of a sufficiently\n"different" distribution than the result on the previous commit (for the same\nhardware/case/context)? That is, when evaluating whether future results are regressions\nor improvements, should we treat data from before this result as incomparable?\n',
                         "type": "object",
                     },
                     "cluster_info": {"$ref": "#/components/schemas/ClusterCreate"},
@@ -1100,7 +1100,7 @@
             "BenchmarkUpdate": {
                 "properties": {
                     "change_annotations": {
-                        "description": "Post-analysis annotations about this BenchmarkResult that\ngive details about whether it represents a change, outlier, etc. in the overall\ndistribution of BenchmarkResults.\n\n\nThis endpoint will only update the user-specified keys, and leave the rest alone. To\ndelete an existing key, set the value to null.\n",
+                        "description": 'Post-analysis annotations about this BenchmarkResult that\ngive details about whether it represents a change, outlier, etc. in the overall\ndistribution of BenchmarkResults.\n\nCurrently-recognized keys that change Conbench behavior:\n\n- `begins_distribution_change` (bool) - Is this result the first result of a sufficiently\n"different" distribution than the result on the previous commit (for the same\nhardware/case/context)? That is, when evaluating whether future results are regressions\nor improvements, should we treat data from before this result as incomparable?\n\n\nThis endpoint will only update the user-specified keys, and leave the rest alone. To\ndelete an existing key, set the value to null.\n',
                         "type": "object",
                     }
                 },


### PR DESCRIPTION
Fixes #472.

This PR enables users to toggle whether BenchmarkResults are step changes in the webapp. It also displays step changes on the plots as vertical lines.

Sorry for the poor-quality GIF, but here's the workflow in action. If logged in, you can toggle with the checkbox, and then the line is persisted on all plots of the same history.

![recording](https://user-images.githubusercontent.com/16600275/210877927-5e0d5070-0ab5-4089-b9de-3021ac0d360e.gif)
