### PR TITLE
history plot: special treatment for multisample

### DIFF
--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -2,12 +2,12 @@ import collections
 import datetime
 import json
 import logging
+from typing import Optional
 
 import bokeh.plotting
 import dateutil
 from bokeh.models import Spacer
 
-from typing import Optional
 from ..hacks import sorted_data
 from ..units import formatter_for_unit
 

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -402,13 +402,13 @@ def time_series_plot(history, benchmark, run, height=380, width=1100):
             name="benchmark",
         )
 
-    renderers = [
+    hover_renderers = [
         scatter_mean_over_time,
         cur_bench_mean_circle,
     ]
 
     if multisample:
-        renderers.append(cur_bench_min_circle)
+        hover_renderers.append(cur_bench_min_circle)
 
     p.add_tools(
         bokeh.models.HoverTool(
@@ -420,7 +420,7 @@ def time_series_plot(history, benchmark, run, height=380, width=1100):
                 ("commit", "@commits"),
             ],
             formatters={"$x": "datetime"},
-            renderers=renderers,
+            renderers=hover_renderers,
         )
     )
 


### PR DESCRIPTION
As discussed in https://github.com/conbench/conbench/pull/591 it makes sense to enrich the history plot with plotting details depending on
- each benchmark having more than one duration sample ('multisample", N>1 case)
- each benchmark having at most one duration sample (N=1 case)

With N=1 min matches mean and this looks rather busy:

![Screenshot from 2023-01-12 16-25-46mod](https://user-images.githubusercontent.com/265630/212109516-259854b0-b452-4589-b2fe-2d3f99304842.png)

Also, the 'current benchmark' black cross can come too close to the black circle for min:


![Screenshot from 2023-01-12 16-08-24](https://user-images.githubusercontent.com/265630/212109696-a2d133c2-2db7-4d2d-9995-86bd10e7649f.png)

This PR addresses both.

## Screenshots for what this PR does

### plot for N=1

![Screenshot from 2023-01-12 16-34-51](https://user-images.githubusercontent.com/265630/212110591-d5b5ae02-3bb9-46a5-bcdb-8d62c5f78386.png)


### plot for N>1



![Screenshot from 2023-01-12 16-15-55](https://user-images.githubusercontent.com/265630/212110207-9d374baf-b543-4a6e-b086-4523b4f5fa4b.png)


