### PR TITLE
Bump to CPython 3.11, remove dateutil dep, introduce tznaive_iso8601_to_tzaware_dt()

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.11
 
 COPY requirements-build.txt /tmp/
 COPY requirements-test.txt /tmp/

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -4,15 +4,14 @@ import logging
 from datetime import timedelta
 from typing import Optional
 
-
 import bokeh.events
 import bokeh.models
 import bokeh.plotting
 
+from conbench import util
+
 from ..hacks import sorted_data
 from ..units import formatter_for_unit
-
-from conbench import util
 
 log = logging.getLogger(__name__)
 

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -1,16 +1,18 @@
 import collections
-import datetime
 import json
 import logging
+from datetime import timedelta
 from typing import Optional
+
 
 import bokeh.events
 import bokeh.models
 import bokeh.plotting
-import dateutil
 
 from ..hacks import sorted_data
 from ..units import formatter_for_unit
+
+from conbench import util
 
 log = logging.getLogger(__name__)
 
@@ -187,16 +189,11 @@ def _source(
     # the tooltip?
     commit_messages = [d["message"] for d in data]
 
-    # TODO: use stdlib
-    # datetime.fromisoformat(date_string) instead of datetutil.parser.
-    # Note(JP): dateutil.parser.isoparse returns a tz-naive `datetime.datetime`
-    # object: the `timestamp` property corresponds to the utc-local commit time
-    # (example value: 2022-03-03T19:48:06 -- that is, ISO 8601 w/o timezone
-    # information)
-    datetimes = [dateutil.parser.isoparse(x["timestamp"]) for x in data]
-
-    # Now attach timezone information.
-    datetimes = [d.replace(tzinfo=datetime.timezone.utc) for d in datetimes]
+    # The `timestamp` property corresponds to the UTC-local commit time
+    # (example value: 2022-03-03T19:48:06). That is, each string is ISO 8601
+    # notation w/o timezone information. Transform those into tz-aware datetime
+    # objects.
+    datetimes = util.tznaive_iso8601_to_tzaware_dt([x["timestamp"] for x in data])
 
     # Get stringified versions of those datetimes for UI display purposes.
     # Include timezone information. This shows UTC for the %Z.
@@ -410,7 +407,7 @@ def time_series_plot(history, benchmark, run, height=380, width=1100):
 
     source_min_over_time = bokeh.models.ColumnDataSource(
         data=dict(
-            x=[dateutil.parser.isoparse(x["timestamp"]) for x in history],
+            x=util.tznaive_iso8601_to_tzaware_dt([x["timestamp"] for x in history]),
             # TODO: best-case is not always min, e.g. when data has a unit like
             # bandwidth.
             y=[min(x["data"]) for x in history],
@@ -464,7 +461,7 @@ def time_series_plot(history, benchmark, run, height=380, width=1100):
     t_start = source_mean_over_time.data["x"][0]
     t_end = source_mean_over_time.data["x"][-1]
 
-    t_range: datetime.timedelta = t_end - t_start
+    t_range: timedelta = t_end - t_start
 
     # Add padding/buffer to left and right so that newest data point does not
     # disappear under right plot boundary, and so that the oldest data point
@@ -585,7 +582,7 @@ def time_series_plot(history, benchmark, run, height=380, width=1100):
         if result["change_annotations"].get("begins_distribution_change", False):
             p.add_layout(
                 bokeh.models.Span(
-                    location=dateutil.parser.isoparse(result["timestamp"]),
+                    location=util.tznaive_iso8601_to_tzaware_dt(result["timestamp"]),
                     dimension="height",
                     line_color="purple",
                     line_dash="dashed",
@@ -596,7 +593,7 @@ def time_series_plot(history, benchmark, run, height=380, width=1100):
             if not dist_change_in_legend:
                 # hack: add a dummy line so it appears on the legend
                 p.line(
-                    [dateutil.parser.isoparse(result["timestamp"])] * 2,
+                    [util.tznaive_iso8601_to_tzaware_dt(result["timestamp"])] * 2,
                     [result["mean"]] * 2,
                     legend_label="distribution change",
                     line_color="purple",

--- a/conbench/entities/commit.py
+++ b/conbench/entities/commit.py
@@ -5,13 +5,13 @@ import os
 from datetime import datetime
 from typing import List, Optional
 
-
 import flask as f
 import requests
 import sqlalchemy as s
 from sqlalchemy.orm import Query
 
 from conbench import util
+
 from ..db import Session
 from ..entities._entity import (
     Base,

--- a/conbench/entities/commit.py
+++ b/conbench/entities/commit.py
@@ -5,12 +5,13 @@ import os
 from datetime import datetime
 from typing import List, Optional
 
-import dateutil.parser
+
 import flask as f
 import requests
 import sqlalchemy as s
 from sqlalchemy.orm import Query
 
+from conbench import util
 from ..db import Session
 from ..entities._entity import (
     Base,
@@ -546,7 +547,7 @@ class GitHub:
             "parent": commit["parents"][0]["sha"] if commit["parents"] else None,
             # Note(JP): this might need attention with respect to time zones.
             # Also see https://github.com/PyGithub/PyGithub/issues/512#issuecomment-1362654366
-            "date": dateutil.parser.isoparse(commit_author["date"]),
+            "date": util.tznaive_iso8601_to_tzaware_dt(commit_author["date"]),
             # Note(JP): don't we want to indicate if the msg was truncated,
             # with e.g. an ellipsis?
             "message": commit["commit"]["message"].split("\n")[0][:240],

--- a/conbench/tests/entities/test_commit.py
+++ b/conbench/tests/entities/test_commit.py
@@ -286,7 +286,7 @@ def test_backfill_default_branch_commits():
             fork_point_sha=test_shas[3],
             message="Store branch information on Commits (#417)",
             author_name=author,
-            timestamp=datetime.datetime(2022, 11, 4, 17, 18, 19, tzinfo=tz),
+            timestamp=datetime.datetime(2022, 11, 4, 17, 18, 19, tzinfo=timezone.utc),
         )
     )
 
@@ -306,7 +306,7 @@ def test_backfill_default_branch_commits():
             fork_point_sha=test_shas[4],
             message="Fixed up test warnings (#424)",
             author_name=author,
-            timestamp=datetime.datetime(2022, 11, 4, 19, 13, 41, tzinfo=tz),
+            timestamp=datetime.datetime(2022, 11, 4, 19, 13, 41, tzinfo=timezone.utc),
         )
     )
 
@@ -323,7 +323,7 @@ def test_backfill_default_branch_commits():
             fork_point_sha=test_shas[0],
             message="did nothing",
             author_name=author,
-            timestamp=datetime.datetime(2022, 10, 29, tzinfo=tz),
+            timestamp=datetime.datetime(2022, 10, 29, tzinfo=timezone.utc),
         )
     )
     backfill_default_branch_commits_ign_rate_limit(repository, commit_4)

--- a/conbench/tests/entities/test_commit.py
+++ b/conbench/tests/entities/test_commit.py
@@ -2,8 +2,8 @@ import datetime
 import json
 import logging
 import os
+from datetime import timezone
 
-import dateutil
 import pytest
 import sqlalchemy as s
 
@@ -171,10 +171,10 @@ def test_get_github_commit_and_fork_point_sha(branch):
 
     repo = "https://github.com/apache/arrow"
     sha = "3decc46119d583df56c7c66c77cf2803441c4458"
-    tz = dateutil.tz.tzutc()
+
     expected = {
         "parent": "fcaa422c84796bcf7dbe328ee3612f434cd4d356",
-        "date": datetime.datetime(2021, 3, 17, 16, 27, 37, tzinfo=tz),
+        "date": datetime.datetime(2021, 3, 17, 16, 27, 37, tzinfo=timezone.utc),
         "message": "ARROW-11997: [Python] concat_tables crashes python interpreter",
         "author_name": "Diana Clarke",
         "author_login": "dianaclarke",
@@ -213,10 +213,10 @@ def test_get_github_commit_and_fork_point_sha_pull_request(branch, pr_number):
 
     repo = "https://github.com/apache/arrow"
     sha = "982023150ccbb06a6f581f6797c017492485b58c"
-    tz = dateutil.tz.tzutc()
+
     expected = {
         "parent": "c8668f85a465ea05b2724ec47ff72c4db4d7dfe6",
-        "date": datetime.datetime(2021, 7, 6, 21, 51, 48, tzinfo=tz),
+        "date": datetime.datetime(2021, 7, 6, 21, 51, 48, tzinfo=timezone.utc),
         "message": "ARROW-13266: [JS] Improve benchmark names",
         "author_name": "Diana Clarke",
         "author_login": "dianaclarke",
@@ -244,7 +244,6 @@ def test_backfill_default_branch_commits():
     repository = "https://github.com/conbench/conbench"
     default_branch = "conbench:main"
     author = "Austin Dickey"
-    tz = dateutil.tz.tzutc()
 
     # 5 commits in a row on conbench:main, starting with the 335th commit to the repo
     test_shas = [
@@ -266,7 +265,7 @@ def test_backfill_default_branch_commits():
             fork_point_sha=test_shas[1],
             message="Fix what bokeh 3.0.0 broke (#420)",
             author_name=author,
-            timestamp=datetime.datetime(2022, 10, 31, 18, 5, 14, tzinfo=tz),
+            timestamp=datetime.datetime(2022, 10, 31, 18, 5, 14, tzinfo=timezone.utc),
         )
     )
 
@@ -375,12 +374,12 @@ def test_parse_commit():
     path = os.path.join(this_dir, "github_child.json")
     with open(path) as f:
         commit = json.load(f)
-    tz = dateutil.tz.tzutc()
+
     message = "Move benchmark tests (so CI runs them)"
     expected = {
         "parent": _fixtures.PARENT,
         "message": f"ARROW-11771: [Developer][Archery] {message}",
-        "date": datetime.datetime(2021, 2, 25, 1, 2, 51, tzinfo=tz),
+        "date": datetime.datetime(2021, 2, 25, 1, 2, 51, tzinfo=timezone.utc),
         "author_name": "Diana Clarke",
         "author_login": "dianaclarke",
         "author_avatar": "https://avatars.githubusercontent.com/u/878798?v=4",
@@ -397,12 +396,12 @@ def test_parse_commit_no_author():
     path = os.path.join(this_dir, "github_commit_no_author.json")
     with open(path) as f:
         commit = json.load(f)
-    tz = dateutil.tz.tzutc()
+
     message = "Move benchmark tests (so CI runs them)"
     expected = {
         "parent": _fixtures.PARENT,
         "message": f"ARROW-11771: [Developer][Archery] {message}",
-        "date": datetime.datetime(2021, 2, 25, 1, 2, 51, tzinfo=tz),
+        "date": datetime.datetime(2021, 2, 25, 1, 2, 51, tzinfo=timezone.utc),
         "author_name": "Diana Clarke",
         "author_login": None,
         "author_avatar": None,
@@ -414,12 +413,12 @@ def test_parse_pull_request_commit():
     path = os.path.join(this_dir, "github_pull_request_commit.json")
     with open(path) as f:
         commit = json.load(f)
-    tz = dateutil.tz.tzutc()
+
     message = "Move benchmark tests (so CI runs them)"
     expected = {
         "parent": "81e9417eb68171e03a304097ae86e1fd83307130",
         "message": f"ARROW-11771: [Developer][Archery] {message}",
-        "date": datetime.datetime(2021, 2, 24, 20, 59, 4, tzinfo=tz),
+        "date": datetime.datetime(2021, 2, 24, 20, 59, 4, tzinfo=timezone.utc),
         "author_name": "Diana Clarke",
         "author_login": "dianaclarke",
         "author_avatar": "https://avatars.githubusercontent.com/u/878798?v=4",

--- a/conbench/util.py
+++ b/conbench/util.py
@@ -45,10 +45,17 @@ def tznaive_iso8601_to_tzaware_dt(
     """
 
     def _convert(s: str):
-        # Do some sanity-checking. If this happens, only emit the warning
-        # but then still hard-set UTC timezone.
-        if "Z" in s or "+" in s:
-            log.warning("expected tz-naive timestring, but saw: %s", s)
+        # Do some sanity-checking. If unexpected input is seen, only emit the
+        # warning but then still hard-set UTC timezone.
+        if "Z" in s:
+            # Input seems to be tz-aware but the timezone it specifies matches
+            # the one we want to set anyway.
+            log.warning("expected tz-naive timestring, but saw UTC: %s", s)
+
+        if "+" in s and "00:00" not in s:
+            # Input seems to be tz-aware but the timezone it specifies does
+            # not match UTC.
+            log.warning("expected tz-naive timestring, but saw non-UTC: %s", s)
 
         return datetime.fromisoformat(s).replace(tzinfo=timezone.utc)
 

--- a/conbench/util.py
+++ b/conbench/util.py
@@ -1,7 +1,10 @@
 import json
 import os
+import logging
 import time
 import urllib.parse
+from datetime import datetime, timezone
+from typing import Union
 
 import click
 import requests
@@ -17,6 +20,44 @@ retry_strategy = Retry(
     backoff_factor=4,  # will retry in 2, 4, 8, 16, 32 seconds
 )
 adapter = HTTPAdapter(max_retries=retry_strategy)
+
+
+log = logging.getLogger()
+
+
+def tznaive_iso8601_to_tzaware_dt(
+    input: Union[str, list[str]]
+) -> Union[datetime, list[datetime]]:
+    """
+    Convert time strings into datetime objects.
+
+    If a list of strings is provided return a list of datetime objects.
+
+    If a single string is provided return a single datetime object.
+
+    Assume that each provided string is in ISO 8601 notation without timezone
+    information, but that the time is actually meant to be interpreted in the
+    UTC timezone.
+
+    Note: this was built with and tested for a value like 2022-03-03T19:48:06
+    which in this example represents a commit timestamp (in UTC, additional
+    knowledge).
+    """
+
+    def _convert(s: str):
+        # Do some sanity-checking. If this happens, only emit the warning
+        # but then still hard-set UTC timezone.
+        if "Z" in s or "+" in s:
+            log.warning("expected tz-naive timestring, but saw: %s", s)
+
+        return datetime.fromisoformat(s).replace(tzinfo=timezone.utc)
+
+    # Handle case where input is a single string.
+    if isinstance(input, str):
+        return _convert(input)
+
+    # Handle case where input is a list of strings.
+    return [_convert(s) for s in input]
 
 
 class Connection:

--- a/conbench/util.py
+++ b/conbench/util.py
@@ -1,6 +1,6 @@
 import json
-import os
 import logging
+import os
 import time
 import urllib.parse
 from datetime import datetime, timezone

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -3,7 +3,6 @@ apispec
 apispec-webframeworks
 bokeh
 click
-python-dateutil
 email-validator
 Flask
 Flask-Bootstrap


### PR DESCRIPTION
This introduces a new function `tznaive_iso8601_to_tzaware_dt()` that I've hopefully specified precisely, and uses that across the code base. The underlying string parsing was changed to be stdlib-based, and an outcome is that we can remove the third-party dependency to python-dateutil.

There is also a change in behavior here that is important: the datetime objects returned by this new function are tz-aware, which is going to be helpful for code maintenance and for displaying correct values to users in the future.

This needs CPython 3.11 to make use of the valuable additions to `datetime.fromisoformat(s)` (e.g. to, not be tripped up by the 'Z'): https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat