### PR TITLE
lint: black formatting after 23.1.0 release

### DIFF
--- a/benchrun/python/tests/test_benchmark_list.py
+++ b/benchrun/python/tests/test_benchmark_list.py
@@ -28,7 +28,6 @@ class TestBenchmarkList:
         monkeypatch.setenv("CONBENCH_PROJECT_COMMIT", self.github["commit"])
 
     def test_init(self) -> None:
-
         assert len(self.benchmark_list.benchmarks) == 2
         assert self.benchmark_list.benchmarks[0] == self.benchmark
 

--- a/ci/screenshot.py
+++ b/ci/screenshot.py
@@ -105,9 +105,7 @@ def main():
 
 
 def screenshot(url, pngpath):
-
     with _get_driver() as driver:
-
         driver.set_window_size(1700, 1900)
         log.info("driver.get(): %s", url)
         driver.get(url)
@@ -118,9 +116,7 @@ def screenshot(url, pngpath):
 
 
 def print_to_pdf(url):
-
     with _get_driver() as driver:
-
         driver.set_window_size(1700, 1900)
         log.info("driver.get(): %s", url)
         driver.get(url)

--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -161,7 +161,6 @@ def dict_or_objattrs_to_nonsensitive_string(obj):
 
     # Iterate over all object and class attributes,
     for k, v in zip(keys, values):
-
         if not isinstance(k, str):
             # We may get here when `obj` is a dictionary with non-string keys.
             # Ignore those keys in textual output.

--- a/conbench/api/_google.py
+++ b/conbench/api/_google.py
@@ -23,7 +23,6 @@ def get_oidc_config():
 
 
 def get_oidc_client():
-
     discovery_url, client_id, _ = get_oidc_config()
 
     # Pragmatic healing for transient errors. Better: cache OP config across

--- a/conbench/api/index.py
+++ b/conbench/api/index.py
@@ -89,7 +89,6 @@ class PingAPI(ApiEndpoint):
         if Config.TESTING:
             alembic_version = "not-set-in-testing"
         else:
-
             query = text("SELECT version_num FROM alembic_version")
             try:
                 # In local deployment the PostgreSQL server logs: `ERROR:  relation

--- a/conbench/app/auth.py
+++ b/conbench/app/auth.py
@@ -71,7 +71,6 @@ class Login(AppEndpoint):
         }
 
     def get(self):
-
         # Read query parameter `target`. Assume that the value is the URL that
         # the user actually wanted to visit before they were redirected to the
         # login page. `f.request.args` holds parsed (i.e. URL-decoded) URL

--- a/conbench/app/batches.py
+++ b/conbench/app/batches.py
@@ -35,7 +35,6 @@ class BatchPlot(AppEndpoint, ContextMixin):
 
     @authorize_or_terminate
     def get(self, batch_id):
-
         benchmarks, response = self._get_benchmarks(batch_id)
         if response.status_code != 200:
             self.flash("Error getting benchmarks.")

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -264,7 +264,6 @@ class BenchmarkList(AppEndpoint, ContextMixin):
 
     @authorize_or_terminate
     def get(self):
-
         benchmarks, response = self._get_benchmarks()
         if response.status_code != 200:
             self.flash("Error getting benchmarks.")

--- a/conbench/app/compare.py
+++ b/conbench/app/compare.py
@@ -25,7 +25,6 @@ def all_keys(dict1, dict2, attr):
 
 class Compare(AppEndpoint, BenchmarkMixin, RunMixin, TimeSeriesPlotMixin):
     def page(self, comparisons, regressions, improvements, baseline_id, contender_id):
-
         unknown = "unknown...unknown"
         compare_runs_url = f.url_for("app.compare-runs", compare_ids=unknown)
         compare_batches_url = f.url_for("app.compare-batches", compare_ids=unknown)
@@ -139,7 +138,6 @@ class Compare(AppEndpoint, BenchmarkMixin, RunMixin, TimeSeriesPlotMixin):
 
     @authorize_or_terminate
     def get(self, compare_ids):
-
         threshold = f.request.args.get("threshold")
         threshold_z = f.request.args.get("threshold_z")
         params = {"compare_ids": compare_ids}

--- a/conbench/app/index.py
+++ b/conbench/app/index.py
@@ -20,7 +20,6 @@ class Index(AppEndpoint, RunMixin):
 
     @authorize_or_terminate
     def get(self):
-
         runs = self.get_display_runs()
         return self.page(runs)
 

--- a/conbench/app/runs.py
+++ b/conbench/app/runs.py
@@ -44,7 +44,6 @@ class Run(AppEndpoint, ContextMixin, RunMixin, TimeSeriesPlotMixin):
 
     @authorize_or_terminate
     def get(self, run_id):
-
         contender_run, baseline_run = self.get_display_run(run_id), None
         if contender_run:
             baseline_url = contender_run["links"].get("baseline")

--- a/conbench/config.py
+++ b/conbench/config.py
@@ -5,7 +5,6 @@ from typing import Optional
 
 
 class ConfigClass:
-
     APPLICATION_NAME = os.environ.get("APPLICATION_NAME", "Conbench")
     DB_HOST = os.environ.get("DB_HOST", "localhost")
     DB_NAME = os.environ.get("DB_NAME", f"{APPLICATION_NAME.lower()}_prod")

--- a/conbench/entities/commit.py
+++ b/conbench/entities/commit.py
@@ -560,7 +560,6 @@ class GitHub:
 
     @staticmethod
     def _parse_commit(commit):
-
         author = commit.get("author")
         commit_author = commit["commit"]["author"]
 

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -81,7 +81,6 @@ class Run(Base, EntityMixin):
         commit = Commit.first(sha=sha, repository=repository)
 
         if not commit:
-
             # Try to fetch data via GitHub HTTP API
             gh_commit_dict = None
             try:

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -135,7 +135,11 @@ class TestRunGet(_asserts.GetEnforcer):
         )
 
     def test_get_run_without_baseline_run_with_matching_benchmarks(self, client):
-        language_1, language_2, name, = (
+        (
+            language_1,
+            language_2,
+            name,
+        ) = (
             _uuid(),
             _uuid(),
             _uuid(),

--- a/conbench/tests/populate_local_conbench.py
+++ b/conbench/tests/populate_local_conbench.py
@@ -207,7 +207,6 @@ def generate_benchmarks_data_with_iteration_missing(
 
 
 def register():
-
     url = f"{base_url}/register/"
     log.info("register via: %s", url)
 
@@ -423,7 +422,6 @@ def create_benchmarks_data_with_history():
 
 
 def generate_synthetic_benchmark_history():
-
     commits = [
         c.strip()
         for c in reversed(ARROW_COMMIT_HASH_LINES_50.splitlines())
@@ -451,7 +449,6 @@ def generate_synthetic_benchmark_history():
         return s + slowdown_offset + slowdown_lin * random.random()
 
     for idx, commit_hash in enumerate(commits, 1):
-
         # Get current time as tzaware datetime object in UTC timezone, and
         # then subtract
         run_start = datetime.datetime.utcnow().replace(

--- a/conbench/util.py
+++ b/conbench/util.py
@@ -96,7 +96,6 @@ def tznaive_iso8601_to_tzaware_dt(input):
     """
 
     def _convert(s: str):
-
         dt = datetime.fromisoformat(s)
 
         if dt.tzinfo == timezone.utc:


### PR DESCRIPTION
This fixes https://github.com/conbench/conbench/issues/652.

Not quite sure if I like the removal of these empty lines, but `black` is here for precisely shortcutting these discussions and removing visual craft from programming :man_shrugging:  :)