### PR TITLE
Search & UI: Unique data count based search type implementation for individual columns

### DIFF
--- a/conbench/static/app.css
+++ b/conbench/static/app.css
@@ -127,4 +127,5 @@ table.dataTable td {
    width: 100%;
    min-width: 80px;
    padding-right: initial;
+   padding-left: initial;
 }

--- a/conbench/static/app.css
+++ b/conbench/static/app.css
@@ -128,7 +128,7 @@ table.dataTable td {
 
 .custom-search-box{
    box-sizing: content-box;
-   width: 100%;
+   width: 70%;
    min-width: 80px;
    padding-right: initial;
    padding-left: initial;

--- a/conbench/static/app.css
+++ b/conbench/static/app.css
@@ -115,3 +115,16 @@ table.dataTable td {
   width: fit-content;
   padding: 3px;
 }
+
+.custom-input-text {
+  font-weight: normal;
+  font-size: 12px;
+  padding: 3px;
+}
+
+.custom-search-box{
+   box-sizing: content-box;
+   width: 100%;
+   min-width: 100px;
+   padding-right: initial;
+}

--- a/conbench/static/app.css
+++ b/conbench/static/app.css
@@ -125,6 +125,6 @@ table.dataTable td {
 .custom-search-box{
    box-sizing: content-box;
    width: 100%;
-   min-width: 100px;
+   min-width: 80px;
    padding-right: initial;
 }

--- a/conbench/static/app.css
+++ b/conbench/static/app.css
@@ -133,3 +133,11 @@ table.dataTable td {
    padding-right: initial;
    padding-left: initial;
 }
+
+.message-header{
+  font-weight: normal;
+  font-size: 10px;
+  padding: 3px;
+  border-style: dotted;
+  border-width: thin;
+}

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -227,7 +227,7 @@ function column_search_implementation(data_table_id) {
                 free_text_column_search(data_table_id, index)
             }
             else if (item == 1) {
-                $(`<p class="message-header"> 👀 only one value found</p>`).appendTo(
+                $(`<p class="message-header"> 👀 only one/null value found</p>`).appendTo(
                     table.columns([index]).header())
             }
             else{

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -150,7 +150,7 @@ INPUTS:
  data_table_id: string
  column_indexes: array
  */
-function specific_column_search(data_table_id, column_indexes) {
+function dropdown_column_search(data_table_id, column_indexes) {
     $(document).ready(function() {
         var table = $(data_table_id).DataTable();
         table.columns(column_indexes).every(function() {
@@ -208,7 +208,12 @@ function free_text_column_search(data_table_id, column_indexes) {
 
 /*
 INFO:
-    Function to check unique value count and set the required search type
+    Function to check unique value count and set the required search type.
+        - Unique values <10 & >1 [specific_column_search]: drop-down based search is implemented
+        - Unique values >10 [free_text_column_search]: free text search is implemented
+        - If there is no data OR only single data point: a message is displayed ("only one/no value found")
+INPUT:
+    data_table_id: string
  */
 function column_search_implementation(data_table_id) {
     $(document).ready(function() {
@@ -221,7 +226,7 @@ function column_search_implementation(data_table_id) {
         });
         unique_count.forEach(function (item, index) {
             if (item < 10 && item > 1) {
-                specific_column_search(data_table_id, index)
+                dropdown_column_search(data_table_id, index)
             }
             else if (item > 10){
                 free_text_column_search(data_table_id, index)

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -230,6 +230,9 @@ function column_search_implementation(data_table_id) {
                 $(`<p class="message-header"> 👀 only one value found</p>`).appendTo(
                     table.columns([index]).header())
             }
+            else{
+                console.log("Unidentified value encountered")
+            }
         });
     })
 }

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -141,7 +141,8 @@ function enable_search_query_string(data_table) {
 /*
 INFO:
     Adds free text search ability for specific columns, based on selected column indexes.
-    Press enter after adding text to search box, which triggers column sorting/search operation
+    Based on the indexes of the columns, input boxes are created. The search is triggered on
+    every key press.
 INPUTS:
  data_table_id: string
  column_indexes: array

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -140,7 +140,8 @@ function enable_search_query_string(data_table) {
 
 /*
 INFO:
-    Adds free text search ability for specific columns in the DataTable
+    Adds free text search ability for specific columns, based on selected column indexes.
+    Press enter after adding text to search box, which triggers column sorting/search operation
 INPUTS:
  data_table_id: string
  column_indexes: array
@@ -149,18 +150,18 @@ function free_text_column_search(data_table_id, column_indexes) {
     $(document).ready(function() {
         var table = $(data_table_id).DataTable();
         table.columns(column_indexes).every(function() {
-            var title = $(this).text();
-            $(this).html('<input type="text" placeholder="Search ' + title + '" />');
+            var that = this;
+            var title = this.header().textContent;
+            $('<input type="text" placeholder="Search ' + title + '" />')
+                .appendTo(this.header())
+                .on('keydown', function(key_opt) {
+                    if (key_opt.keyCode == 13) { //only on enter keypress (code 13)
+                        that
+                            .search(this.value)
+                            .draw();
+                    }
+                });
         });
-
-        table.columns(column_indexes).every(function (){
-            var that= this;
-            $('input', this.headers()).on('keyup change', function (){
-                if (that.search()!== this.value){
-                    that.search(this.value).draw();
-                }
-            })
-        })
     })
 }
 

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -156,22 +156,22 @@ function specific_column_search(data_table_id, column_indexes) {
         table.columns(column_indexes).every(function() {
             var that = this;
             var reset = ""
-            var mySelectList = $("<select></select>")
+            var mySelectList = $("<select class='custom-search-box'></select>")
                 .appendTo(this.header())
                 .on("change", function() {
                     that.search($(this).val()).draw();
                 });
             mySelectList.append(
-                $(`<option class="custom-search-box" value="${reset}">${reset}</option>`)
+                $(`<option value="${reset}">${reset}</option>`)
             );
             this.cache("search").unique().sort().each(function(param) {
                 if (param !== "") {
                     mySelectList.append(
-                        $(`<option class="custom-search-box" value="${param}">${param}</option>`)
+                        $(`<option value="${param}">${param}</option>`)
                     );
                 } else {
                     mySelectList.append(
-                        $(`<option class="custom-search-box" value="${param}">null</option>`)
+                        $(`<option value="${param}">null</option>`)
                     );
                 }           
             });
@@ -227,7 +227,7 @@ function column_search_implementation(data_table_id) {
                 free_text_column_search(data_table_id, index)
             }
             else if (item == 1) {
-                $(`<p class="message-header"> 👀 only one/null value found</p>`).appendTo(
+                $(`<p class="message-header"> 👀 only one/no value found</p>`).appendTo(
                     table.columns([index]).header())
             }
             else{

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -138,6 +138,32 @@ function enable_search_query_string(data_table) {
     });
 }
 
+/*
+INFO:
+    Adds free text search ability for specific columns in the DataTable
+INPUTS:
+ data_table_id: string
+ column_indexes: array
+ */
+function free_text_column_search(data_table_id, column_indexes) {
+    $(document).ready(function() {
+        var table = $(data_table_id).DataTable();
+        table.columns(column_indexes).every(function() {
+            var title = $(this).text();
+            $(this).html('<input type="text" placeholder="Search ' + title + '" />');
+        });
+
+        table.columns(column_indexes).every(function (){
+            var that= this;
+            $('input', this.headers()).on('keyup change', function (){
+                if (that.search()!== this.value){
+                    that.search(this.value).draw();
+                }
+            })
+        })
+    })
+}
+
 $("#confirm-delete").on("show.bs.modal", function(e) {
     $(this).find("#confirm-delete-message").html($(e.relatedTarget).data("message"));
     $(this).find("#delete-form-id").attr("value", $(e.relatedTarget).data("form-id"));

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -142,7 +142,7 @@ function enable_search_query_string(data_table) {
 INFO:
     Adds free text search ability for specific columns, based on selected column indexes.
     Based on the indexes of the columns, input boxes are created. The search is triggered on
-    every key press.
+    key press.
 INPUTS:
  data_table_id: string
  column_indexes: array

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -153,9 +153,10 @@ function free_text_column_search(data_table_id, column_indexes) {
         table.columns(column_indexes).every(function() {
             var that = this;
             var title = this.header().textContent;
-            $('<input class="custom-input-text custom-search-box" type="text" placeholder="🔍 ' + title + '" />')
+            $(`<input class="custom-input-text custom-search-box" type="text" placeholder="🔍 ${title}"
+                onClick="if(event.stopPropagation!==undefined){event.preventDefault(); event.stopPropagation();}event.cancelBubble=true;"/>`)
                 .appendTo(this.header())
-                .on('keyup change clear', function() { //column search/sorting triggered on every input
+                .on('keyup change clear', function() { //column search/sorting triggered on keypress
                             that
                             .search(this.value)
                             .draw();
@@ -163,6 +164,7 @@ function free_text_column_search(data_table_id, column_indexes) {
         });
     })
 }
+
 
 $("#confirm-delete").on("show.bs.modal", function(e) {
     $(this).find("#confirm-delete-message").html($(e.relatedTarget).data("message"));

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -165,7 +165,8 @@ function dropdown_column_search(data_table_id, column_indexes) {
                 $(`<option value="${reset}">${reset}</option>`)
             );
             this.cache("search").unique().sort().each(function(param) {
-                if (param !== "") {
+                // check for multiple whitespaces and empty string
+                if (/^\s*$/.test(param) == false) {
                     mySelectList.append(
                         $(`<option value="${param}">${param}</option>`)
                     );
@@ -173,8 +174,9 @@ function dropdown_column_search(data_table_id, column_indexes) {
                     mySelectList.append(
                         $(`<option value="${param}">null</option>`)
                     );
-                }           
+                }
             });
+            // console.log(mySelectList)
         });
     });
 }
@@ -211,7 +213,8 @@ INFO:
     Function to check unique value count and set the required search type.
         - Unique values <10 & >1 [specific_column_search]: drop-down based search is implemented
         - Unique values >10 [free_text_column_search]: free text search is implemented
-        - If there is no data OR only single data point: a message is displayed ("only one/no value found")
+        - Search is not enabled with single OR null data points and a message is logged on console
+        - If any unidentified value (beyond assumed definitions) is encountered, a message is logged on console
 INPUT:
     data_table_id: string
  */
@@ -224,6 +227,7 @@ function column_search_implementation(data_table_id) {
             //array of unique count for data points within each column
             unique_count.push(current.data().unique().count())
         });
+        console.log(unique_count)
         unique_count.forEach(function (item, index) {
             if (item < 10 && item > 1) {
                 dropdown_column_search(data_table_id, index)
@@ -232,7 +236,9 @@ function column_search_implementation(data_table_id) {
                 free_text_column_search(data_table_id, index)
             }
             else if (item == 1) {
-                $(`<p class="message-header"> 👀 only one/no value found</p>`).appendTo(
+                console.log("Search isn't enabled with one/null data point")
+                // keeping this placeholder for future addition of a message/note
+                $(`<p></p>`).appendTo(
                     table.columns([index]).header())
             }
             else{

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -154,13 +154,11 @@ function free_text_column_search(data_table_id, column_indexes) {
             var title = this.header().textContent;
             $('<input type="text" placeholder="Search ' + title + '" />')
                 .appendTo(this.header())
-                .on('keydown', function(key_opt) {
-                    if (key_opt.keyCode == 13) { //only on enter keypress (code 13)
-                        that
+                .on('keyup change clear', function() { //column search/sorting triggered on every input
+                            that
                             .search(this.value)
                             .draw();
-                    }
-                });
+            });
         });
     })
 }

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -153,7 +153,7 @@ function free_text_column_search(data_table_id, column_indexes) {
         table.columns(column_indexes).every(function() {
             var that = this;
             var title = this.header().textContent;
-            $('<input type="text" placeholder="Search ' + title + '" />')
+            $('<input class="custom-input-text custom-search-box" type="text" placeholder="🔍 ' + title + '" />')
                 .appendTo(this.header())
                 .on('keyup change clear', function() { //column search/sorting triggered on every input
                             that

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -162,16 +162,16 @@ function specific_column_search(data_table_id, column_indexes) {
                     that.search($(this).val()).draw();
                 });
             mySelectList.append(
-                $(`<option value="${reset}">${reset}</option>`)
+                $(`<option class="custom-search-box" value="${reset}">${reset}</option>`)
             );
             this.cache("search").unique().sort().each(function(param) {
                 if (param !== "") {
                     mySelectList.append(
-                        $(`<option value="${param}">${param}</option>`)
+                        $(`<option class="custom-search-box" value="${param}">${param}</option>`)
                     );
                 } else {
                     mySelectList.append(
-                        $(`<option value="${param}">null</option>`)
+                        $(`<option class="custom-search-box" value="${param}">null</option>`)
                     );
                 }           
             });
@@ -206,6 +206,33 @@ function free_text_column_search(data_table_id, column_indexes) {
     })
 }
 
+/*
+INFO:
+    Function to check unique value count and set the required search type
+ */
+function column_search_implementation(data_table_id) {
+    $(document).ready(function() {
+        var table = $(data_table_id).DataTable();
+        var unique_count = [];
+        table.columns().every( function () {
+            var current = this;
+            //array of unique count for data points within each column
+            unique_count.push(current.data().unique().count())
+        });
+        unique_count.forEach(function (item, index) {
+            if (item < 10 && item > 1) {
+                specific_column_search(data_table_id, index)
+            }
+            else if (item > 10){
+                free_text_column_search(data_table_id, index)
+            }
+            else if (item == 1) {
+                $(`<p class="message-header"> 👀 only one value found</p>`).appendTo(
+                    table.columns([index]).header())
+            }
+        });
+    })
+}
 
 $("#confirm-delete").on("show.bs.modal", function(e) {
     $(this).find("#confirm-delete-message").html($(e.relatedTarget).data("message"));

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -113,8 +113,9 @@
 {% block scripts %}
 {{super()}}
 <script type="text/javascript">
-  var table = $('#runs').DataTable( {
+  var table = $('#runs').DataTable({
       "order": [[0, 'desc']],
+      "aaSorting": [],
       "language": {
           "searchPlaceholder": "commit hash works too",
       }

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -118,10 +118,6 @@
       "language": {
           "searchPlaceholder": "commit hash works too",
       },
-      "columnDefs": [{
-          "targets": [1,2,3,4,5,6],
-          "orderable": false
-      }]
 });
 
 enable_search_query_string('#runs');

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -117,7 +117,11 @@
       "order": [[0, 'desc']],
       "language": {
           "searchPlaceholder": "commit hash works too",
-      }
+      },
+      "columnDefs": [{
+          "targets": [1,2,3,4,5,6],
+          "orderable": false
+      }]
 });
 
 enable_search_query_string('#runs');

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -121,6 +121,6 @@
 });
 
 enable_search_query_string('#runs');
-free_text_column_search('#runs', [3]);
+free_text_column_search('#runs', [1,3,4]);
 </script>
 {% endblock %}

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -121,6 +121,6 @@
 });
 
 enable_search_query_string('#runs');
-
+free_text_column_search('#runs', [3]);
 </script>
 {% endblock %}

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -121,6 +121,6 @@
 });
 
 enable_search_query_string('#runs');
-free_text_column_search('#runs', [1,3,4]);
+free_text_column_search('#runs', [1,3,4,5]);
 </script>
 {% endblock %}

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -125,12 +125,10 @@
 });
 enable_search_query_string('#runs');
 
-/* specify the HTML table id (string) and the indexes of the columns for
- which search functionality should be enabled in an array format
+/* specify the HTML table id (string) for
+ which search functionality should be enabled
 */
-specific_column_search('#runs', [6]);
-free_text_column_search('#runs', [1,3,4,5]);
-
+column_search_implementation('#runs')
 
 </script>
 {% endblock %}

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -128,7 +128,7 @@ enable_search_query_string('#runs');
 /* specify the HTML table id (string) for
  which search functionality should be enabled
 */
-column_search_implementation('#runs')
+column_search_implementation('#runs');
 
 </script>
 {% endblock %}

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -115,7 +115,6 @@
 <script type="text/javascript">
   var table = $('#runs').DataTable({
       "order": [[0, 'desc']],
-      "aaSorting": [],
       "language": {
           "searchPlaceholder": "commit hash works too",
       }

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -189,7 +189,7 @@ var table = $('#benchmarks').dataTable( {
 } );
 
 enable_search_query_string('#benchmarks');
-dropdown_column_search('#benchmarks', [1]);
+column_search_implementation('#benchmarks');
 
 $(document).ready(function() {
     $('#unit-tooltip').tooltip()

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -189,7 +189,7 @@ var table = $('#benchmarks').dataTable( {
 } );
 
 enable_search_query_string('#benchmarks');
-specific_column_search('#benchmarks', [1]);
+dropdown_column_search('#benchmarks', [1]);
 
 $(document).ready(function() {
     $('#unit-tooltip').tooltip()


### PR DESCRIPTION
closes #602 
closes #629
closes #619 
closes #642 


#### Details & preview

- Adds additional capabilities for individual column search 


https://user-images.githubusercontent.com/17350312/214005656-f866bfe9-e030-453a-9bdf-d6ad431aa62d.mov



#### Search trigger options
1. Currently the free text is triggered on every keypress/input  
```js
on('keyup change clear', function() {
                that
                .search(this.value)
                .draw();
)};
```

2. trigger only when `enter` is pressed. Reduces the number of API pings + efficient. Little counter intuitive from the existing search option.
```js
.on('keydown', function(key_opt) {
   if (key_opt.keyCode == 13) { //search activated only on enter key-press
                that
                .search(this.value)
                .draw();
            }
)};
```