### PR TITLE
BenchmarkCreate timestamp: improved spec, explicit timezone conversion

### DIFF
--- a/conbench/api/_examples.py
+++ b/conbench/api/_examples.py
@@ -118,7 +118,7 @@ def _api_benchmark_entity(
         "id": benchmark_result_id,
         "run_id": run_id,
         "batch_id": batch_id,
-        "timestamp": "2020-11-25T21:02:42.706806",
+        "timestamp": "2020-11-25T21:02:44Z",
         "stats": stats,
         "error": error,
         "validation": validation,

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -419,9 +419,10 @@ class _BenchmarkFacadeSchemaCreate(marshmallow.Schema):
                 interpreted in UTC. Fractions of seconds can be provided but
                 are not returned by the API. Example value:
                 2022-11-25T22:02:42Z. This timestamp defines the default
-                sorting order when viewing runs via the UI or when enumerating
-                runs via the /api/runs/ HTTP endpoint.
-            """
+                sorting order when viewing a list of benchmarks via the UI or
+                when enumerating benchmarks via the /api/benchmarks/ HTTP
+                endpoint.
+                """
             )
         },
     )

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -418,7 +418,9 @@ class _BenchmarkFacadeSchemaCreate(marshmallow.Schema):
                 Timezone-aware notation recommended. Timezone-naive strings are
                 interpreted in UTC. Fractions of seconds can be provided but
                 are not returned by the API. Example value:
