### PR TITLE
Webapp: dropdown search enabled for individual columns 

### DIFF
--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -155,17 +155,28 @@ function specific_column_search(data_table_id, column_indexes) {
         var table = $(data_table_id).DataTable();
         table.columns(column_indexes).every(function() {
             var that = this;
+            var reset = ""
             var mySelectList = $("<select></select>")
                 .appendTo(this.header())
                 .on("change", function() {
                     that.search($(this).val()).draw();
                 });
-
+            mySelectList.append(
+                        $(`<option value="${reset}">${reset}</option>`)
+                    );
             this.cache("search").unique().sort().each(function(param) {
-                mySelectList.append(
-                    $(`<option value="${param}">${param}</option>`)
-                );
+                if (param!==""){
+                    mySelectList.append(
+                        $(`<option value="${param}">${param}</option>`)
+                    );
+                }
+                else{
+                    mySelectList.append(
+                        $(`<option value="${param}">null</option>`)
+                    );
+                }
             });
+
         });
     });
 }

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -138,25 +138,28 @@ function enable_search_query_string(data_table) {
     });
 
 }
+/*
+INFO:
+    Adds search ability for specific columns in the DataTable,
+    Creates a *table* instance and update the header with the dropdown menu
+    List of unique values based on the column data fields are added
+    Output is yield based on the selected option from the dropdown menu
 
-// requires two inputs: table_id & column_indexes
-function specific_column_search(data_table, column_indexes){
+INPUTS:
+ string: data_table_id
+ array: column_indexes
+ */
+function specific_column_search(data_table_id, column_indexes){
     $(document).ready(function() {
-        var table =  $(data_table).DataTable();
-        table.columns(column_indexes)
-		.every(function () {
+        var table =  $(data_table_id).DataTable();
+        table.columns(column_indexes).every(function () {
             var that = this;
 			var mySelectList = $("<select></select>")
 			.appendTo(this.header())
-			.on("change", function () {
-				that.search($(this).val()).draw();
+			.on("change", function () {that.search($(this).val()).draw();
 			});
 
-        this
-			.cache("search")
-            .unique()
-			.sort()
-			.each(function (param) {
+        this.cache("search").unique().sort().each(function (param) {
 				mySelectList.append(
 				$(`<option value="${param}">${param}</option>`)
 				);

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -173,9 +173,8 @@ function specific_column_search(data_table_id, column_indexes) {
                     mySelectList.append(
                         $(`<option value="${param}">null</option>`)
                     );
-                }
+                }           
             });
-
         });
     });
 }

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -162,15 +162,14 @@ function specific_column_search(data_table_id, column_indexes) {
                     that.search($(this).val()).draw();
                 });
             mySelectList.append(
-                        $(`<option value="${reset}">${reset}</option>`)
-                    );
+                $(`<option value="${reset}">${reset}</option>`)
+            );
             this.cache("search").unique().sort().each(function(param) {
-                if (param!==""){
+                if (param !== "") {
                     mySelectList.append(
                         $(`<option value="${param}">${param}</option>`)
                     );
-                }
-                else{
+                } else {
                     mySelectList.append(
                         $(`<option value="${param}">null</option>`)
                     );

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -121,7 +121,7 @@ $(document).ready(function() {
 });
 
 function enable_search_query_string(data_table) {
-    $(data_table).on( 'search.dt', function () {
+    $(data_table).on('search.dt', function () {
         var current_search_value = $('.dataTables_filter input').val();
         var new_url = window.location.protocol + "//" + window.location.host + window.location.pathname
         if (current_search_value) {
@@ -130,32 +130,34 @@ function enable_search_query_string(data_table) {
         window.history.replaceState(null, document.title, new_url)
     });
 
-    // $(document).ready(function() {
-    //     var table =  $(data_table).DataTable();
-    //     {% if search_value %}
-    //         table.search("{{ search_value }}").draw();
-    //     {% endif %}
-    // });
+    $(document).ready(function() {
+        var table =  $(data_table).DataTable();
+        {% if search_value %}
+            table.search("{{ search_value }}").draw();
+        {% endif %}
+    });
 
+}
 
+// requires two input to enable search: the table id and the column index
+function specific_column_search(data_table, column_index){
     $(document).ready(function() {
         var table =  $(data_table).DataTable();
         table
-		.columns()
-		.flatten()
+		.columns([column_index])
+		.unique()
 		.each(function (colID) {
 			var mySelectList = $("<select />")
 			.appendTo(table.column(colID).header())
 			.on("change", function () {
 				table.column(colID).search($(this).val());
-
-				// update the changes using draw() method
-				table.column(colID).draw();
+                table.column(colID).draw();
 			});
             
 			table
 			.column(colID)
 			.cache("search")
+            .unique()
 			.sort()
 			.each(function (param) {
 				mySelectList.append(

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -139,30 +139,26 @@ function enable_search_query_string(data_table) {
 
 }
 
-// requires two input to enable search: table_id and the column_index
-function specific_column_search(data_table, column_index){
+// requires two inputs: table_id & column_indexes
+function specific_column_search(data_table, column_indexes){
     $(document).ready(function() {
         var table =  $(data_table).DataTable();
-        table
-		.columns(column_index)
-		.unique()
-		.each(function (colID) {
-			var mySelectList = $("<select />")
-			.appendTo(table.column(colID).header())
+        table.columns(column_indexes)
+		.every(function () {
+            var that = this;
+			var mySelectList = $("<select></select>")
+			.appendTo(this.header())
 			.on("change", function () {
-				table.column(colID).search($(this).val());
-                table.column(colID).draw();
+				that.search($(this).val()).draw();
 			});
-            
-			table
-			.column(colID)
+
+        this
 			.cache("search")
             .unique()
 			.sort()
 			.each(function (param) {
 				mySelectList.append(
-				$('<option value="' + param + '">'
-					+ param + "</option>")
+				$(`<option value="${param}">${param}</option>`)
 				);
 			});
 		});

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -130,13 +130,43 @@ function enable_search_query_string(data_table) {
         window.history.replaceState(null, document.title, new_url)
     });
 
+    // $(document).ready(function() {
+    //     var table =  $(data_table).DataTable();
+    //     {% if search_value %}
+    //         table.search("{{ search_value }}").draw();
+    //     {% endif %}
+    // });
+
+
     $(document).ready(function() {
         var table =  $(data_table).DataTable();
-        {% if search_value %}
-            table.search("{{ search_value }}").draw();
-        {% endif %}
-    });
+        table
+		.columns()
+		.flatten()
+		.each(function (colID) {
+			var mySelectList = $("<select />")
+			.appendTo(table.column(colID).header())
+			.on("change", function () {
+				table.column(colID).search($(this).val());
+
+				// update the changes using draw() method
+				table.column(colID).draw();
+			});
+            
+			table
+			.column(colID)
+			.cache("search")
+			.sort()
+			.each(function (param) {
+				mySelectList.append(
+				$('<option value="' + param + '">'
+					+ param + "</option>")
+				);
+			});
+		});
+	});
 }
+
 
 $("#confirm-delete").on("show.bs.modal", function(e) {
     $(this).find("#confirm-delete-message").html($(e.relatedTarget).data("message"));

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -147,8 +147,8 @@ INFO:
     Output is yield based on the selected option from the dropdown menu
 
 INPUTS:
- string: data_table_id
- array: column_indexes
+ data_table_id: string
+ column_indexes: array
  */
 function specific_column_search(data_table_id, column_indexes) {
     $(document).ready(function() {

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -139,12 +139,12 @@ function enable_search_query_string(data_table) {
 
 }
 
-// requires two input to enable search: the table id and the column index
+// requires two input to enable search: table_id and the column_index
 function specific_column_search(data_table, column_index){
     $(document).ready(function() {
         var table =  $(data_table).DataTable();
         table
-		.columns([column_index])
+		.columns(column_index)
 		.unique()
 		.each(function (colID) {
 			var mySelectList = $("<select />")

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -138,6 +138,7 @@ function enable_search_query_string(data_table) {
     });
 
 }
+
 /*
 INFO:
     Adds search ability for specific columns in the DataTable,
@@ -149,25 +150,25 @@ INPUTS:
  string: data_table_id
  array: column_indexes
  */
-function specific_column_search(data_table_id, column_indexes){
+function specific_column_search(data_table_id, column_indexes) {
     $(document).ready(function() {
-        var table =  $(data_table_id).DataTable();
-        table.columns(column_indexes).every(function () {
+        var table = $(data_table_id).DataTable();
+        table.columns(column_indexes).every(function() {
             var that = this;
-			var mySelectList = $("<select></select>")
-			.appendTo(this.header())
-			.on("change", function () {that.search($(this).val()).draw();
-			});
+            var mySelectList = $("<select></select>")
+                .appendTo(this.header())
+                .on("change", function() {
+                    that.search($(this).val()).draw();
+                });
 
-        this.cache("search").unique().sort().each(function (param) {
-				mySelectList.append(
-				$(`<option value="${param}">${param}</option>`)
-				);
-			});
-		});
-	});
+            this.cache("search").unique().sort().each(function(param) {
+                mySelectList.append(
+                    $(`<option value="${param}">${param}</option>`)
+                );
+            });
+        });
+    });
 }
-
 
 $("#confirm-delete").on("show.bs.modal", function(e) {
     $(this).find("#confirm-delete-message").html($(e.relatedTarget).data("message"));

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -120,6 +120,10 @@
       }
 });
 enable_search_query_string('#runs');
+
+/* specify the HTML table id (string) and the indexes of the columns for
+ which search functionality should be enabled in an array format
+*/
 specific_column_search('#runs', [3,6]);
 
 </script>

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -124,7 +124,7 @@ enable_search_query_string('#runs');
 /* specify the HTML table id (string) and the indexes of the columns for
  which search functionality should be enabled in an array format
 */
-specific_column_search('#runs', [3,6]);
+specific_column_search('#runs', [6]);
 
 </script>
 {% endblock %}

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -120,7 +120,7 @@
       }
 });
 enable_search_query_string('#runs');
-specific_column_search('#runs', 6);
+specific_column_search('#runs', [6]);
 
 </script>
 {% endblock %}

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -115,13 +115,12 @@
 <script type="text/javascript">
   var table = $('#runs').DataTable( {
       "order": [[0, 'desc']],
-      // "language": {
-      //     "searchPlaceholder": "commit hash works too",
-      // }
+      "language": {
+          "searchPlaceholder": "commit hash works too",
+      }
 });
-
-
 enable_search_query_string('#runs');
+specific_column_search('#runs', 6);
 
 </script>
 {% endblock %}

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -115,10 +115,11 @@
 <script type="text/javascript">
   var table = $('#runs').DataTable( {
       "order": [[0, 'desc']],
-      "language": {
-          "searchPlaceholder": "commit hash works too",
-      }
+      // "language": {
+      //     "searchPlaceholder": "commit hash works too",
+      // }
 });
+
 
 enable_search_query_string('#runs');
 

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -120,7 +120,7 @@
       }
 });
 enable_search_query_string('#runs');
-specific_column_search('#runs', [6]);
+specific_column_search('#runs', [3,6]);
 
 </script>
 {% endblock %}

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -189,6 +189,7 @@ var table = $('#benchmarks').dataTable( {
 } );
 
 enable_search_query_string('#benchmarks');
+specific_column_search('#benchmarks', 1);
 
 $(document).ready(function() {
     $('#unit-tooltip').tooltip()

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -189,7 +189,7 @@ var table = $('#benchmarks').dataTable( {
 } );
 
 enable_search_query_string('#benchmarks');
-specific_column_search('#benchmarks', 1);
+specific_column_search('#benchmarks', [1]);
 
 $(document).ready(function() {
     $('#unit-tooltip').tooltip()


### PR DESCRIPTION
resolves #564 

#### Details

- This PR enables search for specific columns for the DataTable
- Add-on to the existing search functionality
- New JS method `specific_column_search` under `app.html` which can be used across the templates to enable search for targeted cols

```javascript
// example usage
// requires 02 input: table_id & col indexes in array format
specific_column_search('#runs', [3,6]);
```


https://user-images.githubusercontent.com/17350312/211490986-dbe1c1dc-f5d8-4540-b793-624a7ec43a5b.mov

