### PR TITLE
Accept `"pr_number": ""`

### DIFF
--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -59,7 +59,7 @@ class Run(Base, EntityMixin):
 
         if github_data := data.pop("github", None):
             repository = repository_to_url(github_data["repository"])
-            pr_number = github_data.get("pr_number")
+            pr_number = github_data.get("pr_number") or None
             branch = github_data.get("branch")
             sha = github_data["commit"]
 

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -59,7 +59,7 @@ class Run(Base, EntityMixin):
 
         if github_data := data.pop("github", None):
             repository = repository_to_url(github_data["repository"])
-            pr_number = github_data.get("pr_number") or None
+            pr_number = github_data.get("pr_number")
             branch = github_data.get("branch")
             sha = github_data["commit"]
 
@@ -278,6 +278,13 @@ def commit_hardware_run_map():
 
 
 class GitHubCreate(marshmallow.Schema):
+    @marshmallow.pre_load
+    def change_pr_number_empty_string_to_none(self, data, **kwargs):
+        if "pr_number" in data:
+            data["pr_number"] = data["pr_number"] or None
+
+        return data
+
     commit = marshmallow.fields.String(
         required=True,
         metadata={

--- a/conbench/tests/api/test_benchmarks.py
+++ b/conbench/tests/api/test_benchmarks.py
@@ -780,6 +780,9 @@ class TestBenchmarkPost(_asserts.PostEnforcer):
         data = copy.deepcopy(self.valid_payload)
         data["run_id"] = _uuid()
         data["github"]["pr_number"] = pr_number
+        # viable `github` submissions without `pr_number`:
+        # - just `repository` and `commit` (assumed to be on default branch)
+        # - submit `branch` directly instead (mostly discouraged, but possible)
         if pr_number == "<absent>":
             data["github"].pop("pr_number")
 

--- a/conbench/tests/api/test_benchmarks.py
+++ b/conbench/tests/api/test_benchmarks.py
@@ -774,6 +774,21 @@ class TestBenchmarkPost(_asserts.PostEnforcer):
         location = "http://localhost/api/benchmarks/%s/" % new_id
         self.assert_201_created(response, _expected_entity(benchmark_result), location)
 
+    @pytest.mark.parametrize("pr_number", [12345678, "12345678", None, "", "<absent>"])
+    def test_create_allow_pr_number_variations(self, pr_number, client):
+        self.authenticate(client)
+        data = copy.deepcopy(self.valid_payload)
+        data["run_id"] = _uuid()
+        data["github"]["pr_number"] = pr_number
+        if pr_number == "<absent>":
+            data["github"].pop("pr_number")
+
+        response = client.post("/api/benchmarks/", json=data)
+        new_id = response.json["id"]
+        benchmark_result = BenchmarkResult.one(id=new_id)
+        location = "http://localhost/api/benchmarks/%s/" % new_id
+        self.assert_201_created(response, _expected_entity(benchmark_result), location)
+
     def test_create_benchmark_distribution(self, client):
         for payload in [self.valid_payload, self.valid_payload_for_cluster]:
             self.authenticate(client)

--- a/conbench/tests/api/test_benchmarks.py
+++ b/conbench/tests/api/test_benchmarks.py
@@ -780,6 +780,7 @@ class TestBenchmarkPost(_asserts.PostEnforcer):
         data = copy.deepcopy(self.valid_payload)
         data["run_id"] = _uuid()
         data["github"]["pr_number"] = pr_number
+        # `<absent>` is a sentinel for `pr_number` not being specified.
         # viable `github` submissions without `pr_number`:
         # - just `repository` and `commit` (assumed to be on default branch)
         # - submit `branch` directly instead (mostly discouraged, but possible)


### PR DESCRIPTION
Accept `"pr_number": ""` (in addition to `"pr_number": null` and not populating it) when posting runs and results (`run.github.pr_number` and `benchmark.github.pr_number`), as this metadata is very likely to come from env vars and the intent here is unambiguous. I don't think passing `""` is desired behavior, but it's a worse reason for failing.