### PR TITLE
hotfix: python 3.8-compatible type hints

### DIFF
--- a/conbench/util.py
+++ b/conbench/util.py
@@ -4,7 +4,7 @@ import os
 import time
 import urllib.parse
 from datetime import datetime, timezone
-from typing import Union
+from typing import List, Union
 
 import click
 import requests
@@ -26,8 +26,8 @@ log = logging.getLogger()
 
 
 def tznaive_iso8601_to_tzaware_dt(
-    input: Union[str, list[str]]
-) -> Union[datetime, list[datetime]]:
+    input: Union[str, List[str]]
+) -> Union[datetime, List[datetime]]:
     """
     Convert time strings into datetime objects.
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ requirements_test = parse_requirements(path="requirements-test.txt")
 
 setuptools.setup(
     name="conbench",
-    version="1.62.0",
+    version="1.63.0",
     description="Continuous Benchmarking (CB) Framework",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
There are many infrastructures out there (such as [arrow-benchmarks-ci](https://github.com/voltrondata-labs/arrow-benchmarks-ci)) that download the `conbench` CLI from PyPI and use it to run benchmarks. Some of them are using python<3.9, so we can't use the new method of built-in object subscriptable type hinting like `list[str]`.