### PR TITLE
commit.py: shortcut only for apache/arrow

### DIFF
--- a/conbench/entities/commit.py
+++ b/conbench/entities/commit.py
@@ -316,8 +316,10 @@ def backfill_default_branch_commits(repourl: str, new_commit: Commit) -> None:
 
     github = GitHub()
 
-    # `repo_spec` is expected to be a string specifying a GitHub repository
-    # using the canonical org/repo notation.
+    # `repourl` is expected to be a URL pointing to a GitHub repositopry. It
+    # must be of the shape "https://github.com/org/repo". `repospec` then is
+    # unambiguously specifying the same GitHub repository using the canonical
+    # "org/repo" notation.
     repospec = repository_to_name(repourl)
 
     # This triggers one HTTP request.


### PR DESCRIPTION
This addresses issue #637.

Quick description of the problem:

**Before #592:**
test_backfill_default_branch_commits triggered backfill_default_branch_commits()  to fetch conbench/conbench commits since 1970.

**After #592:**
test_backfill_default_branch_commits triggered backfill_default_branch_commits()  to fetch conbench/conbench commits for the last 60 days since "today".

That is how `test_backfill_default_branch_commits` started to fail. I am addressing this here by making the shortcut criterion more specific. It's aimed at the apache/arrow repo and was meant to help with populate_local_conbench.py. It was never meant to modify behavior of commit.py when executed in the context of the test suite.

When working in this function I wasn't quite sure what the variable `repository` was expected to contain, especially vs `name`. Introduced repospec vs repourl, as hopefully more well-defined terms.  