### PR TITLE
Add environment variables for posting metadata

### DIFF
--- a/benchadapt/python/benchadapt/_machine_info.py
+++ b/benchadapt/python/benchadapt/_machine_info.py
@@ -96,7 +96,7 @@ def github_info():
             (
                 "Both CONBENCH_PROJECT_REPOSITORY and CONBENCH_PROJECT_COMMIT must be "
                 "set if `github` is not specified. CONBENCH_PROJECT_PR_NUMBER should be "
-                "null for builds on the default branch."
+                "not be set for builds on the default branch."
                 f"\nValues: `{gh_info}`"
             ),
         )

--- a/benchadapt/python/benchadapt/_machine_info.py
+++ b/benchadapt/python/benchadapt/_machine_info.py
@@ -91,11 +91,12 @@ def github_info():
         "pr_number": pr_number,
     }
 
-    if not (repo and pr_number and commit):
+    if not (repo and commit):
         warnings.warn(
             (
-                "All of CONBENCH_REPOSITORY, CONBENCH_PR_NUMBER, and "
-                "CONBENCH_COMMIT must be set if `github` is not specified. "
+                "Both CONBENCH_REPOSITORY and CONBENCH_COMMIT must be set if `github` "
+                "is not specified. CONBENCH_PR_NUMBER should be null for builds on the "
+                "default branch."
                 f"\nValues: `{gh_info}`"
             ),
         )
@@ -154,7 +155,7 @@ def detect_github_info():
     }
 
 
-def machine_info(host_name: Optional[str]):
+def machine_info(host_name: Optional[str] = None):
     os_name, os_version = platform.platform(terse=True).split("-", maxsplit=1)
 
     host_name = host_name or os.environ.get("CONBENCH_HOST_NAME")

--- a/benchadapt/python/benchadapt/_machine_info.py
+++ b/benchadapt/python/benchadapt/_machine_info.py
@@ -78,11 +78,11 @@ class GitParseWarning(RuntimeWarning):
 
 def github_info():
     """Get github metadata from environment variables"""
