### PR TITLE
Run timestamp_finished: improved spec, consolidated timezone logic

### DIFF
--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -60,6 +60,7 @@ class BenchmarkResult(Base, EntityMixin):
 
     @staticmethod
     def create(data):
+        """Create BenchmarkResult and write to database."""
         tags = data["tags"]
         has_error = "error" in data
         has_stats = "stats" in data

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import timezone
 from typing import Optional
 
 import flask as f
@@ -6,6 +7,8 @@ import marshmallow
 import sqlalchemy as s
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import relationship
+
+from conbench.util import tznaive_dt_to_aware_iso8601_for_api
 
 from ..db import Session
 from ..entities._entity import Base, EntityMixin, EntitySerializer, NotNull, Nullable
@@ -34,7 +37,9 @@ class Run(Base, EntityMixin):
     id = NotNull(s.String(50), primary_key=True)
     name = Nullable(s.String(250))
     reason = Nullable(s.String(250))
+    # tz-naive timestamp expected to refer to UTC time.
     timestamp = NotNull(s.DateTime(timezone=False), server_default=s.sql.func.now())
+    # tz-naive timestamp expected to refer to UTC time.
     finished_timestamp = Nullable(s.DateTime(timezone=False))
     info = Nullable(postgresql.JSONB)
     error_info = Nullable(postgresql.JSONB)
@@ -206,8 +211,11 @@ class _Serializer(EntitySerializer):
             "id": run.id,
             "name": run.name,
             "reason": run.reason,
+            # TODO: also use tznaive_dt_to_aware_iso8601_for_api
             "timestamp": run.timestamp.isoformat(),
-            "finished_timestamp": run.finished_timestamp.isoformat()
+            "finished_timestamp": tznaive_dt_to_aware_iso8601_for_api(
+                run.finished_timestamp
+            )
             if run.finished_timestamp
             else None,
             "info": run.info,
