### PR TITLE
API docs: notes on implicit Run creation & metadata update, add a test

### DIFF
--- a/conbench/api/benchmarks.py
+++ b/conbench/api/benchmarks.py
@@ -161,11 +161,13 @@ class BenchmarkListAPI(ApiEndpoint, BenchmarkValidationMixin):
         """
         ---
         description:
-            Submit a BenchmarkResult within a specific Run (as defined by its
-            Run ID). If the Run is not known yet in the database it gets
-            implicitly created, using details provided in this request. If the
-            Run is already known then Run-specific info in this request is
-            silently ignored.
+            Submit a BenchmarkResult within a specific Run.
+
+            If the Run (as defined by its Run ID) is not known yet in the
+            database it gets implicitly created, using details provided in this
+            request. If the Run ID matches an existing run, then the rest of
+            the fields describing the Run (such as name, hardware info, ...}
+            are silently ignored.
         responses:
             "201": "BenchmarkCreated"
             "400": "400"

--- a/conbench/api/benchmarks.py
+++ b/conbench/api/benchmarks.py
@@ -160,7 +160,12 @@ class BenchmarkListAPI(ApiEndpoint, BenchmarkValidationMixin):
     def post(self):
         """
         ---
-        description: Create a benchmark.
+        description:
+            Submit a BenchmarkResult within a specific Run (as defined by its
+            Run ID). If the Run is not known yet in the database it gets
+            implicitly created, using details provided in this request. If the
+            Run is already known then Run-specific info in this request is
+            silently ignored.
         responses:
             "201": "BenchmarkCreated"
             "400": "400"

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -157,8 +157,7 @@ class BenchmarkResult(Base, EntityMixin):
         # Run is already known in the database then only update the
         # `has_errors` property, if necessary. All other run-specific
         # properties provided as part of this BenchmarkCreate structure (like
-        # `machine_info` and `run_name`) get silently ignored. already known in
-        # the database.
+        # `machine_info` and `run_name`) get silently ignored.
         run = Run.first(id=data["run_id"])
         if run:
             if has_error:
@@ -397,9 +396,9 @@ class _BenchmarkFacadeSchemaCreate(marshmallow.Schema):
         metadata={
             "description": conbench.util.dedent_rejoin(
                 """
-                Identifier for a Run. This can be the ID of a known Run (as
-                returned by /api/runs) or a new ID in which case a new Run
-                entity is created in the database.
+                Identifier for a Run (required). This can be the ID of a known
+                Run (as returned by /api/runs) or a new ID in which case a new
+                Run entity is created in the database.
                 """
             )
         },
@@ -409,9 +408,10 @@ class _BenchmarkFacadeSchemaCreate(marshmallow.Schema):
         metadata={
             "description": conbench.util.dedent_rejoin(
                 """
-                Name for the run. When run in CI, this should be of the style
-                '{run reason}: {commit sha}'. Ignored when run was previously
-                created.
+                Name for the Run (optional, does not need to be unique). Can be
+                useful for implementing a custom naming convention. For
+                organizing your benchmarks, and for enhanced search &
+                discoverability. Ignored when Run was previously created.
                 """
             )
         },
@@ -421,10 +421,8 @@ class _BenchmarkFacadeSchemaCreate(marshmallow.Schema):
         metadata={
             "description": conbench.util.dedent_rejoin(
                 """
-                Reason for run (commit, pull request, manual, etc). This should
-                be low cardinality. 'commit' is a special run_reason for
-                commits on the default branch which are used for history.
-                Ignored when run was previously created.
+                Reason for the Run (optional, does not need to be unique).
+                Ignored when Run was previously created.
                 """
             )
         },

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -397,9 +397,9 @@ class _BenchmarkFacadeSchemaCreate(marshmallow.Schema):
         metadata={
             "description": conbench.util.dedent_rejoin(
                 """
-                Identifier for a Run (group of benchmarks. This can be the ID
-                of a known Run (as returned by /api/runs) or a new ID in which
-                case a new Run entity is created in the database.
+                Identifier for a Run. This can be the ID of a known Run (as
+                returned by /api/runs) or a new ID in which case a new Run
+                entity is created in the database.
                 """
             )
         },

--- a/conbench/entities/hardware.py
+++ b/conbench/entities/hardware.py
@@ -202,11 +202,14 @@ class ClusterCreate(marshmallow.Schema):
             "benchmark runs performed on different sets of hardware"
         },
     )
