### PR TITLE
history plot: show run details when clicking a glyph

### DIFF
--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -316,11 +316,11 @@ def gen_js_callback_tap_detect_unselect(source: bokeh.models.ColumnDataSource):
         // console.log("cb_obj:", cb_obj);
         // console.log("s1.selected.indices: ", s1.selected.indices);
 
-        if (s1.selected.indices.length == 0){
+        if (s1.selected.indices.length == 0) {
             console.log("nothing selected, remove detail");
             // Make the panel invisible.
             const e = document.getElementsByClassName("conbench-histplot-run-details")[0];
-            e.style.display = 'none'
+            e.style.display = 'none';
         }
     """,
     )

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -486,8 +486,9 @@ def time_series_plot(history, benchmark, run, height=380, width=1100):
     # https://discourse.bokeh.org/t/how-to-trigger-callbacks-on-mouse-click-for-tap-tool/1630
     taptool = p.select(type=bokeh.models.TapTool)
     taptool.callback = gen_js_callback_click_on_glyph_show_run_details(
-        # Assume that the repository is constant across all data points in
-        # this plot. Is that a good assumption
+        # The repository is constant across all data points in this plot. The
+        # underlying database query filters by exactly that (Commit.repository
+        # == repo).
         repo_string=run["commit"]["repository"]
     )
 

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -249,7 +249,6 @@ def _source(
         strings = []
         for d in data:
             samples = d["data"]
-            log.info("samples: %s", samples)
             strings.append(", ".join(unit_fmt(s, unit) for s in samples))
 
         dsdict["multisample_strings_with_unit"] = strings
@@ -278,7 +277,7 @@ def _inspect_for_multisample(items) -> tuple[bool, Optional[int]]:
         # required shape. It's a programming bug, but do not crash in this
         # case. Return an answer: not multisample (at least not in the way as
         # expected).
-        log.warning("_inspect_for_multisampl: unexpected argument: %s", items)
+        log.warning("_inspect_for_multisample: unexpected argument: %s", items)
         return False, None
 
     multisample = True
@@ -363,6 +362,8 @@ def gen_js_callback_click_on_glyph_show_run_details(repo_string):
         // JavaScript code generated in a Python f string -- templating hell, yeah! :)
         // I don't know if repo string is always a URL, if it's always
         // pointing to GitHub. But if it does, we can do some UX sugar.
+        // Austin says that repo string should as of today be either None or
+        // a URL to the GitHub repo. We will see what future needs will bring.
 
         var commit_repo_string =  run_commit_hash_short + ' in {repo_string}';
 
@@ -373,7 +374,7 @@ def gen_js_callback_click_on_glyph_show_run_details(repo_string):
             commit_repo_string = '<a href="' + url_to_commit + '">' + url_to_commit + '</a>';
         }}
 
-
+        // TODO? show run timestamp, not only commit timestamp.
         var newHtml = \
             '<li>Report: <a href="' + run_report_relurl + '">' + run_report_relurl + '</a></li>' +
             '<li>Commit: ' + commit_repo_string + '</li>' +

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -266,6 +266,7 @@ def _inspect_for_multisample(items) -> tuple[bool, Optional[int]]:
     try:
         samplecounts = [len(i["data"]) for i in items]
     except KeyError:
+        # TODO: clean up once type checking is tight enough.
         # Likely, the provided `items` for testing here are not strictly of the
         # required shape. It's a programming bug, but do not crash in this
         # case. Return an answer: not multisample (at least not in the way as

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -188,10 +188,10 @@ def _source(
     commit_messages = [d["message"] for d in data]
 
     # Note(JP): isoparse() returns a `datetime.datetime` object. And I think
-    # that the `timestamp` property corresponds to the invocation (or finish)
-    # time of the corresponding benchmark case run (the `timestamp` property on
-    # the `BenchmarkCreate` schema in the Conbench API). Are these tz-aware or
-    # tz-naive but in UTC?
+    # that the `timestamp` property corresponds to the utc-local invocation (or
+    # finish) time of the corresponding benchmark case run (the `timestamp`
+    # property on the `BenchmarkCreate` schema in the Conbench API). Are these
+    # tz-aware or tz-naive but in UTC?
     datetimes = [dateutil.parser.isoparse(x["timestamp"]) for x in data]
     date_strings = [d.strftime("%Y-%m-%d %H:%M %Z") for d in datetimes]
 
@@ -270,6 +270,7 @@ def _inspect_for_multisample(items) -> tuple[bool, Optional[int]]:
         # required shape. It's a programming bug, but do not crash in this
         # case. Return an answer: not multisample (at least not in the way as
         # expected).
+        log.warning("_inspect_for_multisampl: unexpected argument: %s", items)
         return False, None
 
     multisample = True

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -4,10 +4,10 @@ import json
 import logging
 from typing import Optional
 
-import bokeh.plotting
-import dateutil
 import bokeh.events
 import bokeh.models
+import bokeh.plotting
+import dateutil
 
 from ..hacks import sorted_data
 from ..units import formatter_for_unit

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -31,7 +31,8 @@ class _Serializer(EntitySerializer):
 
         # For both, history.data and history.times expect either None or a list
         # Make it so that in the output object they are always a list,
-        # potentially empty.
+        # potentially empty. `data` contains more than one value if this was
+        # a multi-sample benchmark.
         data = []
         if history.data is not None:
             data = [float(d) if d is not None else None for d in history.data]

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -55,6 +55,7 @@ class _Serializer(EntitySerializer):
             "repository": history.repository,
             # Note(JP): this is the commit message
             "message": history.message,
+            # This is the Commit timestamp. Expose Result timestamp, too?
             "timestamp": history.timestamp.isoformat(),
             "run_name": history.name,
             "distribution_mean": float(history.mean_mean),

--- a/conbench/templates/benchmark-entity.html
+++ b/conbench/templates/benchmark-entity.html
@@ -31,6 +31,15 @@
 <br>
 
 <div class="row">
+  <div class="col-md-8">
+    Click on a glyph in the plot to see corresponding benchmark run details displayed here.
+    <div class="conbench-histplot-rundetails"></div>
+  </div>
+</div>
+<br>
+
+
+<div class="row">
   <div class="col-md-6">
     <ul class="list-group">
       <li class="list-group-item active">Benchmark</li>

--- a/conbench/templates/benchmark-entity.html
+++ b/conbench/templates/benchmark-entity.html
@@ -31,13 +31,20 @@
 <br>
 
 <div class="row">
-  <div class="col-md-8">
-    Click on a glyph in the plot to see corresponding benchmark run details displayed here.
-    <div class="conbench-histplot-rundetails"></div>
+  <div class="col-md-12">
+    Click on a gray glyph in the plot to see corresponding benchmark run details.
+    <div class="conbench-histplot-run-details" style="display: none;">
+      <br />
+      <div class="panel panel-success">
+        <div class="panel-heading">Details for selected benchmark (green data point in plot)</div>
+        <div class="panel-body">
+          <ul class="ul-histplot-run-details"></ul>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 <br>
-
 
 <div class="row">
   <div class="col-md-6">

--- a/conbench/templates/benchmark-entity.html
+++ b/conbench/templates/benchmark-entity.html
@@ -32,7 +32,7 @@
 
 <div class="row">
   <div class="col-md-12">
-    Click on a gray glyph in the plot to see corresponding benchmark run details.
+    Click on a grey point (benchmark mean) in the plot to see corresponding benchmark run details.
     <div class="conbench-histplot-run-details" style="display: none;">
       <br />
       <div class="panel panel-success">

--- a/conbench/tests/app/test_plots.py
+++ b/conbench/tests/app/test_plots.py
@@ -81,11 +81,11 @@ HISTORY = [
 ]
 
 DATES = [
-    datetime.datetime(2021, 8, 4, 10, 26, 7),
-    datetime.datetime(2021, 8, 4, 10, 28, 54),
-    datetime.datetime(2021, 8, 4, 10, 30, 10),
-    datetime.datetime(2021, 8, 4, 10, 31, 35),
-    datetime.datetime(2021, 8, 4, 10, 36, 39),
+    datetime.datetime(2021, 8, 4, 10, 26, 7, tzinfo=datetime.timezone.utc),
+    datetime.datetime(2021, 8, 4, 10, 28, 54, tzinfo=datetime.timezone.utc),
+    datetime.datetime(2021, 8, 4, 10, 30, 10, tzinfo=datetime.timezone.utc),
+    datetime.datetime(2021, 8, 4, 10, 31, 35, tzinfo=datetime.timezone.utc),
+    datetime.datetime(2021, 8, 4, 10, 36, 39, tzinfo=datetime.timezone.utc),
 ]
 COMMITS = [
     "ARROW-13429: [C++][Gandiva] Fix Gandiva codegen for if-else expression with binary type",

--- a/conbench/tests/app/test_plots.py
+++ b/conbench/tests/app/test_plots.py
@@ -177,7 +177,7 @@ def test__source():
     source = _source(HISTORY, "B/s")
     assert source.data["x"] == DATES
     assert source.data["y"] == POINTS
-    assert source.data["means"] == MEANS
+    assert source.data["values_with_unit"] == MEANS
     assert source.data["commit_messages"] == COMMITS
 
 
@@ -185,7 +185,7 @@ def test_source_formatted():
     source = _source(HISTORY, "B/s", formatted=True)
     assert source.data["x"] == DATES
     assert source.data["y"] == POINTS_FORMATTED
-    assert source.data["means"] == MEANS
+    assert source.data["values_with_unit"] == MEANS
     assert source.data["commit_messages"] == COMMITS
 
 
@@ -193,7 +193,7 @@ def test_source_formatted_items_per_second():
     source = _source(HISTORY, "i/s", formatted=True)
     assert source.data["x"] == DATES
     assert source.data["y"] == POINTS_FORMATTED_ITEMS
-    assert source.data["means"] == MEANS_ITEMS
+    assert source.data["values_with_unit"] == MEANS_ITEMS
     assert source.data["commit_messages"] == COMMITS
 
 
@@ -201,7 +201,7 @@ def test_source_alert_min():
     source = _source(HISTORY, "B/s", alert_min=True)
     assert source.data["x"] == DATES
     assert source.data["y"] == POINTS_MIN
-    assert source.data["means"] == MEANS_MIN
+    assert source.data["values_with_unit"] == MEANS_MIN
     assert source.data["commit_messages"] == COMMITS
 
 
@@ -209,7 +209,7 @@ def test_source_alert_min_formatted():
     source = _source(HISTORY, "B/s", alert_min=True, formatted=True)
     assert source.data["x"] == DATES
     assert source.data["y"] == POINTS_MIN_FORMATTED
-    assert source.data["means"] == MEANS_MIN
+    assert source.data["values_with_unit"] == MEANS_MIN
     assert source.data["commit_messages"] == COMMITS
 
 
@@ -217,7 +217,7 @@ def test_source_alert_max():
     source = _source(HISTORY, "B/s", alert_max=True)
     assert source.data["x"] == DATES
     assert source.data["y"] == POINTS_MAX
-    assert source.data["means"] == MEANS_MAX
+    assert source.data["values_with_unit"] == MEANS_MAX
     assert source.data["commit_messages"] == COMMITS
 
 
@@ -225,7 +225,7 @@ def test_source_alert_max_formatted():
     source = _source(HISTORY, "B/s", alert_max=True, formatted=True)
     assert source.data["x"] == DATES
     assert source.data["y"] == POINTS_MAX_FORMATTED
-    assert source.data["means"] == MEANS_MAX
+    assert source.data["values_with_unit"] == MEANS_MAX
     assert source.data["commit_messages"] == COMMITS
 
 


### PR DESCRIPTION
Motivated by #477 -- this is now ready to review.

A few notes:
- Do we have suggeststions for a better panel heading ("Details for selected benchmark (green data point in plot)")?
- Would appreciate: content feedback (words, sentences, details shown...).
- Happy also about color/placement feedback, will do visual changes in follow-up patches. For example, let's remove the zoom slider below the plot, then this detail panel will be closer to the plot (taken from Slack thread with @jonkeane). 
- This introduces a rather complex topic: Bokeh's custom JavaScript callbacks (they are cool, they are powerful, but they are also maintenance burden). This PR in particular introduces JavaScript code as literal Python strings. That code is not covered by linting, not even by any kind of CI. I still think it's for now good to take this approach (as of a lack in alternatives, and the approach is simple enough to still be manually testable and explainable). 

An example view:

![image](https://user-images.githubusercontent.com/265630/213482929-41455d44-cad5-4963-bd0f-36f5e23d5d21.png)
