### PR TITLE
replace print() with logging, or outcomment

### DIFF
--- a/conbench/entities/commit.py
+++ b/conbench/entities/commit.py
@@ -329,7 +329,7 @@ def backfill_default_branch_commits(
     if last_tracked_commit:
         since = last_tracked_commit[0].timestamp
     elif os.getenv("DB_HOST") == "localhost":
-        print(
+        log.info(
             "Your DB_HOST is localhost, so assuming you're running "
             "conbench/tests/populate_local_conbench.py. Backfilling the DB only from "
             "2022-01-01 in order to save time."
@@ -434,7 +434,7 @@ class GitHub:
         since = since.replace(tzinfo=None).isoformat() + "Z"
         until = until.replace(tzinfo=None).isoformat() + "Z"
 
-        print(
+        log.info(
             f"Finding all commits to the {branch} branch of {name} between {since} and "
             f"{until}"
         )
@@ -449,7 +449,7 @@ class GitHub:
         this_page = self._get_response(url + f"&page={page}")
 
         if len(this_page) == 0:
-            print("API returned no commits")
+            log.info("API returned no commits")
             return []
 
         commits += this_page

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -404,8 +404,8 @@ class TestRunPost(_asserts.PostEnforcer):
             run_id = payload["id"]
             assert not Run.first(id=run_id)
             response = client.post(self.url, json=payload)
-            print(response)
-            print(response.json)
+            # print(response)
+            # print(response.json)
             run = Run.one(id=run_id)
             location = f"http://localhost/api/runs/{run_id}/"
             self.assert_201_created(response, _expected_entity(run), location)

--- a/conbench/tests/benchmark/test_runner.py
+++ b/conbench/tests/benchmark/test_runner.py
@@ -79,7 +79,7 @@ def test_runner_simple_benchmark_that_fails():
 
     result = benchmark.conbench.published_benchmark
     assert not BenchmarkFacadeSchema.create.validate(result)
-    print(result)
+    # print(result)
     assert_keys_equal(result, EXAMPLE_WITH_ERROR)
     for key in ["info", "context", "github", "machine_info"]:
         assert_keys_equal(result[key], EXAMPLE_WITH_ERROR[key])

--- a/conbench/util.py
+++ b/conbench/util.py
@@ -131,7 +131,7 @@ class Connection:
                 self.session.mount("https://", adapter)
             start = time.monotonic()
             response = self.session.post(url, json=data)
-            print("Time to POST", url, time.monotonic() - start)
+            log.info("Time to POST", url, time.monotonic() - start)
             if response.status_code != expected:
                 self._unexpected_response("POST", response, url)
         except requests.exceptions.ConnectionError:


### PR DESCRIPTION
I used `grep` to review a few more print() occurrences. Motivating ticket: https://github.com/conbench/conbench/issues/442