+    # Note(JP): `optional` in the name conflicts with `required=True`.
+    # This is confusing for API users.
     optional_info = marshmallow.fields.Dict(
         required=True,
         metadata={
             "description": "Additional optional information about the cluster, which is not likely to impact the "
-            "benchmark performance (e.g. region, settings like logging type, etc)."
+            "benchmark performance (e.g. region, settings like logging type, etc). "
+            "Despite the name, this field is required. An empty dictionary can be passed."
         },
     )
 

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -1007,15 +1007,15 @@
                         "type": "object",
                     },
                     "run_id": {
-                        "description": "Identifier for a Run. This can be the ID of a known Run (as returned by /api/runs) or a new ID in which case a new Run entity is created in the database.",
+                        "description": "Identifier for a Run (required). This can be the ID of a known Run (as returned by /api/runs) or a new ID in which case a new Run entity is created in the database.",
                         "type": "string",
                     },
                     "run_name": {
-                        "description": "Name for the run. When run in CI, this should be of the style '{run reason}: {commit sha}'. Ignored when run was previously created.",
+                        "description": "Name for the Run (optional, does not need to be unique). Can be useful for implementing a custom naming convention. For organizing your benchmarks, and for enhanced search & discoverability. Ignored when Run was previously created.",
                         "type": "string",
                     },
                     "run_reason": {
-                        "description": "Reason for run (commit, pull request, manual, etc). This should be low cardinality. 'commit' is a special run_reason for commits on the default branch which are used for history. Ignored when run was previously created.",
+                        "description": "Reason for the Run (optional, does not need to be unique). Ignored when Run was previously created.",
                         "type": "string",
                     },
                     "stats": {"$ref": "#/components/schemas/BenchmarkResultCreate"},