-                2022-11-25T22:02:42Z.
+                2022-11-25T22:02:42Z. This timestamp defines the default
+                sorting order when viewing runs via the UI or when enumerating
+                runs via the /api/runs/ HTTP endpoint.
             """
             )
         },

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -1,3 +1,5 @@
+from datetime import timezone
+
 import flask as f
 import marshmallow
 import numpy as np
@@ -5,6 +7,8 @@ import sqlalchemy as s
 from sqlalchemy import CheckConstraint as check
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import relationship
+
+import conbench.util
 
 from ..config import Config
 from ..entities._comparator import z_improvement, z_regression
@@ -44,6 +48,9 @@ class BenchmarkResult(Base, EntityMixin):
     unit = Nullable(s.Text)
     time_unit = Nullable(s.Text)
     batch_id = Nullable(s.Text)
+    # Do not store timezone information in the DB. Instead, follow timezone
+    # convention: the application code must make sure that what we store is the
+    # user-given time in UTC.
     timestamp = NotNull(s.DateTime(timezone=False))
     iterations = Nullable(s.Integer)
     min = Nullable(s.Numeric, check("min>=0"))
@@ -168,6 +175,9 @@ class BenchmarkResult(Base, EntityMixin):
 
         benchmark_result_data["run_id"] = data["run_id"]
         benchmark_result_data["batch_id"] = data["batch_id"]
+
+        # At this point `data["timestamp"]` is expected to be a tz-aware
+        # datetime object in UTC.
         benchmark_result_data["timestamp"] = data["timestamp"]
         benchmark_result_data["validation"] = data.get("validation")
         benchmark_result_data["change_annotations"] = {
@@ -311,7 +321,9 @@ class _Serializer(EntitySerializer):
             "id": benchmark_result.id,
             "run_id": benchmark_result.run_id,
             "batch_id": benchmark_result.batch_id,
-            "timestamp": benchmark_result.timestamp.isoformat(),
+            "timestamp": conbench.util.tznaive_dt_to_aware_iso8601_for_api(
+                benchmark_result.timestamp
+            ),
             "tags": tags,
             "optional_benchmark_info": benchmark_result.optional_benchmark_info,
             "validation": benchmark_result.validation,
@@ -391,8 +403,25 @@ class _BenchmarkFacadeSchemaCreate(marshmallow.Schema):
         },
     )
     batch_id = marshmallow.fields.String(required=True)
-    timestamp = marshmallow.fields.DateTime(
-        required=True, metadata={"description": "Timestamp the benchmark ran"}
+
+    # `AwareDateTime` with `default_timezone` set to UTC: naive datetimes are
+    # set this timezone.
+    timestamp = marshmallow.fields.AwareDateTime(
+        required=True,
+        format="iso",
+        default_timezone=timezone.utc,
+        metadata={
+            "description": conbench.util.dedent_rejoin(
+                """
+                A datetime string indicating the time at which the benchmark
+                was started. Expected to be in ISO 8601 notation.
+                Timezone-aware notation recommended. Timezone-naive strings are
+                interpreted in UTC. Fractions of seconds can be provided but
+                are not returned by the API. Example value:
+                2022-11-25T22:02:42Z.
+            """
+            )
+        },
     )
     machine_info = marshmallow.fields.Nested(MachineSchema().create, required=False)
     cluster_info = marshmallow.fields.Nested(ClusterSchema().create, required=False)
@@ -454,6 +483,16 @@ class _BenchmarkFacadeSchemaCreate(marshmallow.Schema):
     def validate_stats_or_error_field_is_present(self, data, **kwargs):
         if "stats" not in data and "error" not in data:
             raise marshmallow.ValidationError("Either stats or error field is required")
+
+    @marshmallow.post_load
+    def recalc_timestamp(self, data, **kwargs):
+        curdt = data.get("timestamp")
+
+        if curdt is None:
+            return data
+
+        data["timestamp"] = conbench.util.dt_shift_to_utc(curdt)
+        return data
 
 
 class _BenchmarkFacadeSchemaUpdate(marshmallow.Schema):

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -109,7 +109,7 @@
                                 "input_type": "arrow",
                                 "name": "file-write",
                             },
-                            "timestamp": "2020-11-25T21:02:42.706806",
+                            "timestamp": "2020-11-25T21:02:44Z",
                             "validation": None,
                         }
                     }
@@ -182,7 +182,7 @@
                                 "input_type": "arrow",
                                 "name": "file-write",
                             },
-                            "timestamp": "2020-11-25T21:02:42.706806",
+                            "timestamp": "2020-11-25T21:02:44Z",
                             "validation": None,
                         }
                     }
@@ -256,7 +256,7 @@
                                     "input_type": "arrow",
                                     "name": "file-write",
                                 },
-                                "timestamp": "2020-11-25T21:02:42.706806",
+                                "timestamp": "2020-11-25T21:02:44Z",
                                 "validation": None,
                             }
                         ]
@@ -1018,7 +1018,7 @@
                         "type": "object",
                     },
                     "timestamp": {
-                        "description": "Timestamp the benchmark ran",
+                        "description": "A datetime string indicating the time at which the benchmark was started. Expected to be in ISO 8601 notation. Timezone-aware notation recommended. Timezone-naive strings are interpreted in UTC. Fractions of seconds can be provided but are not returned by the API. Example value: 2022-11-25T22:02:42Z.",
                         "format": "date-time",
                         "type": "string",
                     },

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -1018,7 +1018,7 @@
                         "type": "object",
                     },
                     "timestamp": {
-                        "description": "A datetime string indicating the time at which the benchmark was started. Expected to be in ISO 8601 notation. Timezone-aware notation recommended. Timezone-naive strings are interpreted in UTC. Fractions of seconds can be provided but are not returned by the API. Example value: 2022-11-25T22:02:42Z. This timestamp defines the default sorting order when viewing runs via the UI or when enumerating runs via the /api/runs/ HTTP endpoint.",
+                        "description": "A datetime string indicating the time at which the benchmark was started. Expected to be in ISO 8601 notation. Timezone-aware notation recommended. Timezone-naive strings are interpreted in UTC. Fractions of seconds can be provided but are not returned by the API. Example value: 2022-11-25T22:02:42Z. This timestamp defines the default sorting order when viewing a list of benchmarks via the UI or when enumerating benchmarks via the /api/benchmarks/ HTTP endpoint.",
                         "format": "date-time",
                         "type": "string",
                     },

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -1018,7 +1018,7 @@
                         "type": "object",
                     },
                     "timestamp": {
-                        "description": "A datetime string indicating the time at which the benchmark was started. Expected to be in ISO 8601 notation. Timezone-aware notation recommended. Timezone-naive strings are interpreted in UTC. Fractions of seconds can be provided but are not returned by the API. Example value: 2022-11-25T22:02:42Z.",
+                        "description": "A datetime string indicating the time at which the benchmark was started. Expected to be in ISO 8601 notation. Timezone-aware notation recommended. Timezone-naive strings are interpreted in UTC. Fractions of seconds can be provided but are not returned by the API. Example value: 2022-11-25T22:02:42Z. This timestamp defines the default sorting order when viewing runs via the UI or when enumerating runs via the /api/runs/ HTTP endpoint.",
                         "format": "date-time",
                         "type": "string",
                     },

--- a/conbench/tests/api/_fixtures.py
+++ b/conbench/tests/api/_fixtures.py
@@ -55,7 +55,7 @@ VALID_PAYLOAD = {
     "run_name": "commit: 02addad336ba19a654f9c857ede546331be7b631",
     "run_reason": "commit",
     "batch_id": "7b2fdd9f929d47b9960152090d47f8e6",
-    "timestamp": "2020-11-25T21:02:42.706806",
+    "timestamp": "2020-11-25T21:02:44Z",
     "context": {
         "arrow_compiler_flags": "-fPIC -arch x86_64 -arch x86_64 -std=c++11 -Qunused-arguments -fcolor-diagnostics -O3 -DNDEBUG",
         "benchmark_language": "Python",

--- a/conbench/util.py
+++ b/conbench/util.py
@@ -120,6 +120,24 @@ def dedent_rejoin(s: str):
     return " ".join(textwrap.dedent(s).strip().splitlines())
 
 
+def dt_shift_to_utc(dt: Union[datetime, None]) -> Union[datetime, None]:
+    """
+    If the provided datetime object has a non-UTC `tzinfo` set then transform
+    the time to UTC.
+
+    This is expected to be called by the application only for tz-aware datetime
+    objects, but it does not crash for tz-naive objects.
+
+    tz-naive objects are returned unmodified.
+    """
+    if dt is not None and dt.tzinfo and dt.tzinfo != timezone.utc:
+        # Change timezone to UTC, and also chang the numerical values so that
+        # the same point in time is retained (change coordinate system).
+        dt = dt.astimezone(timezone.utc)
+
+    return dt
+
+
 class Connection:
     def __init__(self):
         self.config = Config(get_config())

--- a/conbench/util.py
+++ b/conbench/util.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import textwrap
 import time
 import urllib.parse
 from datetime import datetime, timezone
@@ -107,6 +108,16 @@ def tznaive_iso8601_to_tzaware_dt(
 
     # Handle case where input is a list of strings.
     return [_convert(s) for s in input]
+
+
+def dedent_rejoin(s: str):
+    """
+    Remove common leading whitespace, replace newlines by spaces.
+
+    Useful for being able to write marshmallow property docstrings with
+    indented block paragraphs.
+    """
+    return " ".join(textwrap.dedent(s).strip().splitlines())
 
 
 class Connection:


### PR DESCRIPTION
Similar to https://github.com/conbench/conbench/pull/614.

This is motivated by https://github.com/conbench/conbench/issues/534 and https://github.com/conbench/conbench/issues/609.

This patch touches on the behavior of the `timestamp` property in the `BenchmarkCreate` schema.

Specifically, this patch

- changes the user-facing specification text
- adds more code comments around our DB timezone convention
- uses `marshmallow.fields.AwareDateTime` instead of `marshmallow.fields.DateTime`
- uses explicit timezone conversion code (to UTC, when users provide a non-UTC tz-aware time string)
- adds test cases for various special cases, including timezone conversion

I wanted to remove a bit of the ambiguity discussed in https://github.com/conbench/conbench/issues/534 about the meaning of this timestamp. New: "A datetime string indicating the time at which the benchmark _was started_". This takes some mental burden away from users and I think it makes sense in most of the cases. To advanced users it should be obvious that _any_ time can be communicated here. In this API spec I think it's also valuable to let users know where/how this timestamp is used (result sort oder); and so I added that.