### PR TITLE
history plot: rework plot tools (add wheel zoom and box zoom, and more)

### DIFF
--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -513,7 +513,29 @@ def time_series_plot(history, benchmark, run, height=380, width=1100):
         x_axis_type="datetime",
         height=height,
         width=width,
-        tools=["pan", "zoom_in", "zoom_out", "reset", "tap"],
+        tools=[
+            # Allows for dragging the field of view, default drag action.
+            "pan",
+            # Allow for resetting the plot to original view.
+            "reset",
+            # This allows for benchmark-details-on-datapoint-click
+            "tap",
+            # Zoom in and out with mouse wheel, default wheel action
+            "wheel_zoom",
+            # Allow for drawing a box for zooming, not enabled by default,
+            # because the "pan" tool is enabled by default. Can be activated by
+            # clicking the icon on the toolbar (one can toggle manually between
+            # pan and box-zoom).
+            "box_zoom",
+        ],
+        # Bokeh toolbars can have at most one active tool from each kind of
+        # gesture (drag, scroll, tap).
+        # https://docs.bokeh.org/en/2.4.0/docs/user_guide/tools.html#setting-the-active-tools
+        active_drag="pan",
+        active_scroll="wheel_zoom",
+        active_tap="tap",
+        active_inspect=None,
+        toolbar_location="right",
         x_range=(t_start, t_end),
     )
     p.toolbar.logo = None

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -534,7 +534,7 @@ def time_series_plot(history, benchmark, run, height=380, width=1100):
         active_drag="pan",
         active_scroll="wheel_zoom",
         active_tap="tap",
-        active_inspect=None,
+        active_inspect="auto",  # this enables hover by default (tool added below)
         toolbar_location="right",
         x_range=(t_start, t_end),
     )

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -522,16 +522,17 @@ def time_series_plot(history, benchmark, run, height=380, width=1100):
             "tap",
             # Zoom in and out with mouse wheel, default wheel action
             "wheel_zoom",
-            # Allow for drawing a box for zooming, not enabled by default,
-            # because the "pan" tool is enabled by default. Can be activated by
-            # clicking the icon on the toolbar (one can toggle manually between
-            # pan and box-zoom).
+            # Allow for drawing a box for zooming.
             "box_zoom",
         ],
         # Bokeh toolbars can have at most one active tool from each kind of
         # gesture (drag, scroll, tap).
         # https://docs.bokeh.org/en/2.4.0/docs/user_guide/tools.html#setting-the-active-tools
-        active_drag="pan",
+        # Enable box zoom by default, disable the "pan" tool by default. Via
+        # clicking icons on the toolbar one can toggle manually between pan and
+        # box-zoom. As of today we believe that box_zoom&wheel_zoom is a good
+        # default combo to have.
+        active_drag="box_zoom",
         active_scroll="wheel_zoom",
         active_tap="tap",
         active_inspect="auto",  # this enables hover by default (tool added below)

--- a/conbench/tests/populate_local_conbench.py
+++ b/conbench/tests/populate_local_conbench.py
@@ -27,12 +27,12 @@ session = requests.Session()
 def main():
     register()
     login()
-    log.info("start generate_synthetic_benchmark_history()")
-    generate_synthetic_benchmark_history()
     log.info("start create_benchmarks_data()")
     create_benchmarks_data()
     log.info("start create_benchmarks_data()")
     create_benchmarks_data_with_history()
+    log.info("start generate_synthetic_benchmark_history()")
+    generate_synthetic_benchmark_history()
 
 
 def generate_benchmarks_data(


### PR DESCRIPTION
Motivated by https://github.com/conbench/conbench/issues/645

- Add `wheel_zoom` and remove `zoom_in` and `zoom_out`. I think all users can do `wheel_zoom`, including those that use a touch pad. The current wheel_zoom configuration affects x and y axis at the same time.
- Add `box_zoom` (I agree with @jorisvandenbossche and @austin3dickey that this is a useful tool).
- Explicitly define the active tool for each type of user input.
  - Enable `wheel_zoom` by default (upon scroll).
  - Keep `pan` enabled by default upon drag, require active user choice (button click) before `box_zoom` is enabled.


A quick video showing the current state:

https://user-images.githubusercontent.com/265630/216070836-ec06179c-9f52-46a0-92d7-3257ab761219.mov




