### PR TITLE
UI: clarify Run creation time(zone), and Benchmark (start) time(zone)

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -99,12 +99,6 @@ jobs:
                 python screenshot.py "${CONBENCH_BASE_URL}/benchmarks/${SOME_BENCHMARK_ID}/" \
                   /artifacts benchmark-result-view --wait-for-canvas
             /bin/ls -ahltr ci-artifacts/
-            # If the browser-initiated GET requests led to e.g an Internal Server Error
-            # then we see that in the screenshot(s). For debugging that, however,
-            # it's crucial to get web application logs. Note that this shows
-            # container logs interleaved, but prefixed so that it's after all
-            # unambiguous which line came from which container.
-            docker compose logs --since 30m
       - name: upload-artifacts
         uses: actions/upload-artifact@v3
         # Upload screenshots _especially_ when result was unexpected.
@@ -112,6 +106,14 @@ jobs:
         with:
           name: screenshots
           path: ci/ci-artifacts/
+      - name: get container logs
+        if: always()
+        # If the browser-initiated GET requests led to e.g an Internal Server Error
+        # then we see that in the screenshot(s). For debugging that, however,
+        # it's crucial to get web application logs. Note that this shows
+        # container logs interleaved, but prefixed so that it's after all
+        # unambiguous which line came from which container.
+        run: docker compose logs --since 30m
       - name: test `make teardown-app`
         # Run teardown especially when previous step(s) failed, because here
         # we get some good log output for debuggability.

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -107,10 +107,15 @@ jobs:
             docker compose logs --since 30m
       - name: upload-artifacts
         uses: actions/upload-artifact@v3
+        # Upload screenshots _especially_ when result was unexpected.
+        if: always()
         with:
           name: screenshots
           path: ci/ci-artifacts/
       - name: test `make teardown-app`
+        # Run teardown especially when previous step(s) failed, because here
+        # we get some good log output for debuggability.
+        if: always()
         run: make teardown-app
 
   db-migrations:

--- a/ci/screenshot.py
+++ b/ci/screenshot.py
@@ -54,6 +54,8 @@ SLEEP_BEFORE_SCREENSHOT_SECONDS = 10.0
 
 CLI_ARGS = None
 
+EXIT_CODE = 0
+
 
 def main():
     global CLI_ARGS
@@ -98,7 +100,8 @@ def main():
     with open(pdf_path, "wb") as f:
         f.write(pdf_bytes)
 
-    log.info("done")
+    log.info("done, exit with code %s", EXIT_CODE)
+    sys.exit(EXIT_CODE)
 
 
 def screenshot(url, pngpath):
@@ -174,8 +177,10 @@ def _wait(driver):
     try:
         _wait_for_bokeh_canvas(driver)
     except selenium.common.exceptions.NoSuchElementException as exc:
+        # log error and store non-zero exit code, but continue so that
+        # we actually take the screenshot of the bad state.
         log.error("NoSuchElementException during _wait(): %s", exc)
-        sys.exit(1)
+        _set_exit_code(1)
 
 
 def _wait_for_bokeh_canvas(driver):
@@ -247,6 +252,11 @@ def _get_driver():
 
     log.info("webdriver is set up")
     return driver
+
+
+def _set_exit_code(code: int):
+    global EXIT_CODE
+    EXIT_CODE = code
 
 
 if __name__ == "__main__":

--- a/conbench/app/_util.py
+++ b/conbench/app/_util.py
@@ -20,8 +20,16 @@ def dataset_name(name):
     return name.replace("_", " ")
 
 
-def display_time(t):
-    return t.split(".")[0].replace("T", "  ").rsplit(":", 1)[0] if t else ""
+def display_time(t: str):
+    """
+    Expect `t` to be an ISO 8601 compliant string
+    - that encodes the UTC timezone with a Z suffix
+    - that does not contain fractions of seconds
+
+    Input example:  "2023-01-31Z05:36:45Z"
+    Output example: "2023-01-31 05:36:45 UTC"
+    """
+    return t.replace("T", " ").replace("Z", " UTC")
 
 
 def set_display_language(benchmark, contexts):

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -236,6 +236,9 @@ class Benchmark(AppEndpoint, BenchmarkMixin, RunMixin, TimeSeriesPlotMixin):
 
 class BenchmarkList(AppEndpoint, ContextMixin):
     def page(self, benchmarks):
+        # Note(JP): What type is benchmarks? As of `response =
+        # self.api_get("api.benchmarks")` down below it's seemingly the result
+        # of JSON-decoding, i.e. not the DB model type.
         contexts = self.get_contexts(benchmarks)
         for benchmark in benchmarks:
             augment(benchmark, contexts)

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -109,6 +109,9 @@ class RunMixin:
 
     def _augment(self, run):
         self._display_time(run, "timestamp")
+
+        # Note(JP): `run["commit"]["timestamp"]` can be `None`, see
+        # https://github.com/conbench/conbench/pull/651
         self._display_time(run["commit"], "timestamp")
         repository = run["commit"]["repository"]
         repository_name = repository
@@ -122,7 +125,14 @@ class RunMixin:
         run["commit"]["display_message"] = commit_message
 
     def _display_time(self, obj, field):
-        obj[f"display_{field}"] = display_time(obj[field])
+        timestring = obj[field]
+
+        # Seemingly this can be `None`.
+        if isinstance(timestring, str):
+            obj[f"display_{field}"] = display_time(timestring)
+
+        else:
+            obj[f"display_{field}"] = ""
 
     def _get_run(self, run_id):
         response = self.api_get("api.run", run_id=run_id)

--- a/conbench/templates/benchmark-entity.html
+++ b/conbench/templates/benchmark-entity.html
@@ -104,7 +104,7 @@
       {% if benchmark.stats %}
       <li class="list-group-item active">Result</li>
       <li class="list-group-item" style="overflow-y: auto;">
-        <b>timestamp</b>
+        <b>timestamp (start time)</b>
         <div align="right" style="display:inline-block; float: right;">
           {{ benchmark.display_timestamp }}
         </div>

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -29,7 +29,7 @@
           </caption>
             <thead>
                 <tr>
-                    <th scope="col">Run</th>
+                    <th scope="col">Run creation time</th>
                     <th scope="col">Author</th>
                     <th scope="col">Repository</th>
                     <th scope="col">Hardware</th>


### PR DESCRIPTION
This is for https://github.com/conbench/conbench/issues/534 and https://github.com/conbench/conbench/issues/609.

Landing page: this changes the column header from "Run" to "Run creation time", and starts showing the timezone in the individual table rows.

Benchmark result view: this now shows the Benchmark (start) time timezone.

Will add screenshots once they have been created by CI.

