### PR TITLE
Run.timestamp: identify and document current behavior with comments and tests

### DIFF
--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -220,8 +220,9 @@ class _Serializer(EntitySerializer):
             "id": run.id,
             "name": run.name,
             "reason": run.reason,
-            # TODO: also use tznaive_dt_to_aware_iso8601_for_api
-            "timestamp": run.timestamp.isoformat(),
+            "timestamp": conbench.util.tznaive_dt_to_aware_iso8601_for_api(
+                run.timestamp
+            ),
             "finished_timestamp": conbench.util.tznaive_dt_to_aware_iso8601_for_api(
                 run.finished_timestamp
             )

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -37,7 +37,16 @@ class Run(Base, EntityMixin):
     id = NotNull(s.String(50), primary_key=True)
     name = Nullable(s.String(250))
     reason = Nullable(s.String(250))
-    # tz-naive timestamp expected to refer to UTC time.
+    # `timestamp`  is never set by API clients, i.e. the
+    # `server_default=s.sql.func.now()` is always taking effect. That also
+    # means that this property reflects the point in time of DB insertion (that
+    # should be documented in the API schema for Run objects). A more explicit
+    # way to code that would be in the create() method. The point in time by
+    # convention is stored in UTC _without_ timezone information. Is a wrong
+    # point in time stored when `s.sql.func.now()` returns a non-UTC tz-aware
+    # timestamp on a DB server that does not have its system time in UTC? That
+    # should not happen, as is hopefully confirmed by the test
+    # `test_auto_generated_run_timestamp_value()`.
     timestamp = NotNull(s.DateTime(timezone=False), server_default=s.sql.func.now())
     # tz-naive timestamp expected to refer to UTC time.
     finished_timestamp = Nullable(s.DateTime(timezone=False))

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -1,6 +1,6 @@
-import pytest
-
 from datetime import datetime, timedelta, timezone
+
+import pytest
 
 from conbench.util import tznaive_dt_to_aware_iso8601_for_api
 

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -1,5 +1,7 @@
 import pytest
 
+from datetime import datetime, timedelta, timezone
+
 from conbench.util import tznaive_dt_to_aware_iso8601_for_api
 
 from ...api._examples import _api_run_entity
@@ -425,3 +427,45 @@ class TestRunPost(_asserts.PostEnforcer):
         run = Run.one(id=run_id)
         location = f"http://localhost/api/runs/{run_id}/"
         self.assert_201_created(response, _expected_entity(run), location)
+
+    def test_create_run_timestamp_not_allowed(self, client):
+        self.authenticate(client)
+        payload = self.valid_payload.copy()
+
+        # Confirm that setting the timestamp is not possible as an API client,
+        # i.e. that the resulting `timestamp` property when fetching the run
+        # details via API later on reflects the point in time of inserting this
+        # run into the DB.
+        payload["timestamp"] = "2022-12-13T13:37:00Z"
+        resp = client.post(self.url, json=payload)
+        assert resp.status_code == 400, resp.text
+        assert '{"timestamp": ["Unknown field."]}' in resp.text
+
+    def test_auto_generated_run_timestamp_value(self, client):
+        self.authenticate(client)
+        payload = self.valid_payload.copy()
+        resp = client.post(self.url, json=payload)
+        assert resp.status_code == 201, resp.text
+        run_id = payload["id"]
+
+        resp = client.get(f"http://localhost/api/runs/{run_id}/")
+        assert resp.status_code == 200, resp.text
+        assert "timestamp" in resp.json
+
+        # Get current point in time from test runner's perspective (tz-aware
+        # datetime object).
+        now_testrunner = datetime.now(timezone.utc)
+
+        # Get Run entity DB insertion time (set by the DB). This is also a
+        # tz-aware object because `resp.json["timestamp"]` is expected to be an
+        # ISO 8601 timestring _with_ timezone information.
+        run_time_created_in_db = datetime.fromisoformat(resp.json["timestamp"])
+
+        # Build timedelta between those two tz-aware datetime objects (that are
+        # not necessarily in the same timezone).
+        delta: timedelta = run_time_created_in_db - now_testrunner
+
+        # Convert the timedelta object to a float (number of seconds). Check
+        # for tolerance interval but use abs(), i.e. don't expect a certain
+        # order between test runner clock and db clock.
+        assert abs(delta.total_seconds()) < 5.0

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -21,7 +21,7 @@ def _expected_entity(run, baseline_id=None, include_baseline=True):
         run.hardware_id,
         run.hardware.name,
         run.hardware.type,
-        run.timestamp.isoformat(),
+        tznaive_dt_to_aware_iso8601_for_api(run.timestamp),
         baseline_id,
         include_baseline,
         has_errors,


### PR DESCRIPTION
This patch is for https://github.com/conbench/conbench/issues/609, analogue to https://github.com/conbench/conbench/pull/620 and https://github.com/conbench/conbench/pull/623.

What was not clear to me, but is now:

- `Run.timestamp` is set upon DB insertion
- Cannot be set/defined by API clients.

Added a corresponding test to lock this in.

TODO: we should document the Run objects returned by the API (as part of API spec) and then document `timestamp` to correspond to the Run DB insertion/creation time.

This PR makes it so that the API emits `Run.timestamp` now via a tz-aware ISO 8601 string, indicating UTC timezone (before, it was ambiguous). This is achieved by using the new `conbench.util.tznaive_dt_to_aware_iso8601_for_api()` instead of just `naivedatetimeobject.isoformat()`.

This is magic, and brittle:
```python
s.DateTime(timezone=False), server_default=s.sql.func.now()
```

What really happens when `s.sql.func.now()` has the notion of a non-UTC timezone and the result is then stored in a Column defined by `DateTime(timezone=False)`? Is the timezone information brutally discarded, or properly used in a timezone transformation calculation? I have added a test that I think confirms that the conversion is done properly.