@@ -318,7 +326,13 @@ class GitHubCreate(marshmallow.Schema):
 
 
 field_descriptions = {
-    "finished_timestamp": "The datetime the run finished",
+    "finished_timestamp": (
+        "A datetime string indicating the time at which the run finished. "
+        "Expected to be in ISO 8601 notation. Timezone-aware notation "
+        "recommended. Timezone-naive strings are interpreted in UTC. "
+        "Fractions of seconds can be provided but are not returned by the "
+        "API. Example value: 2022-11-25T22:02:42Z"
+    ),
     "info": "Run's metadata",
     "error_info": "Metadata for run's error that prevented all or some benchmarks from running",
     "error_type": """Run's error type. Possible values: none, catastrophic, partial.
@@ -349,6 +363,10 @@ class _RunFacadeSchemaCreate(marshmallow.Schema):
     machine_info = marshmallow.fields.Nested(MachineSchema().create, required=False)
     cluster_info = marshmallow.fields.Nested(ClusterSchema().create, required=False)
 
+    @marshmallow.post_load
+    def recalc_finished_time(self, data, **kwargs):
+        return _recalc_finished_time(data)
+
     @marshmallow.validates_schema
     def validate_hardware_info_fields(self, data, **kwargs):
         if "machine_info" not in data and "cluster_info" not in data:
@@ -362,10 +380,17 @@ class _RunFacadeSchemaCreate(marshmallow.Schema):
 
 
 class _RunFacadeSchemaUpdate(marshmallow.Schema):
-    finished_timestamp = marshmallow.fields.DateTime(
+    # `AwareDateTime` with `default_timezone` set to UTC: naive datetimes are
+    # set this timezone.
+    finished_timestamp = marshmallow.fields.AwareDateTime(
         required=False,
-        metadata={"description": field_descriptions["finished_timestamp"]},
+        format="iso",
+        default_timezone=timezone.utc,
+        metadata={
+            "description": field_descriptions["finished_timestamp"],
+        },
     )
+
     info = marshmallow.fields.Dict(
         required=False, metadata={"description": field_descriptions["info"]}
     )
@@ -376,7 +401,21 @@ class _RunFacadeSchemaUpdate(marshmallow.Schema):
         required=False, metadata={"description": field_descriptions["error_type"]}
     )
 
+    @marshmallow.post_load
+    def recalc_finished_time(self, data, **kwargs):
+        return _recalc_finished_time(data)
+
 
 class RunFacadeSchema:
     create = _RunFacadeSchemaCreate()
     update = _RunFacadeSchemaUpdate()
+
+
+def _recalc_finished_time(data):
+    ft = data.get("finished_timestamp")
+
+    if ft and ft.tzinfo and ft.tzinfo != timezone.utc:
+        ft_utc = ft.astimezone(timezone.utc)
+        data["finished_timestamp"] = ft_utc
+
+    return data

--- a/conbench/tests/api/_asserts.py
+++ b/conbench/tests/api/_asserts.py
@@ -193,15 +193,13 @@ class PostEnforcer(Enforcer):
 
     def test_not_application_json(self, client):
         self.authenticate(client)
-        response = client.post(self.url, data=self.valid_payload)
-        message = {
-            "_errors": ["Empty request body."],
-            "_schema": [
-                "Invalid input type.",
-                "Did you specify Content-type: application/json?",
-            ],
+        resp = client.post(self.url, data=self.valid_payload)
+        assert resp.json == {
+            "code": 400,
+            "name": "Bad Request",
+            "description": "Did not attempt to load JSON data because the "
+            "request Content-Type was not 'application/json'.",
         }
-        self.assert_400_bad_request(response, message)
 
 
 class PutEnforcer(Enforcer):
@@ -270,12 +268,10 @@ class PutEnforcer(Enforcer):
     def test_not_application_json(self, client):
         self.authenticate(client)
         entity = self._create_entity_to_update()
-        response = client.put(self.url.format(entity.id), data=self.valid_payload)
-        message = {
-            "_errors": ["Empty request body."],
-            "_schema": [
-                "Invalid input type.",
-                "Did you specify Content-type: application/json?",
-            ],
+        resp = client.put(self.url.format(entity.id), data=self.valid_payload)
+        assert resp.json == {
+            "code": 400,
+            "name": "Bad Request",
+            "description": "Did not attempt to load JSON data because the "
+            "request Content-Type was not 'application/json'.",
         }
-        self.assert_400_bad_request(response, message)

--- a/conbench/tests/api/_asserts.py
+++ b/conbench/tests/api/_asserts.py
@@ -186,7 +186,8 @@ class PostEnforcer(Enforcer):
     def test_empty_payload(self, client):
         self.authenticate(client)
         response = client.post(self.url, json={})
-        message = {"_errors": ["Empty request body."]}
+        # message = {"_errors": ["Empty request body."]}
+        message = {}
         for field in self.required_fields:
             message[field] = ["Missing data for required field."]
         self.assert_400_bad_request(response, message)

--- a/conbench/tests/api/_asserts.py
+++ b/conbench/tests/api/_asserts.py
@@ -144,7 +144,7 @@ class PostEnforcer(Enforcer):
         data = copy.deepcopy(self.valid_payload)
         data["id"] = "some id"
         response = client.post(self.url, json=data)
-        message = {"id": ["Read-only field."]}
+        message = {"id": ["Unknown field."]}
         self.assert_400_bad_request(response, message)
 
     def test_required_fields(self, client):
@@ -227,7 +227,7 @@ class PutEnforcer(Enforcer):
         entity = self._create_entity_to_update()
         data = {"id": "some id"}
         response = client.put(self.url.format(entity.id), json=data)
-        message = {"id": ["Read-only field."]}
+        message = {"id": ["Unknown field."]}
         self.assert_400_bad_request(response, message)
 
     def test_empty_fields(self, client):

--- a/conbench/tests/api/_asserts.py
+++ b/conbench/tests/api/_asserts.py
@@ -52,7 +52,7 @@ class ApiEndpointTest:
             "code": 400,
             "name": "Bad Request",
             "description": message,
-        }, r.json
+        }
         # TODO: https://github.com/marshmallow-code/marshmallow/issues/120
         # errors = BadRequestSchema().validate(r.json)
         # assert errors == {}, errors

--- a/conbench/tests/api/_asserts.py
+++ b/conbench/tests/api/_asserts.py
@@ -13,7 +13,8 @@ class ApiEndpointTest:
 
     def login(self, client, email, password):
         data = {"email": email, "password": password}
-        client.post("/api/login/", json=data)
+        resp = client.post("/api/login/", json=data)
+        assert resp.status_code == 204, resp.text
 
     def create_random_user(self):
         return create_random_user()

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -1264,7 +1264,7 @@
                         "type": "string",
                     },
                     "finished_timestamp": {
-                        "description": "The datetime the run finished",
+                        "description": "A datetime string indicating the time at which the run finished. Expected to be in ISO 8601 notation. Timezone-aware notation recommended. Timezone-naive strings are interpreted in UTC. Fractions of seconds can be provided but are not returned by the API. Example value: 2022-11-25T22:02:42Z",
                         "format": "date-time",
                         "type": "string",
                     },
@@ -1289,7 +1289,7 @@
                         "type": "string",
                     },
                     "finished_timestamp": {
-                        "description": "The datetime the run finished",
+                        "description": "A datetime string indicating the time at which the run finished. Expected to be in ISO 8601 notation. Timezone-aware notation recommended. Timezone-naive strings are interpreted in UTC. Fractions of seconds can be provided but are not returned by the API. Example value: 2022-11-25T22:02:42Z",
                         "format": "date-time",
                         "type": "string",
                     },

--- a/conbench/tests/api/_fixtures.py
+++ b/conbench/tests/api/_fixtures.py
@@ -55,7 +55,7 @@ VALID_PAYLOAD = {
     "run_name": "commit: 02addad336ba19a654f9c857ede546331be7b631",
     "run_reason": "commit",
     "batch_id": "7b2fdd9f929d47b9960152090d47f8e6",
-    "timestamp": "2020-11-25T21:02:42.706806+00:00",
+    "timestamp": "2020-11-25T21:02:42.706806",
     "context": {
         "arrow_compiler_flags": "-fPIC -arch x86_64 -arch x86_64 -std=c++11 -Qunused-arguments -fcolor-diagnostics -O3 -DNDEBUG",
         "benchmark_language": "Python",
@@ -185,7 +185,7 @@ VALID_RUN_PAYLOAD = {
     "id": _uuid(),
     "name": "commit: 02addad336ba19a654f9c857ede546331be7b631",
     "reason": "commit",
-    "finished_timestamp": "2020-11-25T21:02:42.706806+00:00",
+    "finished_timestamp": "2020-11-25T21:02:42Z",
     "info": {
         "setup": "passed",
     },

--- a/conbench/tests/api/_fixtures.py
+++ b/conbench/tests/api/_fixtures.py
@@ -232,6 +232,8 @@ def benchmark_result(
     empty_results=False,
     reason=None,
 ):
+    """Create BenchmarkResult and write to database."""
+
     data = copy.deepcopy(VALID_PAYLOAD)
     data["run_name"] = f"commit: {_uuid()}"
     data["run_reason"] = reason if reason else "commit"

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -308,6 +308,7 @@ class TestRunPut(_asserts.PutEnforcer):
 
     def _create_entity_to_update(self):
         _fixtures.benchmark_result(sha=_fixtures.PARENT)
+        # This writes to the database.
         benchmark_result = _fixtures.benchmark_result()
         return benchmark_result.run
 

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -358,11 +358,9 @@ class TestRunPut(_asserts.PutEnforcer):
                 "finished_timestamp": timestring[0],
             },
         )
-        # print(resp.text)
         assert resp.status_code == 200
 
         resp = client.get(f"/api/runs/{before.id}/")
-        print(resp.json["finished_timestamp"])
         assert resp.json["finished_timestamp"] == timestring[1]
 
 

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -358,10 +358,30 @@ class TestRunPut(_asserts.PutEnforcer):
                 "finished_timestamp": timestring[0],
             },
         )
-        assert resp.status_code == 200
+        assert resp.status_code == 200, resp.text
 
         resp = client.get(f"/api/runs/{before.id}/")
         assert resp.json["finished_timestamp"] == timestring[1]
+
+    @pytest.mark.parametrize(
+        "timestring",
+        # first item: bad input, second item: expected err msg
+        [
+            ("2022-11-2521:02:41x", "Not a valid datetime"),
+            ("foobar", "Not a valid datetime"),
+        ],
+    )
+    def test_finished_timestamp_invalid(self, client, timestring):
+        self.authenticate(client)
+        run = self._create_entity_to_update()
+        resp = client.put(
+            f"/api/runs/{run.id}/",
+            json={
+                "finished_timestamp": timestring[0],
+            },
+        )
+        assert resp.status_code == 400, resp.text
+        assert timestring[1] in resp.text
 
 
 class TestRunPost(_asserts.PostEnforcer):

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -301,7 +301,7 @@ class TestRunDelete(_asserts.DeleteEnforcer):
 class TestRunPut(_asserts.PutEnforcer):
     url = "/api/runs/{}/"
     valid_payload = {
-        "finished_timestamp": "2022-11-25 21:02:45Z",
+        "finished_timestamp": "2022-11-25T21:02:45Z",
         "info": {"setup": "passed"},
         "error_info": {"error": "error", "stack_trace": "stack_trace", "fatal": True},
         "error_type": "fatal",
@@ -331,7 +331,7 @@ class TestRunPut(_asserts.PutEnforcer):
 
         for key, value in self.valid_payload.items():
             if key == "finished_timestamp":
-                assert str(getattr(after, key)) == value
+                assert tznaive_dt_to_aware_iso8601_for_api(getattr(after, key)) == value
             else:
                 assert getattr(after, key) == value
 

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -23,7 +23,9 @@ def _expected_entity(run, baseline_id=None, include_baseline=True):
         baseline_id,
         include_baseline,
         has_errors,
-        run.finished_timestamp.isoformat() if run.finished_timestamp else None,
+        tznaive_dt_to_aware_iso8601_for_api(run.finished_timestamp)
+        if run.finished_timestamp
+        else None,
         run.info,
         run.error_info,
         run.error_type,
@@ -297,7 +299,7 @@ class TestRunDelete(_asserts.DeleteEnforcer):
 class TestRunPut(_asserts.PutEnforcer):
     url = "/api/runs/{}/"
     valid_payload = {
-        "finished_timestamp": "2022-11-25 21:02:42.706806",
+        "finished_timestamp": "2022-11-25 21:02:45Z",
         "info": {"setup": "passed"},
         "error_info": {"error": "error", "stack_trace": "stack_trace", "fatal": True},
         "error_type": "fatal",

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -1,5 +1,7 @@
 import pytest
 
+from conbench.util import tznaive_dt_to_aware_iso8601_for_api
+
 from ...api._examples import _api_run_entity
 from ...entities._entity import NotFound
 from ...entities.run import Run
@@ -326,11 +328,42 @@ class TestRunPut(_asserts.PutEnforcer):
         response = client.put(f"/api/runs/{before.id}/", json=self.valid_payload)
         after = Run.one(id=before.id)
         self.assert_200_ok(response, _expected_entity(after))
+
         for key, value in self.valid_payload.items():
             if key == "finished_timestamp":
                 assert str(getattr(after, key)) == value
             else:
                 assert getattr(after, key) == value
+
+    @pytest.mark.parametrize(
+        "timestring",
+        # These are input/output pairs.
+        [
+            ("2022-11-25 21:02:41", "2022-11-25T21:02:41Z"),
+            ("2022-11-25 22:02:42Z", "2022-11-25T22:02:42Z"),
+            ("2022-11-25T22:02:42Z", "2022-11-25T22:02:42Z"),
+            # That next pair confirms timezone conversion.
+            ("2022-11-25 23:02:00+07:00", "2022-11-25T16:02:00Z"),
+            # Confirm that fractions of seconds can be provided, but are not
+            # returned (we can dispute that of course).
+            ("2022-11-25T22:02:42.123456Z", "2022-11-25T22:02:42Z"),
+        ],
+    )
+    def test_finished_timestamp_tz(self, client, timestring):
+        self.authenticate(client)
+        before = self._create_entity_to_update()
+        resp = client.put(
+            f"/api/runs/{before.id}/",
+            json={
+                "finished_timestamp": timestring[0],
+            },
+        )
+        # print(resp.text)
+        assert resp.status_code == 200
+
+        resp = client.get(f"/api/runs/{before.id}/")
+        print(resp.json["finished_timestamp"])
+        assert resp.json["finished_timestamp"] == timestring[1]
 
 
 class TestRunPost(_asserts.PostEnforcer):

--- a/conbench/util.py
+++ b/conbench/util.py
@@ -25,6 +25,24 @@ adapter = HTTPAdapter(max_retries=retry_strategy)
 log = logging.getLogger()
 
 
+def tznaive_dt_to_aware_iso8601_for_api(dt: datetime) -> str:
+    """We store datetime objects in the database in columns that are configured
+    to not track timezone information. By convention, each of those tz-naive
+    datetime objects in the database is to be interpreted in UTC. Before
+    emitting a stringified variant of such timestamp to an API user, serialize
+    to a tz-aware ISO 8601 timestring, indicating UTC (Zulu) time, via adding
+    the 'Z'.
+
+    Example output: 2022-11-25T16:02:00Z
+    """
+    if dt.tzinfo is not None:
+        # Programming error, but don't crash.
+        log.warning(
+            "tznaive_dt_to_aware_iso8601_for_api() got tz-aware datetime obj: %s", dt
+        )
+    return dt.isoformat(sep="T", timespec="seconds") + "Z"
+
+
 def tznaive_iso8601_to_tzaware_dt(
     input: Union[str, List[str]]
 ) -> Union[datetime, List[datetime]]:

--- a/conbench/util.py
+++ b/conbench/util.py
@@ -36,15 +36,17 @@ def tznaive_iso8601_to_tzaware_dt(
     If a single string is provided return a single datetime object.
 
     Assume that each provided string is in ISO 8601 notation without timezone
-    information, but that the time is actually meant to be interpreted in the
-    UTC timezone.
+    information, but that the time is meant to be interpreted in the UTC
+    timezone.
 
-    If an input string is tz-aware and encodes Zulu (UTC) time then this
+    If an input string is tz-aware and encodes UTC (Zulu) time then this
     timezone is retained.
 
-    If an input string is tz-aware and encodes a different time zone then the
-    timezone is rewritten to UTC, i.e there is information loss/transformation,
-    but a warning is also emitted.
+    An input string that is tz-aware and that encodes a timezone other than UTC
+    is unexpected input, as of e.g. a programming error or unexpected legacy
+    database state. We decided to log a warning message instead of crashing in
+    that case (also, the indicated time gets interpreted in UTC, i.e. the
+    original timezone information is ignored).
 
     Note: this was built with and tested for a value like 2022-03-03T19:48:06
     which in this example represents a commit timestamp (in UTC, additional

--- a/conbench/util.py
+++ b/conbench/util.py
@@ -34,12 +34,24 @@ def tznaive_dt_to_aware_iso8601_for_api(dt: datetime) -> str:
     the 'Z'.
 
     Example output: 2022-11-25T16:02:00Z
+
+    Note(JP) on time resolution: ISO 8601 allows for fractions of seconds in
+    various formats (3-9 digits). Timestamps in Conbench are not used for
+    uniquely identifying entities. When we return ISO 8601 timestamps to HTTP
+    API users we have to have an opinion about the fraction of the second to
+    encode in the string. I think it's valuable to have a predictable
+    fixed-width format with non-dynamic time precision. As far as I understand
+    the value and use of timestamps returned by the API, I think we do not need
+    to emit fractions of seconds. Therefore the `timespec="seconds"` below.
+    This is currently documented and also tested, but can of course be changed.
     """
     if dt.tzinfo is not None:
         # Programming error, but don't crash.
         log.warning(
             "tznaive_dt_to_aware_iso8601_for_api() got tz-aware datetime obj: %s", dt
         )
+        return dt.isoformat(sep="T", timespec="seconds")
+
     return dt.isoformat(sep="T", timespec="seconds") + "Z"
 
 


### PR DESCRIPTION
This is motivated by https://github.com/conbench/conbench/issues/609.

I started with a rather harmless timestamp, the `timestamp_finished` property of a run.

I started by improving the specification.  My current proposal:

> A datetime string indicating the time at which the run finished. Expected to be in ISO 8601 notation. Timezone-aware notation recommended. Timezone-naive strings are interpreted in UTC. Fractions of seconds can be provided but are not returned by the API. Example value: `2022-11-25T22:02:42Z`"

To implement this kind of logic a convenient, productive, idiomatic place is to use marshmallow's `post_load()` hook, documented [here](https://marshmallow.readthedocs.io/en/stable/marshmallow.decorators.html#marshmallow.decorators.post_load). Initially this didn't work. The reason is that we used only `schema.validate()`, and not `schema.load()`. Docs [here](https://marshmallow.readthedocs.io/en/stable/quickstart.html#validation-without-deserialization).

I decided to do a bit of a risky surgery to replace `schema.validate()` with `schema.load()` in the code path that affects all mutating HTTP handlers. I think this was worth it, led to some good insights and cleanups here and there. Some tests needed to be adjusted slightly with respect to error messages -- I think the subtle changes in behavior are all OK.

I have added a test case with input/output pairs, maybe that's a good starting point for review.

There are more tiny changes in this PR that are hopefully explained in commit msgs, otherwise feel free to leave a comment/question!

Once we settle on this one here the plan is to treat other timestamp properties in the API similarly.



