### PR TITLE
history plot: show commit hash in addition to msg

### DIFF
--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -184,7 +184,8 @@ def _source(
     # Change this to use short commit hashes. The long commit message prefix
     # does not unambiguously specify the commit. Ideally link to the commit, in
     # the tooltip?
-    commits = [x["message"] for x in data]
+    commits = [d["message"] for d in data]
+
     dates = [dateutil.parser.isoparse(x["timestamp"]) for x in data]
 
     points, means = [], []
@@ -211,20 +212,12 @@ def _source(
         # the tooltip string labels?
         points = [x.split(" ")[0] for x in means]
 
-    commit_hashes_short = []
-    for d in data:
-        try:
-            commit_hashes_short.append("#" + d["sha"][:7])
-        except KeyError:
-            # https://github.com/conbench/conbench/issues/589
-            commit_hashes_short.append("not-set")
-
     return bokeh.models.ColumnDataSource(
         data={
             "x": dates,
             "y": points,
             "commits": commits,
-            "commit_hashes_short": commit_hashes_short,
+            "commit_hashes_short": ["#" + d["sha"][:7] for d in data],
             "means": means,
         }
     )
@@ -291,6 +284,7 @@ def time_series_plot(history, benchmark, run, height=380, width=1100):
                 "mean": benchmark["stats"]["mean"],
                 "message": run["commit"]["message"],
                 "timestamp": run["commit"]["timestamp"],
+                "sha": run["commit"]["sha"],
             }
         ],
         unit,
@@ -303,6 +297,7 @@ def time_series_plot(history, benchmark, run, height=380, width=1100):
                 "mean": benchmark["stats"]["min"],
                 "message": run["commit"]["message"],
                 "timestamp": run["commit"]["timestamp"],
+                "sha": run["commit"]["sha"],
             }
         ],
         unit,

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -211,8 +211,23 @@ def _source(
         # the tooltip string labels?
         points = [x.split(" ")[0] for x in means]
 
-    source_data = dict(x=dates, y=points, commits=commits, means=means)
-    return bokeh.models.ColumnDataSource(data=source_data)
+    commit_hashes_short = []
+    for d in data:
+        try:
+            commit_hashes_short.append("#" + d["sha"][:7])
+        except KeyError:
+            # https://github.com/conbench/conbench/issues/589
+            commit_hashes_short.append("not-set")
+
+    return bokeh.models.ColumnDataSource(
+        data={
+            "x": dates,
+            "y": points,
+            "commits": commits,
+            "commit_hashes_short": commit_hashes_short,
+            "means": means,
+        }
+    )
 
 
 def _inspect_for_multisample(items) -> tuple[bool, Optional[int]]:
@@ -443,7 +458,7 @@ def time_series_plot(history, benchmark, run, height=380, width=1100):
                 # Note(JP): this is where the `means` name becomes special,
                 # I think.
                 ("mean", "@means"),
-                ("commit", "@commits"),
+                ("commit", "@commit_hashes_short"),
             ],
             formatters={"$x": "datetime"},
             renderers=hover_renderers,

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -184,7 +184,7 @@ def _source(
     # Change this to use short commit hashes. The long commit message prefix
     # does not unambiguously specify the commit. Ideally link to the commit, in
     # the tooltip?
-    commits = [d["message"] for d in data]
+    commit_messages = [d["message"] for d in data]
 
     dates = [dateutil.parser.isoparse(x["timestamp"]) for x in data]
 
@@ -216,7 +216,7 @@ def _source(
         data={
             "x": dates,
             "y": points,
-            "commits": commits,
+            "commit_messages": commit_messages,
             "commit_hashes_short": ["#" + d["sha"][:7] for d in data],
             "means": means,
         }
@@ -454,6 +454,7 @@ def time_series_plot(history, benchmark, run, height=380, width=1100):
                 # I think.
                 ("mean", "@means"),
                 ("commit", "@commit_hashes_short"),
+                ("commit msg", "@commit_messages"),
             ],
             formatters={"$x": "datetime"},
             renderers=hover_renderers,

--- a/conbench/tests/app/test_plots.py
+++ b/conbench/tests/app/test_plots.py
@@ -178,7 +178,7 @@ def test__source():
     assert source.data["x"] == DATES
     assert source.data["y"] == POINTS
     assert source.data["means"] == MEANS
-    assert source.data["commits"] == COMMITS
+    assert source.data["commit_messages"] == COMMITS
 
 
 def test_source_formatted():
@@ -186,7 +186,7 @@ def test_source_formatted():
     assert source.data["x"] == DATES
     assert source.data["y"] == POINTS_FORMATTED
     assert source.data["means"] == MEANS
-    assert source.data["commits"] == COMMITS
+    assert source.data["commit_messages"] == COMMITS
 
 
 def test_source_formatted_items_per_second():
@@ -194,7 +194,7 @@ def test_source_formatted_items_per_second():
     assert source.data["x"] == DATES
     assert source.data["y"] == POINTS_FORMATTED_ITEMS
     assert source.data["means"] == MEANS_ITEMS
-    assert source.data["commits"] == COMMITS
+    assert source.data["commit_messages"] == COMMITS
 
 
 def test_source_alert_min():
@@ -202,7 +202,7 @@ def test_source_alert_min():
     assert source.data["x"] == DATES
     assert source.data["y"] == POINTS_MIN
     assert source.data["means"] == MEANS_MIN
-    assert source.data["commits"] == COMMITS
+    assert source.data["commit_messages"] == COMMITS
 
 
 def test_source_alert_min_formatted():
@@ -210,7 +210,7 @@ def test_source_alert_min_formatted():
     assert source.data["x"] == DATES
     assert source.data["y"] == POINTS_MIN_FORMATTED
     assert source.data["means"] == MEANS_MIN
-    assert source.data["commits"] == COMMITS
+    assert source.data["commit_messages"] == COMMITS
 
 
 def test_source_alert_max():
@@ -218,7 +218,7 @@ def test_source_alert_max():
     assert source.data["x"] == DATES
     assert source.data["y"] == POINTS_MAX
     assert source.data["means"] == MEANS_MAX
-    assert source.data["commits"] == COMMITS
+    assert source.data["commit_messages"] == COMMITS
 
 
 def test_source_alert_max_formatted():
@@ -226,7 +226,7 @@ def test_source_alert_max_formatted():
     assert source.data["x"] == DATES
     assert source.data["y"] == POINTS_MAX_FORMATTED
     assert source.data["means"] == MEANS_MAX
-    assert source.data["commits"] == COMMITS
+    assert source.data["commit_messages"] == COMMITS
 
 
 def test_should_format():


### PR DESCRIPTION
Before: tooltip showed commit msg prefix:
![Screenshot from 2023-01-13 14-56-24](https://user-images.githubusercontent.com/265630/212341876-bd7bd7ce-1667-4937-9608-f568031211d5.png)


After: tooltip shows short commit hash:
![Screenshot from 2023-01-13 15-20-07](https://user-images.githubusercontent.com/265630/212341987-92699abf-a8b1-4956-9f4e-719d3ea6c93b.png)

I think that's a tiny improvement. Of course, more importantly, we may want to link to that benchmark result (that's tracked in a different ticket which I just didn't find quickly -- update: https://github.com/conbench/conbench/issues/477).

Interestingly, I found that the internal state may not be consistent, probably as of a lack of input data validation: https://github.com/conbench/conbench/issues/589#issuecomment-1381918202