-    repo = os.environ.get("CONBENCH_REPOSITORY")
-    pr_number = os.environ.get("CONBENCH_PR_NUMBER") or os.environ.get(
+    repo = os.environ.get("CONBENCH_PROJECT_REPOSITORY")
+    pr_number = os.environ.get("CONBENCH_PROJECT_PR_NUMBER") or os.environ.get(
         "BENCHMARKABLE_PR_NUMBER"
     )
-    commit = os.environ.get("CONBENCH_COMMIT")
+    commit = os.environ.get("CONBENCH_PROJECT_COMMIT")
 
     gh_info = {
         "commit": commit,
@@ -94,9 +94,9 @@ def github_info():
     if not (repo and commit):
         warnings.warn(
             (
-                "Both CONBENCH_REPOSITORY and CONBENCH_COMMIT must be set if `github` "
-                "is not specified. CONBENCH_PR_NUMBER should be null for builds on the "
-                "default branch."
+                "Both CONBENCH_PROJECT_REPOSITORY and CONBENCH_PROJECT_COMMIT must be "
+                "set if `github` is not specified. CONBENCH_PROJECT_PR_NUMBER should be "
+                "null for builds on the default branch."
                 f"\nValues: `{gh_info}`"
             ),
         )
@@ -158,7 +158,7 @@ def detect_github_info():
 def machine_info(host_name: Optional[str] = None):
     os_name, os_version = platform.platform(terse=True).split("-", maxsplit=1)
 
-    host_name = host_name or os.environ.get("CONBENCH_HOST_NAME")
+    host_name = host_name or os.environ.get("CONBENCH_MACHINE_INFO_NAME")
     host_name = host_name or platform.node()
 
     info = {

--- a/benchadapt/python/benchadapt/machine_info.py
+++ b/benchadapt/python/benchadapt/machine_info.py
@@ -5,8 +5,6 @@ import subprocess
 import warnings
 from typing import Optional
 
-from benchclients.logging import fatal_and_log
-
 
 def _sysctl(stat):
     return ["sysctl", "-n", stat]
@@ -94,14 +92,14 @@ def github_info():
     if repo and pr_number and commit:
         return gh_info
     else:
-        fatal_and_log(
+        warnings.warn(
             (
                 "All of BENCHMARKABLE_REPOSITORY, BENCHMARKABLE_PR_NUMBER, and "
                 "BENCHMARKABLE_COMMIT must be set if `github` is not specified. "
-                f"Values: {gh_info}"
+                f"\nValues: `{gh_info}`"
             ),
-            etype=ValueError,
         )
+        return gh_info
 
 
 def detect_github_info():

--- a/benchadapt/python/benchadapt/machine_info.py
+++ b/benchadapt/python/benchadapt/machine_info.py
@@ -78,9 +78,11 @@ class GitParseWarning(RuntimeWarning):
 
 def github_info():
     """Get github metadata from environment variables"""
-    repo = os.environ.get("BENCHMARKABLE_REPOSITORY")
-    pr_number = os.environ.get("BENCHMARKABLE_PR_NUMBER")
-    commit = os.environ.get("BENCHMARKABLE_COMMIT")
+    repo = os.environ.get("CONBENCH_REPOSITORY")
+    pr_number = os.environ.get("CONBENCH_PR_NUMBER") or os.environ.get(
+        "BENCHMARKABLE_PR_NUMBER"
+    )
+    commit = os.environ.get("CONBENCH_COMMIT")
 
     gh_info = {
         "commit": commit,
@@ -92,8 +94,8 @@ def github_info():
     if not (repo and pr_number and commit):
         warnings.warn(
             (
-                "All of BENCHMARKABLE_REPOSITORY, BENCHMARKABLE_PR_NUMBER, and "
-                "BENCHMARKABLE_COMMIT must be set if `github` is not specified. "
+                "All of CONBENCH_REPOSITORY, CONBENCH_PR_NUMBER, and "
+                "CONBENCH_COMMIT must be set if `github` is not specified. "
                 f"\nValues: `{gh_info}`"
             ),
         )

--- a/benchadapt/python/benchadapt/machine_info.py
+++ b/benchadapt/python/benchadapt/machine_info.py
@@ -89,9 +89,7 @@ def github_info():
         "pr_number": pr_number,
     }
 
-    if repo and pr_number and commit:
-        return gh_info
-    else:
+    if not (repo and pr_number and commit):
         warnings.warn(
             (
                 "All of BENCHMARKABLE_REPOSITORY, BENCHMARKABLE_PR_NUMBER, and "
@@ -99,7 +97,8 @@ def github_info():
                 f"\nValues: `{gh_info}`"
             ),
         )
-        return gh_info
+
+    return gh_info
 
 
 def detect_github_info():

--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -57,7 +57,7 @@ class BenchmarkResult:
         architecture, etc. Auto-populated if ``cluster_info`` not set. If host name
         should not be detected with ``platform.node()`` (e.g. because a consistent
         name is needed for CI or cloud runners), it can be overridden with the
-        ``CONBENCH_HOST_NAME`` environment variable.
+        ``CONBENCH_MACHINE_INFO_NAME`` environment variable.
     cluster_info : Dict[str, Any]
         For benchmarks run on a cluster, information about the cluster
     context : Dict[str, Any]
@@ -68,8 +68,8 @@ class BenchmarkResult:
         If it's a non-default-branch & non-PR commit, you may supply the branch name to
         the optional ``branch`` key in the format ``org:branch``.
 
-        By default, metadata will be obtained from ``CONBENCH_REPOSITORY``,
-        ``CONBENCH_COMMIT``, and ``CONBENCH_PR_NUMBER`` environment variables.
+        By default, metadata will be obtained from ``CONBENCH_PROJECT_REPOSITORY``,
+        ``CONBENCH_PROJECT_COMMIT``, and ``CONBENCH_PROJECT_PR_NUMBER`` environment variables.
         If any are unset, a warning will be raised.
 
         Advanced: if you have a locally cloned repo, you may explicitly supply ``None``
@@ -176,7 +176,10 @@ class BenchmarkResult:
             res_dict["github"].get("repository") and res_dict["github"].get("commit")
         ):
             raise ValueError(
-                "Result not publishable! `github.repository` and `github.commit` must be populated"
+                "Result not publishable! `github.repository` and `github.commit` must be populated. "
+                "You may pass github metadata via CONBENCH_PROJECT_REPOSITORY, CONBENCH_PROJECT_COMMIT, "
+                "and CONBENCH_PR_NUMBER environment variables. "
+                f"\ngithub: {res_dict['github']}"
             )
 
         for attr in [

--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -175,7 +175,7 @@ class BenchmarkResult:
         if not (
             res_dict["github"].get("repository") and res_dict["github"].get("commit")
         ):
-            raise ValueError(
+            warnings.warn(
                 "Result not publishable! `github.repository` and `github.commit` must be populated. "
                 "You may pass github metadata via CONBENCH_PROJECT_REPOSITORY, CONBENCH_PROJECT_COMMIT, "
                 "and CONBENCH_PR_NUMBER environment variables. "

--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -69,8 +69,8 @@ class BenchmarkResult:
         If it's a non-default-branch & non-PR commit, you may supply the branch name to
         the optional ``branch`` key in the format ``org:branch``.
 
-        By default, metadata will be obtained from ``BENCHMARKABLE_REPOSITORY``,
-        ``BENCHMARKABLE_COMMIT``, and ``BENCHMARKABLE_PR_NUMBER`` environment variables.
+        By default, metadata will be obtained from ``CONBENCH_REPOSITORY``,
+        ``CONBENCH_COMMIT``, and ``CONBENCH_PR_NUMBER`` environment variables.
         If any are unset, a warning will be raised.
 
         Advanced: if you have a locally cloned repo, you may explicitly supply ``None``

--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -71,7 +71,7 @@ class BenchmarkResult:
 
         By default, metadata will be obtained from ``BENCHMARKABLE_REPOSITORY``,
         ``BENCHMARKABLE_COMMIT``, and ``BENCHMARKABLE_PR_NUMBER`` environment variables.
-        If any are unset, an error will be raised.
+        If any are unset, a warning will be raised.
 
         Advanced: if you have a locally cloned repo, you may explicitly supply ``None``
         to this argument and its information will be scraped from the cloned repo.

--- a/benchadapt/python/benchadapt/run.py
+++ b/benchadapt/python/benchadapt/run.py
@@ -30,7 +30,7 @@ class BenchmarkRun:
         architecture, etc. Auto-populated if ``cluster_info`` not set. If host name
         should not be detected with ``platform.node()`` (e.g. because a consistent
         name is needed for CI or cloud runners), it can be overridden with the
-        ``CONBENCH_HOST_NAME`` environment variable.
+        ``CONBENCH_MACHINE_INFO_NAME`` environment variable.
     cluster_info : Dict[str, Any]
         For benchmarks run on a cluster, information about the cluster
     github : Dict[str, Any]
@@ -39,8 +39,8 @@ class BenchmarkRun:
         If it's a non-default-branch & non-PR commit, you may supply the branch name to
         the optional ``branch`` key in the format ``org:branch``.
 
-        By default, metadata will be obtained from ``CONBENCH_REPOSITORY``,
-        ``CONBENCH_COMMIT``, and ``CONBENCH_PR_NUMBER`` environment variables.
+        By default, metadata will be obtained from ``CONBENCH_PROJECT_REPOSITORY``,
+        ``CONBENCH_PROJECT_COMMIT``, and ``CONBENCH_PROJECT_PR_NUMBER`` environment variables.
         If any are unset, a warning will be raised.
 
         Advanced: if you have a locally cloned repo, you may explicitly supply ``None``
@@ -125,7 +125,10 @@ class BenchmarkRun:
             res_dict["github"].get("repository") and res_dict["github"].get("commit")
         ):
             raise ValueError(
-                "Run not publishable! `github.repository` and `github.commit` must be populated"
+                "Run not publishable! `github.repository` and `github.commit` must be populated. "
+                "You may pass github metadata via CONBENCH_PROJECT_REPOSITORY, CONBENCH_PROJECT_COMMIT, "
+                "and CONBENCH_PR_NUMBER environment variables. "
+                f"\ngithub: {res_dict['github']}"
             )
 
         for attr in [

--- a/benchadapt/python/benchadapt/run.py
+++ b/benchadapt/python/benchadapt/run.py
@@ -42,7 +42,7 @@ class BenchmarkRun:
 
         By default, metadata will be obtained from ``BENCHMARKABLE_REPOSITORY``,
         ``BENCHMARKABLE_COMMIT``, and ``BENCHMARKABLE_PR_NUMBER`` environment variables.
-        If any are unset, an error will be raised.
+        If any are unset, a warning will be raised.
 
         Advanced: if you have a locally cloned repo, you may explicitly supply ``None``
         to this argument and its information will be scraped from the cloned repo.

--- a/benchadapt/python/benchadapt/run.py
+++ b/benchadapt/python/benchadapt/run.py
@@ -40,8 +40,8 @@ class BenchmarkRun:
         If it's a non-default-branch & non-PR commit, you may supply the branch name to
         the optional ``branch`` key in the format ``org:branch``.
 
-        By default, metadata will be obtained from ``BENCHMARKABLE_REPOSITORY``,
-        ``BENCHMARKABLE_COMMIT``, and ``BENCHMARKABLE_PR_NUMBER`` environment variables.
+        By default, metadata will be obtained from ``CONBENCH_REPOSITORY``,
+        ``CONBENCH_COMMIT``, and ``CONBENCH_PR_NUMBER`` environment variables.
         If any are unset, a warning will be raised.
 
         Advanced: if you have a locally cloned repo, you may explicitly supply ``None``

--- a/benchadapt/python/tests/adapters/test_archery.py
+++ b/benchadapt/python/tests/adapters/test_archery.py
@@ -58,8 +58,14 @@ archery_json = {
 
 
 class TestArcheryAdapter:
-    @pytest.fixture(scope="class")
-    def archery_adapter(self):
+    @pytest.fixture
+    def archery_adapter(self, monkeypatch):
+        monkeypatch.setenv(
+            "BENCHMARKABLE_REPOSITORY", "git@github.com:conchair/conchair"
+        )
+        monkeypatch.setenv("BENCHMARKABLE_PR_NUMBER", "47")
+        monkeypatch.setenv("BENCHMARKABLE_COMMIT", "2z8c9c49a5dc4a179243268e4bb6daa5")
+
         archery_adapter = ArcheryAdapter()
         archery_adapter.command = ["echo", "'Hello, world!'"]
 

--- a/benchadapt/python/tests/adapters/test_archery.py
+++ b/benchadapt/python/tests/adapters/test_archery.py
@@ -60,11 +60,9 @@ archery_json = {
 class TestArcheryAdapter:
     @pytest.fixture
     def archery_adapter(self, monkeypatch):
-        monkeypatch.setenv(
-            "BENCHMARKABLE_REPOSITORY", "git@github.com:conchair/conchair"
-        )
-        monkeypatch.setenv("BENCHMARKABLE_PR_NUMBER", "47")
-        monkeypatch.setenv("BENCHMARKABLE_COMMIT", "2z8c9c49a5dc4a179243268e4bb6daa5")
+        monkeypatch.setenv("CONBENCH_REPOSITORY", "git@github.com:conchair/conchair")
+        monkeypatch.setenv("CONBENCH_PR_NUMBER", "47")
+        monkeypatch.setenv("CONBENCH_COMMIT", "2z8c9c49a5dc4a179243268e4bb6daa5")
 
         archery_adapter = ArcheryAdapter()
         archery_adapter.command = ["echo", "'Hello, world!'"]

--- a/benchadapt/python/tests/adapters/test_archery.py
+++ b/benchadapt/python/tests/adapters/test_archery.py
@@ -60,9 +60,13 @@ archery_json = {
 class TestArcheryAdapter:
     @pytest.fixture
     def archery_adapter(self, monkeypatch):
-        monkeypatch.setenv("CONBENCH_REPOSITORY", "git@github.com:conchair/conchair")
-        monkeypatch.setenv("CONBENCH_PR_NUMBER", "47")
-        monkeypatch.setenv("CONBENCH_COMMIT", "2z8c9c49a5dc4a179243268e4bb6daa5")
+        monkeypatch.setenv(
+            "CONBENCH_PROJECT_REPOSITORY", "git@github.com:conchair/conchair"
+        )
+        monkeypatch.setenv("CONBENCH_PROJECT_PR_NUMBER", "47")
+        monkeypatch.setenv(
+            "CONBENCH_PROJECT_COMMIT", "2z8c9c49a5dc4a179243268e4bb6daa5"
+        )
 
         archery_adapter = ArcheryAdapter()
         archery_adapter.command = ["echo", "'Hello, world!'"]

--- a/benchadapt/python/tests/adapters/test_folly.py
+++ b/benchadapt/python/tests/adapters/test_folly.py
@@ -62,9 +62,13 @@ class TestFollyAdapter:
 
     @pytest.fixture
     def folly_adapter(self, monkeypatch):
-        monkeypatch.setenv("CONBENCH_REPOSITORY", "git@github.com:conchair/conchair")
-        monkeypatch.setenv("CONBENCH_PR_NUMBER", "47")
-        monkeypatch.setenv("CONBENCH_COMMIT", "2z8c9c49a5dc4a179243268e4bb6daa5")
+        monkeypatch.setenv(
+            "CONBENCH_PROJECT_REPOSITORY", "git@github.com:conchair/conchair"
+        )
+        monkeypatch.setenv("CONBENCH_PROJECT_PR_NUMBER", "47")
+        monkeypatch.setenv(
+            "CONBENCH_PROJECT_COMMIT", "2z8c9c49a5dc4a179243268e4bb6daa5"
+        )
 
         tempdir = Path(tempfile.mkdtemp())
 

--- a/benchadapt/python/tests/adapters/test_folly.py
+++ b/benchadapt/python/tests/adapters/test_folly.py
@@ -60,8 +60,14 @@ class TestFollyAdapter:
         *folly_jsons["velox_benchmark_basic_selectivity_vector.json"],
     ]
 
-    @pytest.fixture(scope="class")
-    def folly_adapter(self):
+    @pytest.fixture
+    def folly_adapter(self, monkeypatch):
+        monkeypatch.setenv(
+            "BENCHMARKABLE_REPOSITORY", "git@github.com:conchair/conchair"
+        )
+        monkeypatch.setenv("BENCHMARKABLE_PR_NUMBER", "47")
+        monkeypatch.setenv("BENCHMARKABLE_COMMIT", "2z8c9c49a5dc4a179243268e4bb6daa5")
+
         tempdir = Path(tempfile.mkdtemp())
 
         folly_adapter = FollyAdapter(

--- a/benchadapt/python/tests/adapters/test_folly.py
+++ b/benchadapt/python/tests/adapters/test_folly.py
@@ -62,11 +62,9 @@ class TestFollyAdapter:
 
     @pytest.fixture
     def folly_adapter(self, monkeypatch):
-        monkeypatch.setenv(
-            "BENCHMARKABLE_REPOSITORY", "git@github.com:conchair/conchair"
-        )
-        monkeypatch.setenv("BENCHMARKABLE_PR_NUMBER", "47")
-        monkeypatch.setenv("BENCHMARKABLE_COMMIT", "2z8c9c49a5dc4a179243268e4bb6daa5")
+        monkeypatch.setenv("CONBENCH_REPOSITORY", "git@github.com:conchair/conchair")
+        monkeypatch.setenv("CONBENCH_PR_NUMBER", "47")
+        monkeypatch.setenv("CONBENCH_COMMIT", "2z8c9c49a5dc4a179243268e4bb6daa5")
 
         tempdir = Path(tempfile.mkdtemp())
 

--- a/benchadapt/python/tests/adapters/test_gbench.py
+++ b/benchadapt/python/tests/adapters/test_gbench.py
@@ -192,8 +192,14 @@ gbench_json = {
 
 
 class TestGbenchAdapter:
-    @pytest.fixture(scope="class")
-    def gbench_adapter(self):
+    @pytest.fixture
+    def gbench_adapter(self, monkeypatch):
+        monkeypatch.setenv(
+            "BENCHMARKABLE_REPOSITORY", "git@github.com:conchair/conchair"
+        )
+        monkeypatch.setenv("BENCHMARKABLE_PR_NUMBER", "47")
+        monkeypatch.setenv("BENCHMARKABLE_COMMIT", "2z8c9c49a5dc4a179243268e4bb6daa5")
+
         result_file = tempfile.mktemp(suffix=".json")
         gbench_adapter = GoogleBenchmarkAdapter(
             command=["echo", "'Hello, world!'"], result_file=Path(result_file)

--- a/benchadapt/python/tests/adapters/test_gbench.py
+++ b/benchadapt/python/tests/adapters/test_gbench.py
@@ -194,9 +194,13 @@ gbench_json = {
 class TestGbenchAdapter:
     @pytest.fixture
     def gbench_adapter(self, monkeypatch):
-        monkeypatch.setenv("CONBENCH_REPOSITORY", "git@github.com:conchair/conchair")
-        monkeypatch.setenv("CONBENCH_PR_NUMBER", "47")
-        monkeypatch.setenv("CONBENCH_COMMIT", "2z8c9c49a5dc4a179243268e4bb6daa5")
+        monkeypatch.setenv(
+            "CONBENCH_PROJECT_REPOSITORY", "git@github.com:conchair/conchair"
+        )
+        monkeypatch.setenv("CONBENCH_PROJECT_PR_NUMBER", "47")
+        monkeypatch.setenv(
+            "CONBENCH_PROJECT_COMMIT", "2z8c9c49a5dc4a179243268e4bb6daa5"
+        )
 
         result_file = tempfile.mktemp(suffix=".json")
         gbench_adapter = GoogleBenchmarkAdapter(

--- a/benchadapt/python/tests/adapters/test_gbench.py
+++ b/benchadapt/python/tests/adapters/test_gbench.py
@@ -194,11 +194,9 @@ gbench_json = {
 class TestGbenchAdapter:
     @pytest.fixture
     def gbench_adapter(self, monkeypatch):
-        monkeypatch.setenv(
-            "BENCHMARKABLE_REPOSITORY", "git@github.com:conchair/conchair"
-        )
-        monkeypatch.setenv("BENCHMARKABLE_PR_NUMBER", "47")
-        monkeypatch.setenv("BENCHMARKABLE_COMMIT", "2z8c9c49a5dc4a179243268e4bb6daa5")
+        monkeypatch.setenv("CONBENCH_REPOSITORY", "git@github.com:conchair/conchair")
+        monkeypatch.setenv("CONBENCH_PR_NUMBER", "47")
+        monkeypatch.setenv("CONBENCH_COMMIT", "2z8c9c49a5dc4a179243268e4bb6daa5")
 
         result_file = tempfile.mktemp(suffix=".json")
         gbench_adapter = GoogleBenchmarkAdapter(

--- a/benchadapt/python/tests/test_result.py
+++ b/benchadapt/python/tests/test_result.py
@@ -79,18 +79,22 @@ class TestBenchmarkResult:
             ).to_publishable_dict()
 
     def test_github_detection(self, monkeypatch):
-        monkeypatch.setenv("CONBENCH_REPOSITORY", res_json["github"]["repository"])
-        monkeypatch.setenv("CONBENCH_PR_NUMBER", res_json["github"]["pr_number"])
-        monkeypatch.setenv("CONBENCH_COMMIT", res_json["github"]["commit"])
+        monkeypatch.setenv(
+            "CONBENCH_PROJECT_REPOSITORY", res_json["github"]["repository"]
+        )
+        monkeypatch.setenv(
+            "CONBENCH_PROJECT_PR_NUMBER", res_json["github"]["pr_number"]
+        )
+        monkeypatch.setenv("CONBENCH_PROJECT_COMMIT", res_json["github"]["commit"])
         assert BenchmarkResult().github == res_json["github"]
 
-        monkeypatch.delenv("CONBENCH_REPOSITORY")
-        monkeypatch.delenv("CONBENCH_PR_NUMBER")
-        monkeypatch.delenv("CONBENCH_COMMIT")
+        monkeypatch.delenv("CONBENCH_PROJECT_REPOSITORY")
+        monkeypatch.delenv("CONBENCH_PROJECT_PR_NUMBER")
+        monkeypatch.delenv("CONBENCH_PROJECT_COMMIT")
 
         with pytest.warns(
             UserWarning,
-            match="Both CONBENCH_REPOSITORY and CONBENCH_COMMIT must be set if `github` is not specified",
+            match="Both CONBENCH_PROJECT_REPOSITORY and CONBENCH_PROJECT_COMMIT must be set if `github` is not specified",
         ):
             BenchmarkResult()
 
@@ -102,7 +106,7 @@ class TestBenchmarkResult:
 
     def test_host_detection(self, monkeypatch):
         machine_info_name = "fake-computer-name"
-        monkeypatch.setenv("CONBENCH_HOST_NAME", machine_info_name)
+        monkeypatch.setenv("CONBENCH_MACHINE_INFO_NAME", machine_info_name)
 
         result = BenchmarkResult(github=res_json["github"])
 

--- a/benchadapt/python/tests/test_result.py
+++ b/benchadapt/python/tests/test_result.py
@@ -75,16 +75,16 @@ class TestBenchmarkResult:
             ).to_publishable_dict()
 
     def test_github_detection(self, monkeypatch):
-        monkeypatch.setenv("BENCHMARKABLE_REPOSITORY", res_json["github"]["repository"])
-        monkeypatch.setenv("BENCHMARKABLE_PR_NUMBER", res_json["github"]["pr_number"])
-        monkeypatch.setenv("BENCHMARKABLE_COMMIT", res_json["github"]["commit"])
+        monkeypatch.setenv("CONBENCH_REPOSITORY", res_json["github"]["repository"])
+        monkeypatch.setenv("CONBENCH_PR_NUMBER", res_json["github"]["pr_number"])
+        monkeypatch.setenv("CONBENCH_COMMIT", res_json["github"]["commit"])
         assert BenchmarkResult().github == res_json["github"]
 
-        monkeypatch.delenv("BENCHMARKABLE_REPOSITORY")
-        monkeypatch.delenv("BENCHMARKABLE_PR_NUMBER")
-        monkeypatch.delenv("BENCHMARKABLE_COMMIT")
+        monkeypatch.delenv("CONBENCH_REPOSITORY")
+        monkeypatch.delenv("CONBENCH_PR_NUMBER")
+        monkeypatch.delenv("CONBENCH_COMMIT")
         with pytest.warns(
             UserWarning,
-            match="All of BENCHMARKABLE_REPOSITORY, BENCHMARKABLE_PR_NUMBER, and BENCHMARKABLE_COMMIT must be set if `github` is not specified.",
+            match="All of CONBENCH_REPOSITORY, CONBENCH_PR_NUMBER, and CONBENCH_COMMIT must be set if `github` is not specified.",
         ):
             BenchmarkResult()

--- a/benchadapt/python/tests/test_result.py
+++ b/benchadapt/python/tests/test_result.py
@@ -98,8 +98,8 @@ class TestBenchmarkResult:
         ):
             BenchmarkResult()
 
-            with pytest.raises(
-                ValueError,
+            with pytest.warns(
+                UserWarning,
                 match="Result not publishable! `github.repository` and `github.commit` must be populated",
             ):
                 BenchmarkResult().to_publishable_dict()

--- a/benchadapt/python/tests/test_run.py
+++ b/benchadapt/python/tests/test_run.py
@@ -1,0 +1,84 @@
+import pytest
+
+from benchadapt import BenchmarkRun
+
+run_json = {
+    "name": "very-real-benchmark",
+    "id": "ezf69672dc3741259aac97650414a18c",
+    "reason": "test",
+    "finished_timestamp": "2202-09-16T15:42:27.527948+00:00",
+    "error_info": {"stack_trace": ["nothing", "really", "went", "wrong"]},
+    "error_type": "none really",
+    "info": {},
+    "machine_info": {
+        "name": "beepboop.local",
+        "os_name": "macOS",
+        "os_version": "12.6",
+        "architecture_name": "arm64",
+        "kernel_name": "21.6.0",
+        "memory_bytes": "17179869184",
+        "cpu_model_name": "Apple M3 Pro",
+        "cpu_core_count": "100",
+        "cpu_thread_count": "100",
+        "cpu_l1d_cache_bytes": "655360",
+        "cpu_l1i_cache_bytes": "1310720",
+        "cpu_l2_cache_bytes": "41943040",
+        "cpu_l3_cache_bytes": "0",
+        "cpu_frequency_max_hz": "0",
+        "gpu_count": "0",
+        "gpu_product_names": [],
+    },
+    "github": {
+        "commit": "2z8c9c49a5dc4a179243268e4bb6daa5",
+        "repository": "git@github.com:conchair/conchair",
+        "pr_number": "47",
+    },
+}
+
+
+class TestBenchmarkRun:
+    def test_roundtrip(self):
+        run = BenchmarkRun(**run_json)
+        assert run_json == run.to_publishable_dict()
+
+    def test_warns_machine_cluster(self):
+        with pytest.warns(UserWarning, match="Run not publishable!"):
+            BenchmarkRun(
+                machine_info={}, cluster_info={}, github=run_json["github"]
+            ).to_publishable_dict()
+
+        with pytest.warns(UserWarning, match="Run not publishable!"):
+            BenchmarkRun(
+                machine_info=None, cluster_info=None, github=run_json["github"]
+            ).to_publishable_dict()
+
+    def test_github_detection(self, monkeypatch):
+        monkeypatch.setenv("CONBENCH_REPOSITORY", run_json["github"]["repository"])
+        monkeypatch.setenv("CONBENCH_PR_NUMBER", run_json["github"]["pr_number"])
+        monkeypatch.setenv("CONBENCH_COMMIT", run_json["github"]["commit"])
+        assert BenchmarkRun().github == run_json["github"]
+
+        monkeypatch.delenv("CONBENCH_REPOSITORY")
+        monkeypatch.delenv("CONBENCH_PR_NUMBER")
+        monkeypatch.delenv("CONBENCH_COMMIT")
+
+        with pytest.warns(
+            UserWarning,
+            match="Both CONBENCH_REPOSITORY and CONBENCH_COMMIT must be set if `github` is not specified",
+        ):
+            BenchmarkRun()
+
+            with pytest.raises(
+                ValueError,
+                match="Run not publishable! `github.repository` and `github.commit` must be populated",
+            ):
+                BenchmarkRun().to_publishable_dict()
+
+    def test_host_detection(self, monkeypatch):
+        machine_info_name = "fake-computer-name"
+        monkeypatch.setenv("CONBENCH_HOST_NAME", machine_info_name)
+
+        run = BenchmarkRun(github=run_json["github"])
+
+        assert run.machine_info["name"] == machine_info_name
+        assert run.machine_info["name"] != run_json["machine_info"]["name"]

--- a/benchadapt/python/tests/test_run.py
+++ b/benchadapt/python/tests/test_run.py
@@ -53,18 +53,22 @@ class TestBenchmarkRun:
             ).to_publishable_dict()
 
     def test_github_detection(self, monkeypatch):
-        monkeypatch.setenv("CONBENCH_REPOSITORY", run_json["github"]["repository"])
-        monkeypatch.setenv("CONBENCH_PR_NUMBER", run_json["github"]["pr_number"])
-        monkeypatch.setenv("CONBENCH_COMMIT", run_json["github"]["commit"])
+        monkeypatch.setenv(
+            "CONBENCH_PROJECT_REPOSITORY", run_json["github"]["repository"]
+        )
+        monkeypatch.setenv(
+            "CONBENCH_PROJECT_PR_NUMBER", run_json["github"]["pr_number"]
+        )
+        monkeypatch.setenv("CONBENCH_PROJECT_COMMIT", run_json["github"]["commit"])
         assert BenchmarkRun().github == run_json["github"]
 
-        monkeypatch.delenv("CONBENCH_REPOSITORY")
-        monkeypatch.delenv("CONBENCH_PR_NUMBER")
-        monkeypatch.delenv("CONBENCH_COMMIT")
+        monkeypatch.delenv("CONBENCH_PROJECT_REPOSITORY")
+        monkeypatch.delenv("CONBENCH_PROJECT_PR_NUMBER")
+        monkeypatch.delenv("CONBENCH_PROJECT_COMMIT")
 
         with pytest.warns(
             UserWarning,
-            match="Both CONBENCH_REPOSITORY and CONBENCH_COMMIT must be set if `github` is not specified",
+            match="Both CONBENCH_PROJECT_REPOSITORY and CONBENCH_PROJECT_COMMIT must be set if `github` is not specified",
         ):
             BenchmarkRun()
 
@@ -76,7 +80,7 @@ class TestBenchmarkRun:
 
     def test_host_detection(self, monkeypatch):
         machine_info_name = "fake-computer-name"
-        monkeypatch.setenv("CONBENCH_HOST_NAME", machine_info_name)
+        monkeypatch.setenv("CONBENCH_MACHINE_INFO_NAME", machine_info_name)
 
         run = BenchmarkRun(github=run_json["github"])
 

--- a/benchconnect/README.md
+++ b/benchconnect/README.md
@@ -29,12 +29,12 @@ slash, e.g. `https://conbench.example.com`
 server is private.
 - `CONBENCH_PASSWORD`: The password to use for Conbench login. Only required
 if the server is private.
-- `CONBENCH_REPOSITORY`: The repository name (in the format `org/repo`) or the
+- `CONBENCH_PROJECT_REPOSITORY`: The repository name (in the format `org/repo`) or the
 URL (in the format `https://github.com/org/repo`)
-- `CONBENCH_PR_NUMBER`: [recommended] The number of the GitHub pull request that
+- `CONBENCH_PROJECT_PR_NUMBER`: [recommended] The number of the GitHub pull request that
 is running this benchmark, or ``None`` if for a run on the default branch
-- `CONBENCH_COMMIT`: The 40-character commit SHA of the repo being benchmarked
-- `CONBENCH_HOST_NAME`: By default, the running machine host name (sent in
+- `CONBENCH_PROJECT_COMMIT`: The 40-character commit SHA of the repo being benchmarked
+- `CONBENCH_MACHINE_INFO_NAME`: By default, the running machine host name (sent in
 `machine_info.name` when posting runs and benchmarks) will be obtained with
 `platform.node()`, but in circumstances where consistency is needed (e.g.
 running in CI or on cloud runners), a value for host name can be specified via

--- a/benchconnect/README.md
+++ b/benchconnect/README.md
@@ -32,7 +32,7 @@ if the server is private.
 - `CONBENCH_PROJECT_REPOSITORY`: The repository name (in the format `org/repo`) or the
 URL (in the format `https://github.com/org/repo`)
 - `CONBENCH_PROJECT_PR_NUMBER`: [recommended] The number of the GitHub pull request that
-is running this benchmark, or ``None`` if for a run on the default branch
+is running this benchmark. Do not supply this for a runs on the default branch.
 - `CONBENCH_PROJECT_COMMIT`: The 40-character commit SHA of the repo being benchmarked
 - `CONBENCH_MACHINE_INFO_NAME`: By default, the running machine host name (sent in
 `machine_info.name` when posting runs and benchmarks) will be obtained with

--- a/benchconnect/README.md
+++ b/benchconnect/README.md
@@ -18,6 +18,28 @@ With [pipx](https://pypa.github.io/pipx/):
 pipx install benchconnect@git+https://github.com/conbench/conbench.git@main#subdirectory=benchconnect
 ```
 
+## Environment variables
+
+benchconnect relies on a number of environment variables to obtain various
+metadata:
+
+- `CONBENCH_URL`: The URL of the Conbench server. Required.
+- `CONBENCH_EMAIL`: The email to use for Conbench login. Only required if the
+server is private.
+- `CONBENCH_PASSWORD`: The password to use for Conbench login. Only required
+if the server is private.
+- `BENCHMARKABLE_REPOSITORY`: The URL of the repo being benchmarked. Defaults
+to `"https://github.com/apache/arrow"` if unset.
+- `BENCHMARKABLE_PR_NUMBER`: Integer of pull request number associated with
+the run being benchmarked.
+- `BENCHMARKABLE_COMMIT`: Hash of commit being benchmarked. If missing, will
+attempt to obtain it from `arrow::arrow_info()$build_info$git_id`, though
+this may not be populated depending on how Arrow was built.
+- `CONBENCH_HOST_NAME`: By default, the running machine host name will be
+obtained with `platform.node()`, but in circumstances where consistency is
+needed (e.g. running in CI or on cloud runners), a value for host name can
+be specified via this environment variable instead.
+
 ## Usage
 
 ### Benchmark run workflow

--- a/benchconnect/README.md
+++ b/benchconnect/README.md
@@ -23,22 +23,22 @@ pipx install benchconnect@git+https://github.com/conbench/conbench.git@main#subd
 benchconnect relies on a number of environment variables to obtain various
 metadata:
 
-- `CONBENCH_URL`: The URL of the Conbench server. Required.
+- `CONBENCH_URL`: Required. The URL of the Conbench server without a trailing
+slash, e.g. `https://conbench.example.com`
 - `CONBENCH_EMAIL`: The email to use for Conbench login. Only required if the
 server is private.
 - `CONBENCH_PASSWORD`: The password to use for Conbench login. Only required
 if the server is private.
-- `CONBENCH_REPOSITORY`: The URL of the repo being benchmarked. Defaults
-to `"https://github.com/apache/arrow"` if unset.
-- `CONBENCH_PR_NUMBER`: Integer of pull request number associated with
-the run being benchmarked.
-- `CONBENCH_COMMIT`: Hash of commit being benchmarked. If missing, will
-attempt to obtain it from `arrow::arrow_info()$build_info$git_id`, though
-this may not be populated depending on how Arrow was built.
-- `CONBENCH_HOST_NAME`: By default, the running machine host name will be
-obtained with `platform.node()`, but in circumstances where consistency is
-needed (e.g. running in CI or on cloud runners), a value for host name can
-be specified via this environment variable instead.
+- `CONBENCH_REPOSITORY`: The repository name (in the format `org/repo`) or the
+URL (in the format `https://github.com/org/repo`)
+- `CONBENCH_PR_NUMBER`: [recommended] The number of the GitHub pull request that
+is running this benchmark, or ``None`` if for a run on the default branch
+- `CONBENCH_COMMIT`: The 40-character commit SHA of the repo being benchmarked
+- `CONBENCH_HOST_NAME`: By default, the running machine host name (sent in
+`machine_info.name` when posting runs and benchmarks) will be obtained with
+`platform.node()`, but in circumstances where consistency is needed (e.g.
+running in CI or on cloud runners), a value for host name can be specified via
+this environment variable instead.
 
 ## Usage
 

--- a/benchconnect/README.md
+++ b/benchconnect/README.md
@@ -28,11 +28,11 @@ metadata:
 server is private.
 - `CONBENCH_PASSWORD`: The password to use for Conbench login. Only required
 if the server is private.
-- `BENCHMARKABLE_REPOSITORY`: The URL of the repo being benchmarked. Defaults
+- `CONBENCH_REPOSITORY`: The URL of the repo being benchmarked. Defaults
 to `"https://github.com/apache/arrow"` if unset.
-- `BENCHMARKABLE_PR_NUMBER`: Integer of pull request number associated with
+- `CONBENCH_PR_NUMBER`: Integer of pull request number associated with
 the run being benchmarked.
-- `BENCHMARKABLE_COMMIT`: Hash of commit being benchmarked. If missing, will
+- `CONBENCH_COMMIT`: Hash of commit being benchmarked. If missing, will
 attempt to obtain it from `arrow::arrow_info()$build_info$git_id`, though
 this may not be populated depending on how Arrow was built.
 - `CONBENCH_HOST_NAME`: By default, the running machine host name will be

--- a/benchconnect/tests/test_augment.py
+++ b/benchconnect/tests/test_augment.py
@@ -13,11 +13,17 @@ minimal_result = {"stats": {"data": [1, 2], "unit": "s"}}
 minimal_run = {}
 
 
+@pytest.fixture
+def mock_github_env_vars(monkeypatch):
+    monkeypatch.setenv("CONBENCH_REPOSITORY", "conchair/conchair")
+    monkeypatch.setenv("CONBENCH_COMMIT", "fake-commit-hash")
+
+
 @pytest.mark.parametrize(
     ("raw_blob", "cls"),
     [(minimal_result, BenchmarkResult), (minimal_run, BenchmarkRun)],
 )
-def test_augment_blob(raw_blob: dict, cls):
+def test_augment_blob(raw_blob: dict, cls, mock_github_env_vars):
     augmented_blob = augment_blob(raw_blob, cls=cls)
     assert augmented_blob.keys() > raw_blob.keys()
 
@@ -34,7 +40,7 @@ class TestCliAugment:
     @pytest.mark.parametrize(
         ("command", "raw_blob"), [(result, minimal_result), (run, minimal_run)]
     )
-    def test_json(self, command: click.Command, raw_blob: dict):
+    def test_json(self, command: click.Command, raw_blob: dict, mock_github_env_vars):
         res = self.runner.invoke(command, args=["--json", json.dumps(raw_blob)])
         assert res.exit_code == 0
         augmented_blob = json.loads(res.output)
@@ -43,7 +49,9 @@ class TestCliAugment:
     @pytest.mark.parametrize(
         ("command", "raw_blob"), [(result, minimal_result), (run, minimal_run)]
     )
-    def test_path(self, command: click.Command, raw_blob: dict, tmpdir):
+    def test_path(
+        self, command: click.Command, raw_blob: dict, tmpdir, mock_github_env_vars
+    ):
         tempjson1 = tmpdir / "file1.json"
         tempjson2 = tmpdir / "file2.json"
 

--- a/benchconnect/tests/test_augment.py
+++ b/benchconnect/tests/test_augment.py
@@ -15,8 +15,8 @@ minimal_run = {}
 
 @pytest.fixture
 def mock_github_env_vars(monkeypatch):
-    monkeypatch.setenv("CONBENCH_REPOSITORY", "conchair/conchair")
-    monkeypatch.setenv("CONBENCH_COMMIT", "fake-commit-hash")
+    monkeypatch.setenv("CONBENCH_PROJECT_REPOSITORY", "conchair/conchair")
+    monkeypatch.setenv("CONBENCH_PROJECT_COMMIT", "fake-commit-hash")
 
 
 @pytest.mark.parametrize(

--- a/benchrun/python/tests/test_benchmark_list.py
+++ b/benchrun/python/tests/test_benchmark_list.py
@@ -1,3 +1,5 @@
+import pytest
+
 from benchrun import Benchmark, BenchmarkList, CaseList, Iteration
 
 
@@ -13,13 +15,24 @@ class TestBenchmarkList:
     case_list = CaseList(params={"foo": [1, 10, 100]})
     benchmark = Benchmark(iteration=iteration, case_list=case_list)
     benchmark_list = BenchmarkList([benchmark, benchmark])
+    github = {
+        "commit": "2z8c9c49a5dc4a179243268e4bb6daa5",
+        "repository": "git@github.com:conchair/conchair",
+        "pr_number": "47",
+    }
+
+    @pytest.fixture
+    def mock_github_env_vars(self, monkeypatch):
+        monkeypatch.setenv("CONBENCH_PROJECT_REPOSITORY", self.github["repository"])
+        monkeypatch.setenv("CONBENCH_PROJECT_PR_NUMBER", self.github["pr_number"])
+        monkeypatch.setenv("CONBENCH_PROJECT_COMMIT", self.github["commit"])
 
     def test_init(self) -> None:
 
         assert len(self.benchmark_list.benchmarks) == 2
         assert self.benchmark_list.benchmarks[0] == self.benchmark
 
-    def test_call(self) -> None:
+    def test_call(self, mock_github_env_vars) -> None:
         result_list = self.benchmark_list(run_reason="test")
         assert len(result_list) == (
             len(self.benchmark_list.benchmarks) * len(self.case_list.case_list)

--- a/conbench/machine_info.py
+++ b/conbench/machine_info.py
@@ -138,7 +138,7 @@ def github_info():
 def machine_info(host_name):
     os_name, os_version = platform.platform(terse=True).split("-", maxsplit=1)
 
-    host_name = host_name or os.environ.get("CONBENCH_HOST_NAME")
+    host_name = host_name or os.environ.get("CONBENCH_MACHINE_INFO_NAME")
     host_name = host_name or platform.node()
 
     info = {

--- a/conbench/machine_info.py
+++ b/conbench/machine_info.py
@@ -138,8 +138,8 @@ def github_info():
 def machine_info(host_name):
     os_name, os_version = platform.platform(terse=True).split("-", maxsplit=1)
 
-    if not host_name:
-        host_name = platform.node()
+    host_name = host_name or os.environ.get("CONBENCH_HOST_NAME")
+    host_name = host_name or platform.node()
 
     info = {
         "name": host_name,


### PR DESCRIPTION
Cleanup for passing metadata about a run to runners for posting via various environment variables. Specifically:

- Extends/replaces `BENCHMARKABLE_PR_NUMBER` with ~`BENCHMARKABLE_REPOSITORY` and `BENCHMARKABLE_COMMIT`~ `CONBENCH_PR_NUMBER`, `CONBENCH_REPOSITORY`, and `CONBENCH_COMMIT` so all github info can be passed via env vars. Since this makes everything automatable again, I changed the default for populating `github` in `benchadapt.BenchmarkResult` and `benchadapt.BenchmarkRun` to attempt to grab the metadata from the env vars instead of an empty dict (which will always fail if posted). If any are unspecified, it will raise a warning. All existing behavior (including pass `None` for detection) should continue as-is unless we're relying on that empty dict somewhere (which we shouldn't). I did not implement this for the old conbench version since nothing relying on it should need this new functionality (everything is already specifying this directly), though if we think I should I can.
- Adds `CONBENCH_HOST_NAME` as an env var to use as an alternative to detecting the machine host name in `machine_info()` (needed for cases where a consistent host name is needed where the actual one can vary, like on CI or cloud runners). Previously this was handled via the `.conbench` config; that will keep working for now, but this is intended to be the preferred path for this in the future. Implemented in conbench version as well because it's simple.
- Documents everything in docstrings and benchconnect, which are the two important places they'll be needed.
- Not here but related: I haven't introduced them externally anywhere (yet), but in an upcoming arrowbench PR I'll start using `CONBENCH_RUN_NAME`, `CONBENCH_RUN_ID`, and `CONBENCH_RUN_REASON` internally, and I'll likely reuse those again when I rework arrow-benchmarks-ci (again internally). I don't see a reason yet to codify them anywhere since usages are all internal, but consistency in implementations is nice, and anybody implementing benchmarks that will be sent to a Conbench server will likely need similar. Once things are settled, these should probably go in an implementation guidebook or CI template or however we decide to document implementation.