@@ -1350,7 +1350,7 @@
                 "tags": ["Benchmarks"],
             },
             "post": {
-                "description": "Submit a BenchmarkResult within a specific Run (as defined by its Run ID). If the Run is not known yet in the database it gets implicitly created, using details provided in this request. If the Run is already known then Run-specific info in this request is silently ignored.",
+                "description": "Submit a BenchmarkResult within a specific Run.\nIf the Run (as defined by its Run ID) is not known yet in the database it gets implicitly created, using details provided in this request. If the Run ID matches an existing run, then the rest of the fields describing the Run (such as name, hardware info, ...} are silently ignored.",
                 "requestBody": {
                     "content": {
                         "application/json": {

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -981,7 +981,10 @@
                         "description": 'Post-analysis annotations about this BenchmarkResult that\ngive details about whether it represents a change, outlier, etc. in the overall\ndistribution of BenchmarkResults.\n\nCurrently-recognized keys that change Conbench behavior:\n\n- `begins_distribution_change` (bool) - Is this result the first result of a sufficiently\n"different" distribution than the result on the previous commit (for the same\nhardware/case/context)? That is, when evaluating whether future results are regressions\nor improvements, should we treat data from before this result as incomparable?\n',
                         "type": "object",
                     },
-                    "cluster_info": {"$ref": "#/components/schemas/ClusterCreate"},
+                    "cluster_info": {
+                        "allOf": [{"$ref": "#/components/schemas/ClusterCreate"}],
+                        "description": "Precisely one of `machine_info` and `cluster_info` must be provided. The data is however ignored when the Run (referred to by `run_id`) was previously created.",
+                    },
                     "context": {
                         "description": "Information about the context the benchmark was run in (e.g. compiler flags, benchmark langauge) that are reasonably expected to have an impact on benchmark performance. This information is expected to be the same across a number of benchmarks. (free-form JSON)",
                         "type": "object",
@@ -995,21 +998,24 @@
                         "description": "Additional information about the context the benchmark was run in that is not expected to have an impact on benchmark performance (e.g. benchmark language version, compiler version). This information is expected to be the same across a number of benchmarks. (free-form JSON)",
                         "type": "object",
                     },
-                    "machine_info": {"$ref": "#/components/schemas/MachineCreate"},
+                    "machine_info": {
+                        "allOf": [{"$ref": "#/components/schemas/MachineCreate"}],
+                        "description": "Precisely one of `machine_info` and `cluster_info` must be provided. The data is however ignored when the Run (referred to by `run_id`) was previously created.",
+                    },
                     "optional_benchmark_info": {
                         "description": "Optional information about Benchmark results (e.g., telemetry links, logs links). These are unique to each benchmark that is run, but are information that aren't reasonably expected to impact benchmark performance. Helpful for adding debugging or additional links and context for a benchmark (free-form JSON)",
                         "type": "object",
                     },
                     "run_id": {
-                        "description": "Unique identifier for a run of benchmarks.",
+                        "description": "Identifier for a Run (group of benchmarks. This can be the ID of a known Run (as returned by /api/runs) or a new ID in which case a new Run entity is created in the database.",
                         "type": "string",
                     },
                     "run_name": {
-                        "description": "Name for the run. When run in CI, this should be of the style '{run reason}: {commit sha}'.",
+                        "description": "Name for the run. When run in CI, this should be of the style '{run reason}: {commit sha}'. Ignored when run was previously created.",
                         "type": "string",
                     },
                     "run_reason": {
-                        "description": "Reason for run (commit, pull request, manual, etc). This should be low cardinality. 'commit' is a special run_reason for commits on the default branch which are used for history",
+                        "description": "Reason for run (commit, pull request, manual, etc). This should be low cardinality. 'commit' is a special run_reason for commits on the default branch which are used for history. Ignored when run was previously created.",
                         "type": "string",
                     },
                     "stats": {"$ref": "#/components/schemas/BenchmarkResultCreate"},
@@ -1117,7 +1123,7 @@
                         "type": "string",
                     },
                     "optional_info": {
-                        "description": "Additional optional information about the cluster, which is not likely to impact the benchmark performance (e.g. region, settings like logging type, etc).",
+                        "description": "Additional optional information about the cluster, which is not likely to impact the benchmark performance (e.g. region, settings like logging type, etc). Despite the name, this field is required. An empty dictionary can be passed.",
                         "type": "object",
                     },
                 },
@@ -1344,7 +1350,7 @@
                 "tags": ["Benchmarks"],
             },
             "post": {
-                "description": "Create a benchmark.",
+                "description": "Submit a BenchmarkResult within a specific Run (as defined by its Run ID). If the Run is not known yet in the database it gets implicitly created, using details provided in this request. If the Run is already known then Run-specific info in this request is silently ignored.",
                 "requestBody": {
                     "content": {
                         "application/json": {

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -1007,7 +1007,7 @@
                         "type": "object",
                     },
                     "run_id": {
-                        "description": "Identifier for a Run (group of benchmarks. This can be the ID of a known Run (as returned by /api/runs) or a new ID in which case a new Run entity is created in the database.",
+                        "description": "Identifier for a Run. This can be the ID of a known Run (as returned by /api/runs) or a new ID in which case a new Run entity is created in the database.",
                         "type": "string",
                     },
                     "run_name": {

--- a/conbench/tests/api/test_benchmarks.py
+++ b/conbench/tests/api/test_benchmarks.py
@@ -462,15 +462,6 @@ class TestBenchmarkPost(_asserts.PostEnforcer):
         self.authenticate(client)
 
         machine_info_A = _fixtures.MACHINE_INFO.copy()
-
-        # Create a copy of the above's machine_info example object with a
-        # different CPU model name. This is set in
-        # BenchmarkResultCreate.machine_info.cpu_model_name and will be
-        # silently dropped
-        lost_cpu_model_name = "qubit1337"
-        machine_info_B = _fixtures.MACHINE_INFO.copy()
-        machine_info_B["cpu_model_name"] = lost_cpu_model_name
-
         run_payload = _fixtures.VALID_RUN_PAYLOAD.copy()
         run_payload["machine_info"] = machine_info_A
         resp = client.post("/api/runs/", json=run_payload)
@@ -484,6 +475,14 @@ class TestBenchmarkPost(_asserts.PostEnforcer):
         # Confirm that the above's Run submission created a Hardware entity
         # representing the details in `machine_info_A`.
         assert_machine_info_equals_hardware(run_asindb["hardware"], machine_info_A)
+
+        # Create a copy of the above's machine_info example object with a
+        # different CPU model name. This is set in
+        # BenchmarkResultCreate.machine_info.cpu_model_name and will be
+        # silently dropped
+        lost_cpu_model_name = "qubit1337"
+        machine_info_B = _fixtures.MACHINE_INFO.copy()
+        machine_info_B["cpu_model_name"] = lost_cpu_model_name
 
         # Submit BenchmarkResultCreate structure, refer to the previously
         # submitted Run entity (via ID), but provide _different_ machine_info.
@@ -508,8 +507,6 @@ class TestBenchmarkPost(_asserts.PostEnforcer):
         run_asindb2 = resp.json
         # Confirm that machine_info_A took precedence.
         assert_machine_info_equals_hardware(run_asindb2["hardware"], machine_info_A)
-
-        # print("run as in db 2", json.dumps(run_asindb, indent=2))
 
     def test_create_benchmark_with_error(self, client):
         self.authenticate(client)

--- a/conbench/tests/api/test_benchmarks.py
+++ b/conbench/tests/api/test_benchmarks.py
@@ -423,14 +423,23 @@ class TestBenchmarkPost(_asserts.PostEnforcer):
                 ) == int(value)
 
     def test_create_benchmark_after_run_different_machine_info(self, client):
-        """This test confirms behavior that I was initially only suspecting
-        and then wanted to confirm with code.
+        """
+        This test documents current behavior that I was initially only
+        suspecting and then wanted to confirm with code.
 
-        I am not sure that the below is desired behavior.
+        We can of course re-think the specification (expected behavior).
 
         This is a special case in the API surface, but because it's API
         behavior it's important that we think about specification first
         (desired behavior), and then judge about the implementation.
+
+        I think this is an artifact of us allowing for potentially many
+        concurrent executors to submit results within a specific run without
+        requiring special coordination between those executors. That is, it is
+        expected that the submitted run metadata (like name and machine info)
+        are equivalent across all BenchmarkResult entities, and the fastest
+        submitter wins the price of DB insertion, while the other racers get
+        their info silently dropped.
         """
 
         def assert_machine_info_equals_hardware(hwdict, midict):


### PR DESCRIPTION
'Implicit run creation' was a bit of a mystery to me so far, and today's side quest was to understand what's actually happening (because current API documentation didn't really provide answers). While exploring the current behavior I documented findings on-the-fly in code and API docs, that's how this patch came to be.