### PR TITLE
Conbench on minikube with kube-prometheus (milestones 1, 2, 3)

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,19 +20,9 @@ jobs:
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@latest
-      - name: kubectl
-        run: kubectl get pods -A
-      - name: postgres-operator
-        run: |
-          git clone https://github.com/zalando/postgres-operator
-          cd postgres-operator
-          # 1.9.0 release from 2023-01-30
-          git checkout 30b612489a2a20d968262791857d1db1a85e0b36
-          # This should tear down the current minikube, and re-spawn another
-          # one, bootstrapping the postgres operator using
-          # https://github.com/zalando/postgres-operator/blob/v1.9.0/manifests/minimal-postgres-manifest.yaml
-          bash ./run_operator_locally.sh
-          kubectl get pods -A
+      - name: set up postgres-operator
+        run: bash ci/minikube/test-conbench-on-mk.sh
+
 
   # lint:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -184,5 +184,4 @@ jobs:
           cpus: max
           memory: max
       - name: ci/minikube/test-conbench-on-mk.sh
-        run: export CONBENCH_REPO_ROOT_DIR=$(pwd) && \
-          bash ci/minikube/test-conbench-on-mk.sh
+        run: export CONBENCH_REPO_ROOT_DIR=$(pwd) && bash ci/minikube/test-conbench-on-mk.sh

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -24,10 +24,7 @@ jobs:
         uses: medyagh/setup-minikube@latest
         with:
           # from https://github.com/prometheus-operator/kube-prometheus#minikube
-          extra-config: kubelet.authentication-token-webhook=true
-          extra-config: kubelet.authorization-mode=Webhook
-          extra-config: scheduler.bind-address=0.0.0.0
-          extra-config: controller-manager.bind-address=0.0.0.0
+          extra-config: kubelet.authentication-token-webhook=true,kubelet.authorization-mode=Webhook,scheduler.bind-address=0.0.0.0,controller-manager.bind-address=0.0.0.0
       - name: ci/minikube/test-conbench-on-mk.sh
         run: bash ci/minikube/test-conbench-on-mk.sh
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,6 +14,162 @@ env:
   GITHUB_API_TOKEN: ${{ secrets.PERSONAL_GITHUB_API_TOKEN }}
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install linting dependencies
+        run: pip install -r requirements-dev.txt
+      - name: lint
+        run: make lint-ci
+
+  testsuite:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: Run tests, generate coverage data
+        # This is expected to create /etc/conbench-coverage-dir/.coverage
+        # in the `app` service container.
+        run: make tests
+      - name: Convert coverage data to LCOV
+        run: |
+          docker compose run -e COVERAGE_FILE=/etc/conbench-coverage-dir/.coverage app \
+            coverage lcov -o /etc/conbench-coverage-dir/coverage.lcov
+      - name: Publish coverage
+        uses: coverallsapp/github-action@master
+        # sometimes the coveralls API fails transiently, and we don't want that to affect this build
+        continue-on-error: true
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: _conbench-coverage-dir/coverage.lcov
+
+  # This is to confirm that commonly used developer commands still work.
+  dev-cmds:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: rebuild-expected-api-docs
+        run: |
+          pip install black
+          make rebuild-expected-api-docs
+      # Launch application as containerized stack. This terminates after
+      # health checks confirm that stack is running.
+      - name: run-app-bg
+        run: make run-app-bg
+      # Run `db-populate` twice to see that this can be repeated w/o failing.
+      - name: test `make db-populate`, twice
+        run: |
+            pip install requests # the nonly non-stdlib dependency as of now
+            export CONBENCH_BASE_URL=http://$(docker compose port app 5000) && \
+            make db-populate && make db-populate
+            docker-compose logs # view logs to see why transient errs happen
+      - name: test `make teardown-app`
+        run: make teardown-app
+      # The goal of this is to largely test `make run-app-dev`.
+      - name: test-run-app-dev
+        run: make test-run-app-dev
+
+  ui-screenshots:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: run-app-bg
+        run: make run-app-bg
+      - name: populate DB & take screenshots
+        run: |
+            pip install requests # the nonly non-stdlib dependency as of now
+            export CONBENCH_BASE_URL=http://$(docker compose port app 5000)
+            export SOME_BENCHMARK_ID="$(make -s db-populate)"
+            echo "conbench base URL: $CONBENCH_BASE_URL"
+            echo "a valid benchmark ID: $SOME_BENCHMARK_ID"
+            cd ci
+            docker build . -t conbench-screenshot -f screenshot.Dockerfile
+            mkdir ci-artifacts
+            docker run --net=host -v $(pwd)/ci-artifacts:/artifacts conbench-screenshot \
+                python screenshot.py ${CONBENCH_BASE_URL} /artifacts frontpage
+            docker run --net=host -v $(pwd)/ci-artifacts:/artifacts conbench-screenshot \
+                python screenshot.py "${CONBENCH_BASE_URL}/benchmarks/${SOME_BENCHMARK_ID}/" \
+                  /artifacts benchmark-result-view --wait-for-canvas
+            /bin/ls -ahltr ci-artifacts/
+      - name: upload-artifacts
+        uses: actions/upload-artifact@v3
+        # Upload screenshots _especially_ when result was unexpected.
+        if: always()
+        with:
+          name: screenshots
+          path: ci/ci-artifacts/
+      - name: get container logs
+        if: always()
+        # If the browser-initiated GET requests led to e.g an Internal Server Error
+        # then we see that in the screenshot(s). For debugging that, however,
+        # it's crucial to get web application logs. Note that this shows
+        # container logs interleaved, but prefixed so that it's after all
+        # unambiguous which line came from which container.
+        run: docker compose logs --since 30m
+      - name: test `make teardown-app`
+        # Run teardown especially when previous step(s) failed, because here
+        # we get some good log output for debuggability.
+        if: always()
+        run: make teardown-app
+
+  db-migrations:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: Start PostgreSQL DB
+        run: docker compose run --detach db
+      # Run `alembic upgrade head` via docker compose so that it is within
+      # the network that the DB is also in, reachable via DNS name `db`
+      - name: Test database migrations
+        run: docker compose run -e CREATE_ALL_TABLES app alembic upgrade head
+        env:
+          CREATE_ALL_TABLES: false
+
+  clis:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          pip install --no-deps \
+            -e benchadapt/python \
+            -e benchrun/python \
+            -e benchconnect && \
+          pip install \
+            -U --upgrade-strategy eager \
+            -e .[dev] \
+            -e benchclients/python
+      - name: Test benchclients
+        run: |
+          pytest -vv benchclients/python/tests
+      - name: Test benchadapt
+        run: |
+          pytest -vv benchadapt/python/tests
+      - name: Test benchrun
+        run: |
+          pytest -vv benchrun/python/tests
+      - name: Test benchconnect
+        run: |
+          pytest -vv benchconnect
+
   cb-on-minikube:
     runs-on: ubuntu-latest
     steps:
@@ -29,160 +185,3 @@ jobs:
           memory: max
       - name: ci/minikube/test-conbench-on-mk.sh
         run: export CONBENCH_REPO_ROOT_DIR=$(pwd) && bash ci/minikube/test-conbench-on-mk.sh
-
-
-  # lint:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: checkout
-  #       uses: actions/checkout@v3
-  #     - name: Set up Python
-  #       uses: actions/setup-python@v4
-  #       with:
-  #         python-version: "3.11"
-  #     - name: Install linting dependencies
-  #       run: pip install -r requirements-dev.txt
-  #     - name: lint
-  #       run: make lint-ci
-
-  # testsuite:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: checkout
-  #       uses: actions/checkout@v3
-  #     - name: Run tests, generate coverage data
-  #       # This is expected to create /etc/conbench-coverage-dir/.coverage
-  #       # in the `app` service container.
-  #       run: make tests
-  #     - name: Convert coverage data to LCOV
-  #       run: |
-  #         docker compose run -e COVERAGE_FILE=/etc/conbench-coverage-dir/.coverage app \
-  #           coverage lcov -o /etc/conbench-coverage-dir/coverage.lcov
-  #     - name: Publish coverage
-  #       uses: coverallsapp/github-action@master
-  #       # sometimes the coveralls API fails transiently, and we don't want that to affect this build
-  #       continue-on-error: true
-  #       with:
-  #         github-token: ${{ secrets.GITHUB_TOKEN }}
-  #         path-to-lcov: _conbench-coverage-dir/coverage.lcov
-
-  # # This is to confirm that commonly used developer commands still work.
-  # dev-cmds:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: checkout
-  #       uses: actions/checkout@v3
-  #     - name: Set up Python
-  #       uses: actions/setup-python@v4
-  #       with:
-  #         python-version: "3.10"
-  #     - name: rebuild-expected-api-docs
-  #       run: |
-  #         pip install black
-  #         make rebuild-expected-api-docs
-  #     # Launch application as containerized stack. This terminates after
-  #     # health checks confirm that stack is running.
-  #     - name: run-app-bg
-  #       run: make run-app-bg
-  #     # Run `db-populate` twice to see that this can be repeated w/o failing.
-  #     - name: test `make db-populate`, twice
-  #       run: |
-  #           pip install requests # the nonly non-stdlib dependency as of now
-  #           export CONBENCH_BASE_URL=http://$(docker compose port app 5000) && \
-  #           make db-populate && make db-populate
-  #           docker-compose logs # view logs to see why transient errs happen
-  #     - name: test `make teardown-app`
-  #       run: make teardown-app
-  #     # The goal of this is to largely test `make run-app-dev`.
-  #     - name: test-run-app-dev
-  #       run: make test-run-app-dev
-
-  # ui-screenshots:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: checkout
-  #       uses: actions/checkout@v3
-  #     - name: run-app-bg
-  #       run: make run-app-bg
-  #     - name: populate DB & take screenshots
-  #       run: |
-  #           pip install requests # the nonly non-stdlib dependency as of now
-  #           export CONBENCH_BASE_URL=http://$(docker compose port app 5000)
-  #           export SOME_BENCHMARK_ID="$(make -s db-populate)"
-  #           echo "conbench base URL: $CONBENCH_BASE_URL"
-  #           echo "a valid benchmark ID: $SOME_BENCHMARK_ID"
-  #           cd ci
-  #           docker build . -t conbench-screenshot -f screenshot.Dockerfile
-  #           mkdir ci-artifacts
-  #           docker run --net=host -v $(pwd)/ci-artifacts:/artifacts conbench-screenshot \
-  #               python screenshot.py ${CONBENCH_BASE_URL} /artifacts frontpage
-  #           docker run --net=host -v $(pwd)/ci-artifacts:/artifacts conbench-screenshot \
-  #               python screenshot.py "${CONBENCH_BASE_URL}/benchmarks/${SOME_BENCHMARK_ID}/" \
-  #                 /artifacts benchmark-result-view --wait-for-canvas
-  #           /bin/ls -ahltr ci-artifacts/
-  #     - name: upload-artifacts
-  #       uses: actions/upload-artifact@v3
-  #       # Upload screenshots _especially_ when result was unexpected.
-  #       if: always()
-  #       with:
-  #         name: screenshots
-  #         path: ci/ci-artifacts/
-  #     - name: get container logs
-  #       if: always()
-  #       # If the browser-initiated GET requests led to e.g an Internal Server Error
-  #       # then we see that in the screenshot(s). For debugging that, however,
-  #       # it's crucial to get web application logs. Note that this shows
-  #       # container logs interleaved, but prefixed so that it's after all
-  #       # unambiguous which line came from which container.
-  #       run: docker compose logs --since 30m
-  #     - name: test `make teardown-app`
-  #       # Run teardown especially when previous step(s) failed, because here
-  #       # we get some good log output for debuggability.
-  #       if: always()
-  #       run: make teardown-app
-
-  # db-migrations:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: checkout
-  #       uses: actions/checkout@v3
-  #     - name: Start PostgreSQL DB
-  #       run: docker compose run --detach db
-  #     # Run `alembic upgrade head` via docker compose so that it is within
-  #     # the network that the DB is also in, reachable via DNS name `db`
-  #     - name: Test database migrations
-  #       run: docker compose run -e CREATE_ALL_TABLES app alembic upgrade head
-  #       env:
-  #         CREATE_ALL_TABLES: false
-
-  # clis:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: checkout
-  #       uses: actions/checkout@v3
-  #     - name: Set up Python
-  #       uses: actions/setup-python@v4
-  #       with:
-  #         python-version: "3.10"
-  #     - name: Install dependencies
-  #       run: |
-  #         pip install --no-deps \
-  #           -e benchadapt/python \
-  #           -e benchrun/python \
-  #           -e benchconnect && \
-  #         pip install \
-  #           -U --upgrade-strategy eager \
-  #           -e .[dev] \
-  #           -e benchclients/python
-  #     - name: Test benchclients
-  #       run: |
-  #         pytest -vv benchclients/python/tests
-  #     - name: Test benchadapt
-  #       run: |
-  #         pytest -vv benchadapt/python/tests
-  #     - name: Test benchrun
-  #       run: |
-  #         pytest -vv benchrun/python/tests
-  #     - name: Test benchconnect
-  #       run: |
-  #         pytest -vv benchconnect

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v3
       - name: start minikube
         id: minikube
-        uses: medyagh/setup-minikube@master
+        uses: medyagh/setup-minikube@latest
         with:
           # from https://github.com/prometheus-operator/kube-prometheus#minikube
           extra-config: kubelet.authentication-token-webhook=true,kubelet.authorization-mode=Webhook,scheduler.bind-address=0.0.0.0,controller-manager.bind-address=0.0.0.0

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -28,7 +28,7 @@ jobs:
           cpus: max
           memory: max
       - name: ci/minikube/test-conbench-on-mk.sh
-        run: bash ci/minikube/test-conbench-on-mk.sh
+        run: export CONBENCH_REPO_ROOT_DIR=$(pwd) && bash ci/minikube/test-conbench-on-mk.sh
 
 
   # lint:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -25,8 +25,8 @@ jobs:
         with:
           # from https://github.com/prometheus-operator/kube-prometheus#minikube
           extra-config: kubelet.authentication-token-webhook=true,kubelet.authorization-mode=Webhook,scheduler.bind-address=0.0.0.0,controller-manager.bind-address=0.0.0.0
-          cpus: max
-          memory: max
+          cpus: 4
+          memory: 8000
       - name: ci/minikube/test-conbench-on-mk.sh
         run: bash ci/minikube/test-conbench-on-mk.sh
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -22,6 +22,13 @@ jobs:
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@latest
+        with:
+          # from https://github.com/prometheus-operator/kube-prometheus#minikube
+          extra-config:
+            kubelet.authentication-token-webhook=true
+            kubelet.authorization-mode=Webhook
+            scheduler.bind-address=0.0.0.0
+            controller-manager.bind-address=0.0.0.0
       - name: ci/minikube/test-conbench-on-mk.sh
         run: bash ci/minikube/test-conbench-on-mk.sh
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,7 +14,6 @@ env:
   GITHUB_API_TOKEN: ${{ secrets.PERSONAL_GITHUB_API_TOKEN }}
 
 jobs:
-
   cb-on-minikube:
     runs-on: ubuntu-latest
     steps:
@@ -24,7 +23,7 @@ jobs:
       - name: kubectl
         run: kubectl get pods -A
       - name: postgres-operator
-        run:
+        run: |
           git clone https://github.com/zalando/postgres-operator
           cd postgres-operator
           # 1.9.0 release from 2023-01-30

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -17,10 +17,12 @@ jobs:
   cb-on-minikube:
     runs-on: ubuntu-latest
     steps:
+      - name: checkout
+        uses: actions/checkout@v3
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@latest
-      - name: set up postgres-operator
+      - name: ci/minikube/test-conbench-on-mk.sh
         run: bash ci/minikube/test-conbench-on-mk.sh
 
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   # secrets.GITHUB_TOKEN is provided by GitHub Actions and not
-  # bound to a personal user account. It allows for 1000 
+  # bound to a personal user account. It allows for 1000
   # GitHub HTTP API requests per hour. A personal token
   # allows for 5000 of those.
   GITHUB_API_TOKEN: ${{ secrets.PERSONAL_GITHUB_API_TOKEN }}
@@ -184,4 +184,5 @@ jobs:
           cpus: max
           memory: max
       - name: ci/minikube/test-conbench-on-mk.sh
-        run: export CONBENCH_REPO_ROOT_DIR=$(pwd) && bash ci/minikube/test-conbench-on-mk.sh
+        run: export CONBENCH_REPO_ROOT_DIR=$(pwd) && \
+          bash ci/minikube/test-conbench-on-mk.sh

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,158 +14,179 @@ env:
   GITHUB_API_TOKEN: ${{ secrets.PERSONAL_GITHUB_API_TOKEN }}
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-      - name: Install linting dependencies
-        run: pip install -r requirements-dev.txt
-      - name: lint
-        run: make lint-ci
 
-  testsuite:
+  cb-on-minikube:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
-      - name: Run tests, generate coverage data
-        # This is expected to create /etc/conbench-coverage-dir/.coverage
-        # in the `app` service container.
-        run: make tests
-      - name: Convert coverage data to LCOV
-        run: |
-          docker compose run -e COVERAGE_FILE=/etc/conbench-coverage-dir/.coverage app \
-            coverage lcov -o /etc/conbench-coverage-dir/coverage.lcov
-      - name: Publish coverage
-        uses: coverallsapp/github-action@master
-        # sometimes the coveralls API fails transiently, and we don't want that to affect this build
-        continue-on-error: true
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: _conbench-coverage-dir/coverage.lcov
+      - name: start minikube
+        id: minikube
+        uses: medyagh/setup-minikube@latest
+      - name: kubectl
+        run: kubectl get pods -A
+      - name: postgres-operator
+        run:
+          git clone https://github.com/zalando/postgres-operator
+          cd postgres-operator
+          # 1.9.0 release from 2023-01-30
+          git checkout 30b612489a2a20d968262791857d1db1a85e0b36
+          # This should tear down the current minikube, and re-spawn another
+          # one, bootstrapping the postgres operator using
+          # https://github.com/zalando/postgres-operator/blob/v1.9.0/manifests/minimal-postgres-manifest.yaml
+          bash ./run_operator_locally.sh
+          kubectl get pods -A
 
-  # This is to confirm that commonly used developer commands still work.
-  dev-cmds:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-      - name: rebuild-expected-api-docs
-        run: |
-          pip install black
-          make rebuild-expected-api-docs
-      # Launch application as containerized stack. This terminates after
-      # health checks confirm that stack is running.
-      - name: run-app-bg
-        run: make run-app-bg
-      # Run `db-populate` twice to see that this can be repeated w/o failing.
-      - name: test `make db-populate`, twice
-        run: |
-            pip install requests # the nonly non-stdlib dependency as of now
-            export CONBENCH_BASE_URL=http://$(docker compose port app 5000) && \
-            make db-populate && make db-populate
-            docker-compose logs # view logs to see why transient errs happen
-      - name: test `make teardown-app`
-        run: make teardown-app
-      # The goal of this is to largely test `make run-app-dev`.
-      - name: test-run-app-dev
-        run: make test-run-app-dev
+  # lint:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: checkout
+  #       uses: actions/checkout@v3
+  #     - name: Set up Python
+  #       uses: actions/setup-python@v4
+  #       with:
+  #         python-version: "3.11"
+  #     - name: Install linting dependencies
+  #       run: pip install -r requirements-dev.txt
+  #     - name: lint
+  #       run: make lint-ci
 
-  ui-screenshots:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-      - name: run-app-bg
-        run: make run-app-bg
-      - name: populate DB & take screenshots
-        run: |
-            pip install requests # the nonly non-stdlib dependency as of now
-            export CONBENCH_BASE_URL=http://$(docker compose port app 5000)
-            export SOME_BENCHMARK_ID="$(make -s db-populate)"
-            echo "conbench base URL: $CONBENCH_BASE_URL"
-            echo "a valid benchmark ID: $SOME_BENCHMARK_ID"
-            cd ci
-            docker build . -t conbench-screenshot -f screenshot.Dockerfile
-            mkdir ci-artifacts
-            docker run --net=host -v $(pwd)/ci-artifacts:/artifacts conbench-screenshot \
-                python screenshot.py ${CONBENCH_BASE_URL} /artifacts frontpage
-            docker run --net=host -v $(pwd)/ci-artifacts:/artifacts conbench-screenshot \
-                python screenshot.py "${CONBENCH_BASE_URL}/benchmarks/${SOME_BENCHMARK_ID}/" \
-                  /artifacts benchmark-result-view --wait-for-canvas
-            /bin/ls -ahltr ci-artifacts/
-      - name: upload-artifacts
-        uses: actions/upload-artifact@v3
-        # Upload screenshots _especially_ when result was unexpected.
-        if: always()
-        with:
-          name: screenshots
-          path: ci/ci-artifacts/
-      - name: get container logs
-        if: always()
-        # If the browser-initiated GET requests led to e.g an Internal Server Error
-        # then we see that in the screenshot(s). For debugging that, however,
-        # it's crucial to get web application logs. Note that this shows
-        # container logs interleaved, but prefixed so that it's after all
-        # unambiguous which line came from which container.
-        run: docker compose logs --since 30m
-      - name: test `make teardown-app`
-        # Run teardown especially when previous step(s) failed, because here
-        # we get some good log output for debuggability.
-        if: always()
-        run: make teardown-app
+  # testsuite:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: checkout
+  #       uses: actions/checkout@v3
+  #     - name: Run tests, generate coverage data
+  #       # This is expected to create /etc/conbench-coverage-dir/.coverage
+  #       # in the `app` service container.
+  #       run: make tests
+  #     - name: Convert coverage data to LCOV
+  #       run: |
+  #         docker compose run -e COVERAGE_FILE=/etc/conbench-coverage-dir/.coverage app \
+  #           coverage lcov -o /etc/conbench-coverage-dir/coverage.lcov
+  #     - name: Publish coverage
+  #       uses: coverallsapp/github-action@master
+  #       # sometimes the coveralls API fails transiently, and we don't want that to affect this build
+  #       continue-on-error: true
+  #       with:
+  #         github-token: ${{ secrets.GITHUB_TOKEN }}
+  #         path-to-lcov: _conbench-coverage-dir/coverage.lcov
 
-  db-migrations:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-      - name: Start PostgreSQL DB
-        run: docker compose run --detach db
-      # Run `alembic upgrade head` via docker compose so that it is within
-      # the network that the DB is also in, reachable via DNS name `db`
-      - name: Test database migrations
-        run: docker compose run -e CREATE_ALL_TABLES app alembic upgrade head
-        env:
-          CREATE_ALL_TABLES: false
+  # # This is to confirm that commonly used developer commands still work.
+  # dev-cmds:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: checkout
+  #       uses: actions/checkout@v3
+  #     - name: Set up Python
+  #       uses: actions/setup-python@v4
+  #       with:
+  #         python-version: "3.10"
+  #     - name: rebuild-expected-api-docs
+  #       run: |
+  #         pip install black
+  #         make rebuild-expected-api-docs
+  #     # Launch application as containerized stack. This terminates after
+  #     # health checks confirm that stack is running.
+  #     - name: run-app-bg
+  #       run: make run-app-bg
+  #     # Run `db-populate` twice to see that this can be repeated w/o failing.
+  #     - name: test `make db-populate`, twice
+  #       run: |
+  #           pip install requests # the nonly non-stdlib dependency as of now
+  #           export CONBENCH_BASE_URL=http://$(docker compose port app 5000) && \
+  #           make db-populate && make db-populate
+  #           docker-compose logs # view logs to see why transient errs happen
+  #     - name: test `make teardown-app`
+  #       run: make teardown-app
+  #     # The goal of this is to largely test `make run-app-dev`.
+  #     - name: test-run-app-dev
+  #       run: make test-run-app-dev
 
-  clis:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-      - name: Install dependencies
-        run: |
-          pip install --no-deps \
-            -e benchadapt/python \
-            -e benchrun/python \
-            -e benchconnect && \
-          pip install \
-            -U --upgrade-strategy eager \
-            -e .[dev] \
-            -e benchclients/python
-      - name: Test benchclients
-        run: |
-          pytest -vv benchclients/python/tests
-      - name: Test benchadapt
-        run: |
-          pytest -vv benchadapt/python/tests
-      - name: Test benchrun
-        run: |
-          pytest -vv benchrun/python/tests
-      - name: Test benchconnect
-        run: |
-          pytest -vv benchconnect
+  # ui-screenshots:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: checkout
+  #       uses: actions/checkout@v3
+  #     - name: run-app-bg
+  #       run: make run-app-bg
+  #     - name: populate DB & take screenshots
+  #       run: |
+  #           pip install requests # the nonly non-stdlib dependency as of now
+  #           export CONBENCH_BASE_URL=http://$(docker compose port app 5000)
+  #           export SOME_BENCHMARK_ID="$(make -s db-populate)"
+  #           echo "conbench base URL: $CONBENCH_BASE_URL"
+  #           echo "a valid benchmark ID: $SOME_BENCHMARK_ID"
+  #           cd ci
+  #           docker build . -t conbench-screenshot -f screenshot.Dockerfile
+  #           mkdir ci-artifacts
+  #           docker run --net=host -v $(pwd)/ci-artifacts:/artifacts conbench-screenshot \
+  #               python screenshot.py ${CONBENCH_BASE_URL} /artifacts frontpage
+  #           docker run --net=host -v $(pwd)/ci-artifacts:/artifacts conbench-screenshot \
+  #               python screenshot.py "${CONBENCH_BASE_URL}/benchmarks/${SOME_BENCHMARK_ID}/" \
+  #                 /artifacts benchmark-result-view --wait-for-canvas
+  #           /bin/ls -ahltr ci-artifacts/
+  #     - name: upload-artifacts
+  #       uses: actions/upload-artifact@v3
+  #       # Upload screenshots _especially_ when result was unexpected.
+  #       if: always()
+  #       with:
+  #         name: screenshots
+  #         path: ci/ci-artifacts/
+  #     - name: get container logs
+  #       if: always()
+  #       # If the browser-initiated GET requests led to e.g an Internal Server Error
+  #       # then we see that in the screenshot(s). For debugging that, however,
+  #       # it's crucial to get web application logs. Note that this shows
+  #       # container logs interleaved, but prefixed so that it's after all
+  #       # unambiguous which line came from which container.
+  #       run: docker compose logs --since 30m
+  #     - name: test `make teardown-app`
+  #       # Run teardown especially when previous step(s) failed, because here
+  #       # we get some good log output for debuggability.
+  #       if: always()
+  #       run: make teardown-app
+
+  # db-migrations:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: checkout
+  #       uses: actions/checkout@v3
+  #     - name: Start PostgreSQL DB
+  #       run: docker compose run --detach db
+  #     # Run `alembic upgrade head` via docker compose so that it is within
+  #     # the network that the DB is also in, reachable via DNS name `db`
+  #     - name: Test database migrations
+  #       run: docker compose run -e CREATE_ALL_TABLES app alembic upgrade head
+  #       env:
+  #         CREATE_ALL_TABLES: false
+
+  # clis:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: checkout
+  #       uses: actions/checkout@v3
+  #     - name: Set up Python
+  #       uses: actions/setup-python@v4
+  #       with:
+  #         python-version: "3.10"
+  #     - name: Install dependencies
+  #       run: |
+  #         pip install --no-deps \
+  #           -e benchadapt/python \
+  #           -e benchrun/python \
+  #           -e benchconnect && \
+  #         pip install \
+  #           -U --upgrade-strategy eager \
+  #           -e .[dev] \
+  #           -e benchclients/python
+  #     - name: Test benchclients
+  #       run: |
+  #         pytest -vv benchclients/python/tests
+  #     - name: Test benchadapt
+  #       run: |
+  #         pytest -vv benchadapt/python/tests
+  #     - name: Test benchrun
+  #       run: |
+  #         pytest -vv benchrun/python/tests
+  #     - name: Test benchconnect
+  #       run: |
+  #         pytest -vv benchconnect

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           # from https://github.com/prometheus-operator/kube-prometheus#minikube
           extra-config: kubelet.authentication-token-webhook=true,kubelet.authorization-mode=Webhook,scheduler.bind-address=0.0.0.0,controller-manager.bind-address=0.0.0.0
+          cpus: max
+          memory: max
       - name: ci/minikube/test-conbench-on-mk.sh
         run: bash ci/minikube/test-conbench-on-mk.sh
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v3
       - name: start minikube
         id: minikube
-        uses: medyagh/setup-minikube@latest
+        uses: medyagh/setup-minikube@master
         with:
           # from https://github.com/prometheus-operator/kube-prometheus#minikube
           extra-config: kubelet.authentication-token-webhook=true,kubelet.authorization-mode=Webhook,scheduler.bind-address=0.0.0.0,controller-manager.bind-address=0.0.0.0

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -24,11 +24,10 @@ jobs:
         uses: medyagh/setup-minikube@latest
         with:
           # from https://github.com/prometheus-operator/kube-prometheus#minikube
-          extra-config:
-            kubelet.authentication-token-webhook=true
-            kubelet.authorization-mode=Webhook
-            scheduler.bind-address=0.0.0.0
-            controller-manager.bind-address=0.0.0.0
+          extra-config: kubelet.authentication-token-webhook=true
+          extra-config: kubelet.authorization-mode=Webhook
+          extra-config: scheduler.bind-address=0.0.0.0
+          extra-config: controller-manager.bind-address=0.0.0.0
       - name: ci/minikube/test-conbench-on-mk.sh
         run: bash ci/minikube/test-conbench-on-mk.sh
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -25,8 +25,8 @@ jobs:
         with:
           # from https://github.com/prometheus-operator/kube-prometheus#minikube
           extra-config: kubelet.authentication-token-webhook=true,kubelet.authorization-mode=Webhook,scheduler.bind-address=0.0.0.0,controller-manager.bind-address=0.0.0.0
-          cpus: 4
-          memory: 8000
+          cpus: max
+          memory: max
       - name: ci/minikube/test-conbench-on-mk.sh
         run: bash ci/minikube/test-conbench-on-mk.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,11 @@ RUN pwd && /bin/ls -1 .
 # importlib.metadata.PackageNotFoundError: No package metadata was found for conbench
 RUN pip install .
 
+# Make it so that this directory exists in the container file system
+# that's the value of the PROMETHEUS_MULTIPROC_DIR env var.
+RUN mkdir -p /tmp/_conbench-promcl-coord-dir
+
+
 # Re-active this to get ideas for how the image size can be further reduced.
 #RUN echo "biggest dirs"
 #RUN cd / && du -ha . | sort -r -h | head -n 50 || true
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,13 @@ RUN pwd && /bin/ls -1 .
 # importlib.metadata.PackageNotFoundError: No package metadata was found for conbench
 RUN pip install .
 
-# Make it so that this directory exists in the container file system
-# that's the value of the PROMETHEUS_MULTIPROC_DIR env var.
+# Make it so that this directory exists in the container file system. That's
+# the value of the PROMETHEUS_MULTIPROC_DIR env var. The prometheus-client
+# Python library needs this to be set to a path pointing to a directory. I have
+# tried setting this up within the CPython process (early during import) but
+# that wasn't early enough. Note that when mounting the host's /tmp to the
+# container's /tmp the host is expected to have /tmp/_conbench-promcl-coord-dir
+# in its file system.
 RUN mkdir -p /tmp/_conbench-promcl-coord-dir
 
 

--- a/Makefile
+++ b/Makefile
@@ -105,12 +105,11 @@ test-run-app-dev:
 	docker compose down
 
 
-# The version string representing the current checkout / working directory.
-# This for example defines the Docker image tags. The default `dev` suffix
-# represents a local dev environment. Override CHECKOUT_VERSION_STRING with a
-# different suffix (e.g. `ci`) in the CI environment so that the version string
-# attached to build artifacts reveals the environment that the build artifact
-# was created in.
+# The version string representing the current checkout / working directory. The
+# default `dev` suffix represents a local dev environment. Override
+# CHECKOUT_VERSION_STRING with a different suffix (e.g. `ci`) in the CI
+# environment so that the version string attached to build artifacts reveals
+# the environment that the build artifact was created in.
 export CHECKOUT_VERSION_STRING ?= $(shell git rev-parse --short=9 HEAD)-dev
 # Set a different repo organization for pushing images to
 DOCKER_REPO_ORG ?= conbench
@@ -120,6 +119,7 @@ CONTAINER_IMAGE_SPEC=$(DOCKER_REPO_ORG)/conbench:$(CHECKOUT_VERSION_STRING)
 .PHONY: print-container-image-spec
 print-container-image-spec:
 	@echo $(CONTAINER_IMAGE_SPEC)
+
 
 .PHONY: build-conbench-container-image
 build-conbench-container-image:
@@ -145,22 +145,20 @@ start-minikube:
 		--extra-config=controller-manager.bind-address=0.0.0.0
 
 
-# This target is used by ci/minikube/test-conbench-on-mk.sh.
-# The `minikube image load` technique is rather new and allows for using local
-# Docker images in k8s deployments (as long as they specify `imagePullPolicy:
-# Never`). That command however takes a while for bigger images (about 1 min
-# per GB, on my machine).
+# This target is used by ci/minikube/test-conbench-on-mk.sh. The `minikube
+# image load` technique allows for using local Docker images in k8s deployments
+# (as long as they specify `imagePullPolicy: Never`). That command however
+# takes a while for bigger images (about 1 min per GB, on my machine).
 # https://minikube.sigs.k8s.io/docs/handbook/pushing/
 # https://stackoverflow.com/a/62303945
 .PHONY: deploy-on-minikube
 deploy-on-minikube:
 	minikube status
 	mkdir -p _build
-	cat ci/minikube/deploy-conbench.template.yml > _build/deploy-conbench.yml
+	cp ci/minikube/deploy-conbench.template.yml _build/deploy-conbench.yml
 	sed -i.bak "s|<CONBENCH_CONTAINER_IMAGE_SPEC>|${CONTAINER_IMAGE_SPEC}|g" _build/deploy-conbench.yml
-	rm _build/deploy-conbench.yml.bak
 	time minikube image load ${CONTAINER_IMAGE_SPEC}
-	minikube kubectl -- apply -f  _build/deploy-conbench.yml
+	minikube kubectl -- apply -f _build/deploy-conbench.yml
 
 .PHONY: minikube-bigflow
 minikube-bigflow: build-conbench-container-image start-minikube

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,8 @@ build-conbench-container-image:
 # Docker images in k8s deployments (as long as they specify `imagePullPolicy:
 # Never`). That command however takes a while for bigger images (about 1 min
 # per GB, on my machine).
+# https://minikube.sigs.k8s.io/docs/handbook/pushing/
+# https://stackoverflow.com/a/62303945
 .PHONY: deploy-on-minikube
 deploy-on-minikube:
 	minikube status

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ run-app-bg:
 # fails then emit container logs before fast-failing the makefile target.
 .PHONY: test-run-app-dev
 test-run-app-dev:
-	docker compose down
+	docker compose down --remove-orphans
 	docker compose -f docker-compose.yml -f docker-compose.dev.yml \
 		up --build --wait --detach || (docker compose logs --since 30m; exit 1)
 	docker compose down

--- a/Makefile
+++ b/Makefile
@@ -115,10 +115,10 @@ export CHECKOUT_VERSION_STRING ?= $(shell git rev-parse --short=9 HEAD)-dev
 DOCKER_REPO_ORG ?= conbench
 CONTAINER_IMAGE_SPEC=$(DOCKER_REPO_ORG)/conbench:$(CHECKOUT_VERSION_STRING)
 
-$(info --------------------------------------------------------------)
-$(info CONTAINER_IMAGE_SPEC is $(CONTAINER_IMAGE_SPEC))
-$(info --------------------------------------------------------------)
 
+.PHONY: print-container-image-spec
+print-container-image-spec:
+	@echo $(CONTAINER_IMAGE_SPEC)
 
 .PHONY: build-conbench-container-image
 build-conbench-container-image:

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ run-app-bg:
 # fails then emit container logs before fast-failing the makefile target.
 .PHONY: test-run-app-dev
 test-run-app-dev:
+	mkdir -p /tmp/_conbench-promcl-coord-dir
 	docker compose down --remove-orphans
 	docker compose -f docker-compose.yml -f docker-compose.dev.yml \
 		up --build --wait --detach || (docker compose logs --since 30m; exit 1)

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ deploy-on-minikube: build-conbench-container-image
 	minikube addons enable ingress
 	minikube status
 	mkdir -p _build
-	cat ci/minikube/deploy-conbench.yml.template > _build/deploy-conbench.yml
+	cat ci/minikube/deploy-conbench.template.yml > _build/deploy-conbench.yml
 	sed -i.bak "s|<CONBENCH_CONTAINER_IMAGE_SPEC>|${CONTAINER_IMAGE_SPEC}|g" _build/deploy-conbench.yml
 	rm _build/deploy-conbench.yml.bak
 	minikube image load ${CONTAINER_IMAGE_SPEC}

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,6 @@ build-conbench-container-image:
 
 .PHONY: deploy-on-minikube
 deploy-on-minikube: build-conbench-container-image
-	minikube addons enable ingress
 	minikube status
 	mkdir -p _build
 	cat ci/minikube/deploy-conbench.template.yml > _build/deploy-conbench.yml
@@ -137,4 +136,3 @@ deploy-on-minikube: build-conbench-container-image
 	rm _build/deploy-conbench.yml.bak
 	minikube image load ${CONTAINER_IMAGE_SPEC}
 	minikube kubectl -- apply -f  _build/deploy-conbench.yml
-

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,6 @@ tests:
 # That mounts the local checkout into the Conbench container.
 .PHONY: run-app-dev
 run-app-dev:
-	export DCOMP_CONBENCH_METRICS_HOST_PORT=127.0.0.1:8000 && \
 	export DCOMP_CONBENCH_HOST_PORT=127.0.0.1:5000 && \
 		docker compose down && \
 			docker compose -f docker-compose.yml -f docker-compose.dev.yml \

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ test-run-app-dev:
 		up --build --wait --detach || (docker compose logs --since 30m; exit 1)
 	docker compose down
 
+
 # The version string representing the current checkout / working directory.
 # This for example defines the Docker image tags. The default `dev` suffix
 # represents a local dev environment. Override CHECKOUT_VERSION_STRING with a
@@ -111,9 +112,8 @@ test-run-app-dev:
 # was created in.
 export CHECKOUT_VERSION_STRING ?= $(shell git rev-parse --short=9 HEAD)-dev
 # Set a different repo organization for pushing images to
-DOCKER_REPO ?= conbench
-
-CONTAINER_IMAGE_SPEC=$(DOCKER_REPO)/conbench:$(CHECKOUT_VERSION_STRING)
+DOCKER_REPO_ORG ?= conbench
+CONTAINER_IMAGE_SPEC=$(DOCKER_REPO_ORG)/conbench:$(CHECKOUT_VERSION_STRING)
 
 $(info --------------------------------------------------------------)
 $(info CONTAINER_IMAGE_SPEC is $(CONTAINER_IMAGE_SPEC))
@@ -126,6 +126,7 @@ build-conbench-container-image:
 	echo "Size of docker image:"
 	docker images --format "{{.Size}}" ${CONTAINER_IMAGE_SPEC}
 	# docker push ${CONTAINER_IMAGE_SPEC}
+
 
 # Some of the cmdline flags are taken from
 # https://github.com/prometheus-operator/kube-prometheus#minikube
@@ -143,6 +144,7 @@ start-minikube:
 		--extra-config=controller-manager.bind-address=0.0.0.0
 
 
+# This target is used by ci/minikube/test-conbench-on-mk.sh.
 # The `minikube image load` technique is rather new and allows for using local
 # Docker images in k8s deployments (as long as they specify `imagePullPolicy:
 # Never`). That command however takes a while for bigger images (about 1 min
@@ -162,5 +164,4 @@ deploy-on-minikube:
 .PHONY: minikube-bigflow
 minikube-bigflow: build-conbench-container-image start-minikube
 	rm -rf _build && mkdir -p _build && cd _build && bash ../ci/minikube/test-conbench-on-mk.sh
-
 

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ CONTAINER_IMAGE_SPEC=$(DOCKER_REPO_ORG)/conbench:$(CHECKOUT_VERSION_STRING)
 
 
 .PHONY: build-conbench-container-image
-build-conbench-container-image:
+build-conbench-container-image: set-build-info
 	docker build . -f Dockerfile -t ${CONTAINER_IMAGE_SPEC}
 	echo "Size of docker image:"
 	docker images --format "{{.Size}}" ${CONTAINER_IMAGE_SPEC}

--- a/ci/minikube/conbench-config-for-minikube.yml
+++ b/ci/minikube/conbench-config-for-minikube.yml
@@ -17,3 +17,8 @@ data:
   DISTRIBUTION_COMMITS: "100"
   # value does not seem to matter, hard-coded in gunicorn cmd
   FLASK_APP: foobarrofl
+  # For
+  # https://github.com/prometheus/client_python#multiprocess-mode-eg-gunicorn
+  # timing of setting this matters:
+  # https://github.com/rycus86/prometheus_flask_exporter/issues/131
+  PROMETHEUS_MULTIPROC_DIR: /tmp/_conbench-promcl-coord-dir

--- a/ci/minikube/conbench-config-for-minikube.yml
+++ b/ci/minikube/conbench-config-for-minikube.yml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: conbench-config
+  labels:
+    app: conbench
+data:
+  CONBENCH_INTENDED_BASE_URL: "http://localhost"
+  APPLICATION_NAME: "conbench-for-minikube"
+  BENCHMARKS_DATA_PUBLIC: "true"
+  # This corresponds to postgres-operator
+  # https://github.com/zalando/postgres-operator/blob/v1.9.0/manifests/minimal-postgres-manifest.yaml
+  DB_NAME: "foo"
+  # DNS name as of k8s service object created by postgres-operator
+  DB_HOST: "acid-minimal-cluster"
+  DB_PORT: "5432"
+  DISTRIBUTION_COMMITS: "100"
+  # value does not seem to matter, hard-coded in gunicorn cmd
+  FLASK_APP: foobarrofl

--- a/ci/minikube/deploy-conbench.template.yml
+++ b/ci/minikube/deploy-conbench.template.yml
@@ -45,6 +45,7 @@ spec:
           requests:
             # A request of zero CPU and memory effectively means "infinitely
             # small" for the scheduler deciding on which node to place the pod.
+            # Use this technique to get things running on small GHA runners.
             memory: 0
             cpu: 0
         readinessProbe:

--- a/ci/minikube/deploy-conbench.template.yml
+++ b/ci/minikube/deploy-conbench.template.yml
@@ -43,8 +43,10 @@ spec:
               name: conbench-secret
         resources:
           requests:
-            memory: '1Gi'
-            cpu: 0.1
+            # A request of zero CPU and memory effectively means "infinitely
+            # small" for the scheduler deciding on which node to place the pod.
+            memory: 0
+            cpu: 0
         readinessProbe:
           failureThreshold: 1
           httpGet:

--- a/ci/minikube/deploy-conbench.template.yml
+++ b/ci/minikube/deploy-conbench.template.yml
@@ -26,7 +26,8 @@ spec:
         imagePullPolicy: Never
         #imagePullPolicy: "Always"
         ports:
-          - containerPort: 5000
+          - name: gunicorn
+            containerPort: 5000
         envFrom:
           - configMapRef:
               name: conbench-config
@@ -48,12 +49,29 @@ spec:
           timeoutSeconds: 20
       terminationGracePeriodSeconds: 60
 ---
+apiVersion: monitoring.coreos.com/v1
+# This is a CRD defined by the prometheus-operator/kube-prometheus project
+kind: ServiceMonitor
+metadata:
+  name: conbench-service-monitor
+spec:
+  selector:
+    matchLabels:
+      app: conbench
+  endpoints:
+    - path: /metrics
+      port: gunicorn
+      scheme: http
+      interval: 60s
+---
 apiVersion: v1
 kind: Service
 metadata:
   annotations:
     alb.ingress.kubernetes.io/target-type: ip
   name: "conbench-service"
+  labels:
+    app: conbench
 spec:
   ports:
   - port: 80

--- a/ci/minikube/deploy-conbench.template.yml
+++ b/ci/minikube/deploy-conbench.template.yml
@@ -26,8 +26,7 @@ spec:
           "-w", "5",
           "conbench:application",
           "--access-logfile=-",
-          "--error-logfile=-",
-          "--preload",
+          "--error-logfile=-"
           "-c", "conbench/gunicorn-conf.py"
           ]
         # for minikube local docker images

--- a/ci/minikube/deploy-conbench.template.yml
+++ b/ci/minikube/deploy-conbench.template.yml
@@ -26,7 +26,7 @@ spec:
           "-w", "5",
           "conbench:application",
           "--access-logfile=-",
-          "--error-logfile=-"
+          "--error-logfile=-",
           "-c", "conbench/gunicorn-conf.py"
           ]
         # for minikube local docker images

--- a/ci/minikube/deploy-conbench.template.yml
+++ b/ci/minikube/deploy-conbench.template.yml
@@ -74,7 +74,8 @@ spec:
     - port: conbench-service-port
       path: /metrics
       scheme: http
-      interval: 60s
+      # This defines the time resolution.
+      interval: 30s
 ---
 apiVersion: v1
 kind: Service

--- a/ci/minikube/deploy-conbench.template.yml
+++ b/ci/minikube/deploy-conbench.template.yml
@@ -6,7 +6,7 @@ spec:
   selector:
     matchLabels:
       app: conbench
-  replicas: 2
+  replicas: 1
   strategy:
     rollingUpdate:
       maxSurge: 25%
@@ -43,8 +43,8 @@ spec:
               name: conbench-secret
         resources:
           requests:
-            memory: '2Gi'
-            cpu: 0.5
+            memory: '1Gi'
+            cpu: 0.1
         readinessProbe:
           failureThreshold: 1
           httpGet:

--- a/ci/minikube/deploy-conbench.template.yml
+++ b/ci/minikube/deploy-conbench.template.yml
@@ -22,12 +22,12 @@ spec:
         image: "<CONBENCH_CONTAINER_IMAGE_SPEC>"
         command: [
           "gunicorn",
+          "-c", "conbench/gunicorn-conf.py",
           "-b", "0.0.0.0:5000",
           "-w", "5",
           "conbench:application",
           "--access-logfile=-",
-          "--error-logfile=-",
-          "-c", "conbench/gunicorn-conf.py"
+          "--error-logfile=-"
           ]
         # for minikube local docker images
         # added via minikube image load <IMAGE_NAME>
@@ -70,7 +70,8 @@ spec:
       app: conbench
   endpoints:
     - path: /metrics
-      port: gunicorn
+      # could maybe also do this by name? `gunicorn`
+      port: 5000
       scheme: http
       interval: 60s
 ---

--- a/ci/minikube/deploy-conbench.template.yml
+++ b/ci/minikube/deploy-conbench.template.yml
@@ -20,7 +20,16 @@ spec:
       containers:
       - name: conbench
         image: "<CONBENCH_CONTAINER_IMAGE_SPEC>"
-        command: ["gunicorn", "-b", "0.0.0.0:5000", "-w", "5", "conbench:application", "--access-logfile=-", "--error-logfile=-", "--preload"]
+        command: [
+          "gunicorn",
+          "-b", "0.0.0.0:5000",
+          "-w", "5",
+          "conbench:application",
+          "--access-logfile=-",
+          "--error-logfile=-",
+          "--preload",
+          "-c", "conbench/gunicorn-conf.py"
+          ]
         # for minikube local docker images
         # added via minikube image load <IMAGE_NAME>
         imagePullPolicy: Never

--- a/ci/minikube/deploy-conbench.template.yml
+++ b/ci/minikube/deploy-conbench.template.yml
@@ -34,7 +34,7 @@ spec:
         imagePullPolicy: Never
         #imagePullPolicy: "Always"
         ports:
-          - name: gunicorn
+          - name: gunicorn-port
             containerPort: 5000
         envFrom:
           - configMapRef:
@@ -69,9 +69,10 @@ spec:
     matchLabels:
       app: conbench
   endpoints:
-    - path: /metrics
-      # could maybe also do this by name? `gunicorn`
-      port: 5000
+    # It's important that ServiceMonitor i) refers to a Service port  and ii)
+    # refers to it via its name.
+    - port: conbench-service-port
+      path: /metrics
       scheme: http
       interval: 60s
 ---
@@ -85,8 +86,9 @@ metadata:
     app: conbench
 spec:
   ports:
-  - port: 80
-    targetPort: 5000
+  - name: conbench-service-port
+    port: 80
+    targetPort: gunicorn-port
     protocol: TCP
   type: NodePort
   selector:

--- a/ci/minikube/deploy-conbench.yml.template
+++ b/ci/minikube/deploy-conbench.yml.template
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: conbench-deployment
+spec:
+  selector:
+    matchLabels:
+      app: conbench
+  replicas: 2
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: conbench
+    spec:
+      containers:
+      - name: conbench
+        image: "<CONBENCH_CONTAINER_IMAGE_SPEC>"
+        command: ["gunicorn", "-b", "0.0.0.0:5000", "-w", "5", "conbench:application", "--access-logfile=-", "--error-logfile=-", "--preload"]
+        # for minikube local docker images
+        # added via minikube image load <IMAGE_NAME>
+        imagePullPolicy: Never
+        #imagePullPolicy: "Always"
+        ports:
+          - containerPort: 5000
+        envFrom:
+          - configMapRef:
+              name: conbench-config
+          - secretRef:
+              name: conbench-secret
+        resources:
+          requests:
+            memory: '2Gi'
+            cpu: 0.5
+        readinessProbe:
+          failureThreshold: 1
+          httpGet:
+            path: /api/ping/
+            port: 5000
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 2
+          timeoutSeconds: 20
+      terminationGracePeriodSeconds: 60
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    alb.ingress.kubernetes.io/target-type: ip
+  name: "conbench-service"
+spec:
+  ports:
+  - port: 80
+    targetPort: 5000
+    protocol: TCP
+  type: NodePort
+  selector:
+    app: "conbench"

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -80,10 +80,6 @@ pushd kube-prometheus
     kubectl apply -f manifests/
 popd
 
-# Be sure that prometheus-operator entities are done with their setup.
-kubectl wait --for=condition=Ready pods -l  \
-    app.kubernetes.io/name=prometheus-operator -n default
-
 
 # show contents, inject into k8s
 cat conbench-secrets-for-minikube.yml
@@ -100,6 +96,13 @@ kubectl logs deployment/conbench-deployment --all-containers
 
 sleep 30
 kubectl get pods -A
+
+
+sleep 3
+# Be sure that prometheus-operator entities are done with their setup.
+kubectl wait --for=condition=Ready pods -l  \
+    app.kubernetes.io/name=prometheus-operator -n default
+
 
 sleep 5
 kubectl logs deployment/conbench-deployment --all-containers

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -104,7 +104,9 @@ kubectl apply -f conbench-secrets-for-minikube.yml
 # Show what's running now.
 kubectl get pods -A
 
-sleep 5
+# At this point it's expected that the postgres stack still needs a tiny bit
+# of time before it's operational.
+sleep 15
 kubectl logs deployment/conbench-deployment --all-containers
 
 sleep 5
@@ -127,7 +129,8 @@ sleep 5
 
 export CONBENCH_BASE_URL=$(minikube service conbench-service --url) && echo $CONBENCH_BASE_URL
 
-make db-populate
+(cd "${CONBENCH_REPO_ROOT_DIR}" && make db-populate)
+
 
 sleep 10
 kubectl logs deployment/conbench-deployment --all-containers

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -74,7 +74,7 @@ type: Opaque
 stringData:
   DB_PASSWORD: "${POSTGRES_CONBENCH_USER_PASSWORD}"
   DB_USERNAME: "zalando"
-  GITHUB_API_TOKEN: "${GITHUB_TOKEN}"
+  GITHUB_API_TOKEN: "${GITHUB_API_TOKEN:=notset}"
   REGISTRATION_KEY: "innocent-registration-key"
   SECRET_KEY: "not-actually-secret"
 EOF

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -7,6 +7,10 @@ set -o pipefail
 # show commands
 set -o xtrace
 
+
+# assume that minikube cluster is running. show config.
+minikube config view
+
 # This project vastly simplifies setting up PostgreSQL in minikube for us:
 # https://postgres-operator.readthedocs.io
 #
@@ -17,7 +21,6 @@ set -o xtrace
 
 
 git clone https://github.com/zalando/postgres-operator
-
 pushd postgres-operator
 # 1.9.0 release from 2023-01-30
 git checkout 30b612489a2a20d968262791857d1db1a85e0b36
@@ -76,9 +79,20 @@ make deploy-on-minikube
 kubectl get pods -A
 
 sleep 60
-
 kubectl logs deployment/conbench-deployment --all-containers
 
+
+sleep 30
+kubectl get pods -A
+
+sleep 5
+kubectl logs deployment/conbench-deployment --all-containers
+
+sleep 10
+kubectl get pods -A
+sleep 5
+
 export CONBENCH_BASE_URL=$(minikube service conbench-service --url) && echo $CONBENCH_BASE_URL
+
 
 make db-populate

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -37,7 +37,7 @@ pushd postgres-operator
 
     # alchemy: Remove 'clean_up' and 'start_minikube' from
     # `run_operator_locally.sh` (the minikube cluster is already up and running
-    # at this poing). Do this via line number deletion. In the original file,
+    # at this point). Do this via line number deletion. In the original file,
     # delete line 256 and 257. That is safe, because a specific commit of this
     # file was checked out.
     cat ./run_operator_locally.sh | tail -n 15
@@ -130,7 +130,7 @@ kubectl get pods -A
 # of time before it's operational.
 # One could do
 #   kubectl wait --timeout=90s --for=condition=Ready pods acid-minimal-cluster-0
-# but for now it seems this just works because Conbench has rather persistent]
+# but for now it seems this just works because Conbench has rather persistent
 # internal retrying upon DB connect error.
 
 # sleep 20
@@ -147,16 +147,15 @@ kubectl wait --timeout=90s --for=condition=Ready \
     pods -l app.kubernetes.io/name=prometheus-operator -n monitoring
 
 # Be sure that the Prometheus instances managed by the prometheus operator are
-# ready (ready to scrape!). There are two instances. At the time of writing I
-# am not sure which of both is scraping Conbench. Just wait for the both of
-# them.
+# ready (ready to scrape!). There are two instances. At the time of writing it
+# appears as if prometheus-k8s-0 is reproducibly scraping Conbench. Looks like
+# prometheus-k8s-1 does not always start up on GHA because of a resource
+# shortage. Explicitly wait for prometheus-k8s-0, to do care about -1 for now.
 sleep 1
 kubectl wait --timeout=90s --for=condition=Ready pods prometheus-k8s-0 -n monitoring
 
-# looks like prometheus-k8s-1 is precisely what does not start up on GHA
-# because of a resource shortage.
-# kubectl wait --timeout=90s --for=condition=Ready pods prometheus-k8s-1 -n monitoring
 
+# kubectl wait --timeout=90s --for=condition=Ready pods prometheus-k8s-1 -n monitoring
 # sleep 1
 # kubectl logs deployment/conbench-deployment --all-containers
 

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -17,14 +17,15 @@ set -o xtrace
 
 
 git clone https://github.com/zalando/postgres-operator
-cd postgres-operator
+
+pushd postgres-operator
 # 1.9.0 release from 2023-01-30
 git checkout 30b612489a2a20d968262791857d1db1a85e0b36
-
 # This should tear down the current minikube, and re-spawn another
 # one, bootstrapping the postgres operator using
 # https://github.com/zalando/postgres-operator/blob/v1.9.0/manifests/minimal-postgres-manifest.yaml
 bash ./run_operator_locally.sh
+popd
 
 # Show what's running now.
 kubectl get pods -A

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -32,6 +32,11 @@ pushd postgres-operator
     # `run_operator_locally.sh`. Do this via line number deletion. In the original
     # file, delete line 256 and 256. That is safe, because a specific commit of
     # this file was checked out.
+
+    sed -i 's|numberOfInstances: 2|numberOfInstances: 1|g' manifests/minimal-postgres-manifest.yaml
+
+    cat manifests/minimal-postgres-manifest.yaml | grep numberOfInstances
+
     cat ./run_operator_locally.sh | tail -n 15
     sed -i '256d;257d' run_operator_locally.sh
     cat ./run_operator_locally.sh | tail -n 15

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -11,6 +11,9 @@ set -o xtrace
 # assume that minikube cluster is running. show config.
 minikube config view
 
+# for https://github.com/prometheus-operator/kube-prometheus
+minikube addons disable metrics-server
+
 # This project vastly simplifies setting up PostgreSQL in minikube for us:
 # https://postgres-operator.readthedocs.io
 #
@@ -34,7 +37,7 @@ git checkout 30b612489a2a20d968262791857d1db1a85e0b36
 # file, delete line 256 and 256. That is safe, because a specific commit of
 # this file was checked out.
 cat ./run_operator_locally.sh | tail -n 15
-sed -i '256d;257d' file
+sed -i '256d;257d' run_operator_locally.sh
 cat ./run_operator_locally.sh | tail -n 15
 bash ./run_operator_locally.sh
 popd
@@ -91,6 +94,27 @@ kubectl logs deployment/conbench-deployment --all-containers
 sleep 10
 kubectl get pods -A
 sleep 5
+
+
+
+
+git clone https://github.com/prometheus-operator/kube-prometheus
+pushd kube-prometheus
+# 0.12.0 release from 2023-01-27
+git checkout v0.12.0
+kubectl apply --server-side -f manifests/setup
+kubectl wait \
+	--for condition=Established \
+	--all CustomResourceDefinition \
+	--namespace=monitoring
+kubectl apply -f manifests/
+popd
+
+
+
+
+
+
 
 export CONBENCH_BASE_URL=$(minikube service conbench-service --url) && echo $CONBENCH_BASE_URL
 

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -133,13 +133,20 @@ kubectl get pods -A
 sleep 3
 # kubectl describe pods/prometheus-k8s-0 --namespace monitoring
 
-# Be sure that prometheus-operator entities are done with their setup.
+# Be sure that prometheus-operator pods are done with their setup.
 kubectl wait --timeout=90s --for=condition=Ready \
     pods -l app.kubernetes.io/name=prometheus-operator -n monitoring
 
 
+# Be sure that the Prometheus instances managed by the prometheus operator are
+# ready (ready to scrape!). There are two instances. At the time of writing I
+# am not sure which of both is scraping Conbench. Just wait for the both of
+# them.
+kubectl wait --timeout=90s --for=condition=Ready pods prometheus-k8s-0 -n monitoring
+kubectl wait --timeout=90s --for=condition=Ready pods prometheus-k8s-1 -n monitoring
+
 sleep 5
-kubectl logs deployment/conbench-deployment --all-containers
+# kubectl logs deployment/conbench-deployment --all-containers
 
 sleep 5
 kubectl get pods -A

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -99,9 +99,12 @@ kubectl get pods -A
 
 
 sleep 3
+
+kubectl describe pods/prometheus-k8s-0 --namespace monitoring
+
 # Be sure that prometheus-operator entities are done with their setup.
 kubectl wait --for=condition=Ready pods -l  \
-    app.kubernetes.io/name=prometheus-operator -n default
+    app.kubernetes.io/name=prometheus-operator -n monitoring
 
 
 sleep 5

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -143,7 +143,10 @@ kubectl wait --timeout=90s --for=condition=Ready \
 # am not sure which of both is scraping Conbench. Just wait for the both of
 # them.
 kubectl wait --timeout=90s --for=condition=Ready pods prometheus-k8s-0 -n monitoring
-kubectl wait --timeout=90s --for=condition=Ready pods prometheus-k8s-1 -n monitoring
+
+# looks like prometheus-k8s-1 is precisely what does not start up on GHA
+# because of a resource shortage.
+# kubectl wait --timeout=90s --for=condition=Ready pods prometheus-k8s-1 -n monitoring
 
 sleep 5
 # kubectl logs deployment/conbench-deployment --all-containers
@@ -156,10 +159,8 @@ sleep 5
 # /api/ping.
 kubectl wait --timeout=90s --for=condition=Ready pods -l app=conbench
 
-
 export CONBENCH_BASE_URL=$(minikube service conbench-service --url) && echo $CONBENCH_BASE_URL
 (cd "${CONBENCH_REPO_ROOT_DIR}" && make db-populate)
 
 sleep 10
 kubectl logs deployment/conbench-deployment --all-containers
-

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -11,18 +11,19 @@ set -o xtrace
 CONBENCH_REPO_ROOT_DIR="${CONBENCH_REPO_ROOT_DIR:=..}"
 echo "CONBENCH_REPO_ROOT_DIR: $CONBENCH_REPO_ROOT_DIR"
 
-# Design choice for this script here: assume that minikube cluster is running.
-# Show debug info.
+# Design choice for this script: assume that minikube cluster is running. Show
+# debug info.
 minikube config view
 minikube status
 
-# A small cleanup, for https://github.com/prometheus-operator/kube-prometheus
+# A small cleanup for https://github.com/prometheus-operator/kube-prometheus
+# Unclear if actually required.
 minikube addons disable metrics-server
 
 # postgres-operator vastly simplifies setting up PostgreSQL in minikube for us:
 # https://postgres-operator.readthedocs.io
 # Great docs: https://postgres-operator.readthedocs.io/en/latest/user/
-# Running ./run_operator_locally.sh effectively means installing this manifest:
+# Running ./run_operator_locally.sh means installing this manifest:
 # https://github.com/zalando/postgres-operator/blob/v1.9.0/manifests/minimal-postgres-manifest.yaml
 git clone https://github.com/zalando/postgres-operator
 pushd postgres-operator
@@ -44,20 +45,20 @@ pushd postgres-operator
     bash ./run_operator_locally.sh
 popd
 
-# Show what's running now.
+# debuggability. show what's running now.
 kubectl get pods -A
 
-# In the PostgreSQL cluster the user 'zalando' has superuser privileges. Can of
-# course rename that user if we'd like to, by modifying
+# In the PostgreSQL cluster the user 'zalando' has superuser privileges. We can
+# of course rename that user if we'd like to, by modifying
 # minimal-postgres-manifest.yaml. Get password:
 export POSTGRES_CONBENCH_USER_PASSWORD="$(kubectl get secret zalando.acid-minimal-cluster.credentials.postgresql.acid.zalan.do -o 'jsonpath={.data.password}' | base64 -d)"
-echo "password: ${POSTGRES_CONBENCH_USER_PASSWORD}"
+echo "db password: ${POSTGRES_CONBENCH_USER_PASSWORD}"
 
 # Set static non-sensitive configuration.
 kubectl apply -f ${CONBENCH_REPO_ROOT_DIR}/ci/minikube/conbench-config-for-minikube.yml
 
 # env var GITHUB_API_TOKEN is set in the context of a github action run.
-# Build dynamic sensitive configuration. If GITHUB_API_TOKEN is nto set then
+# Build dynamic sensitive configuration. If GITHUB_API_TOKEN is not set then
 # default to an empty string.
 cat << EOF > conbench-secrets-for-minikube.yml
 apiVersion: v1
@@ -97,12 +98,12 @@ popd
 # that's seemingly a very new concept in the k8s ecosystem:
 # https://github.com/kubernetes/kubernetes/issues/104737
 
-# show contents, inject into k8s
-cat conbench-secrets-for-minikube.yml
+# show contents (do not show api token), inject into k8s
+cat conbench-secrets-for-minikube.yml | grep -v TOKEN
 kubectl apply -f conbench-secrets-for-minikube.yml
 
-# Build container image and deploy Conbench into the k8s cluster. This uses a
-# makefile target, i.e. the repo's root dir needs to be the current working
+# Build container image and deploy Conbench into the k8s cluster. This uses
+# Makefile targets, i.e. the repo's root dir needs to be the current working
 # directory. Regardless in which current working directory we are right now; go
 # to that directory in a sub shell.
 (
@@ -111,53 +112,64 @@ kubectl apply -f conbench-secrets-for-minikube.yml
         make deploy-on-minikube
 )
 
-# Show what's running now.
+# The various `sleep`s below are also here to have less interleaved command
+# output in the GHA log viewer (the output created by set -o xtrace might
+# otherwise interleave with output from previously executed commands.
+
+# debuggability: show what's running now.
 kubectl get pods -A
 
 # At this point it's expected that the postgres stack still needs a tiny bit
 # of time before it's operational.
 # One could do
 #   kubectl wait --timeout=90s --for=condition=Ready pods acid-minimal-cluster-0
-# but Conbench has internal retrying upon DB connect error
+# but for now it seems this just works because Conbench has rather persistent]
+# internal retrying upon DB connect error.
 
-#sleep 20
-#kubectl logs deployment/conbench-deployment --all-containers
+# sleep 20
+# kubectl logs deployment/conbench-deployment --all-containers
 
 sleep 5
 kubectl get pods -A
 
-sleep 3
 # kubectl describe pods/prometheus-k8s-0 --namespace monitoring
 
-# Be sure that prometheus-operator pods are done with their setup.
+# Explicitly wait for this dependency.
+sleep 1
 kubectl wait --timeout=90s --for=condition=Ready \
     pods -l app.kubernetes.io/name=prometheus-operator -n monitoring
-
 
 # Be sure that the Prometheus instances managed by the prometheus operator are
 # ready (ready to scrape!). There are two instances. At the time of writing I
 # am not sure which of both is scraping Conbench. Just wait for the both of
 # them.
+sleep 1
 kubectl wait --timeout=90s --for=condition=Ready pods prometheus-k8s-0 -n monitoring
 
 # looks like prometheus-k8s-1 is precisely what does not start up on GHA
 # because of a resource shortage.
 # kubectl wait --timeout=90s --for=condition=Ready pods prometheus-k8s-1 -n monitoring
 
-sleep 5
+# sleep 1
 # kubectl logs deployment/conbench-deployment --all-containers
 
 sleep 5
 kubectl get pods -A
-sleep 5
 
 # Wait for the readiness check to succeed, which implies responsiveness to
 # /api/ping.
+sleep 1
 kubectl wait --timeout=90s --for=condition=Ready pods -l app=conbench
 
 #
 export CONBENCH_BASE_URL=$(minikube service conbench-service --url) && echo $CONBENCH_BASE_URL
 (cd "${CONBENCH_REPO_ROOT_DIR}" && make db-populate)
 
-sleep 10
-kubectl logs deployment/conbench-deployment --all-containers
+sleep 5
+
+kubectl logs deployment/conbench-deployment --all-containers > conbench_container_output.log
+# show in logs
+cat conbench_container_output.log
+
+# Require access log line confirming that the /metrics endpoint was hit.
+grep '"GET /metrics HTTP/1.1" 200' conbench_container_output.log

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -11,6 +11,8 @@ set -o xtrace
 # assume that minikube cluster is running. show config.
 minikube config view
 
+minikube status
+
 # for https://github.com/prometheus-operator/kube-prometheus
 minikube addons disable metrics-server
 

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -59,3 +59,16 @@ cat conbench-secrets-for-minikube.yml
 
 # inject into k8s
 kubectl apply -f conbench-secrets-for-minikube.yml
+
+make deploy-on-minikube
+
+# Show what's running now.
+kubectl get pods -A
+
+sleep 60
+
+kubectl logs deployment/conbench-deployment --all-containers
+
+export CONBENCH_BASE_URL=$(minikube service conbench-service --url) && echo $CONBENCH_BASE_URL
+
+make db-populate

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -166,10 +166,10 @@ export CONBENCH_BASE_URL=$(minikube service conbench-service --url) && echo $CON
 (cd "${CONBENCH_REPO_ROOT_DIR}" && make db-populate)
 
 sleep 5
-
 kubectl logs deployment/conbench-deployment --all-containers > conbench_container_output.log
 # show in logs
 cat conbench_container_output.log
 
 # Require access log line confirming that the /metrics endpoint was hit.
+sleep 2
 grep '"GET /metrics HTTP/1.1" 200' conbench_container_output.log

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -109,7 +109,11 @@ kubectl apply -f conbench-secrets-for-minikube.yml
 # makefile target, i.e. the repo's root dir needs to be the current working
 # directory. Regardless in which current working directory we are right now; go
 # to that directory in a sub shell.
-(cd "${CONBENCH_REPO_ROOT_DIR}" && make deploy-on-minikube)
+(
+    cd "${CONBENCH_REPO_ROOT_DIR}" && \
+        make build-conbench-container-image && \
+        make deploy-on-minikube
+)
 
 # Show what's running now.
 kubectl get pods -A

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o errtrace
+set -o nounset
+set -o pipefail
+
+# show commands
+set -o xtrace
+
+# This project vastly simplifies setting up PostgreSQL in minikube for us:
+# https://postgres-operator.readthedocs.io
+#
+# Great docs: https://postgres-operator.readthedocs.io/en/latest/user/
+#
+# Use this manifest by running ./run_operator_locally.sh
+# https://github.com/zalando/postgres-operator/blob/v1.9.0/manifests/minimal-postgres-manifest.yaml
+
+
+git clone https://github.com/zalando/postgres-operator
+cd postgres-operator
+# 1.9.0 release from 2023-01-30
+git checkout 30b612489a2a20d968262791857d1db1a85e0b36
+
+# This should tear down the current minikube, and re-spawn another
+# one, bootstrapping the postgres operator using
+# https://github.com/zalando/postgres-operator/blob/v1.9.0/manifests/minimal-postgres-manifest.yaml
+bash ./run_operator_locally.sh
+
+# Show what's running now.
+kubectl get pods -A
+
+# In the PostgreSQL cluster the user 'zalando' has superuser privileges. Can of
+# course rename that user if we'd like to, by modifying
+# minimal-postgres-manifest.yaml. Get password:
+export POSTGRES_CONBENCH_USER_PASSWORD="$(kubectl get secret zalando.acid-minimal-cluster.credentials.postgresql.acid.zalan.do -o 'jsonpath={.data.password}' | base64 -d)"
+echo "password: ${POSTGRES_CONBENCH_USER_PASSWORD}"
+
+# Set static non-sensitive configuration.
+kubectl apply -f ci/minikube/conbench-config-for-minikube.yml
+
+# Build dynamic sensitive configuration
+cat << EOF > conbench-secrets-for-minikube.yml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: conbench-secret
+type: Opaque
+# stringData: no base64 decoding
+stringData:
+  DB_PASSWORD: "${POSTGRES_CONBENCH_USER_PASSWORD}"
+  DB_USERNAME: "zalando"
+  GITHUB_API_TOKEN: "noo"
+  REGISTRATION_KEY: "innocent-registration-key"
+  SECRET_KEY: "not-actually-secret"
+EOF
+
+# show contents.
+cat conbench-secrets-for-minikube.yml
+
+# inject into k8s
+kubectl apply -f conbench-secrets-for-minikube.yml

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -24,6 +24,15 @@ git checkout 30b612489a2a20d968262791857d1db1a85e0b36
 # This should tear down the current minikube, and re-spawn another
 # one, bootstrapping the postgres operator using
 # https://github.com/zalando/postgres-operator/blob/v1.9.0/manifests/minimal-postgres-manifest.yaml
+
+# alchemy: the minikube cluster is already up and running as of a previous step
+# in github actions. Remove 'clean_up' and 'start_minikube' from
+# `run_operator_locally.sh`. Do this via line number deletion. In the original
+# file, delete line 256 and 256. That is safe, because a specific commit of
+# this file was checked out.
+cat ./run_operator_locally.sh | tail -n 15
+sed -i '256d;257d' file
+cat ./run_operator_locally.sh | tail -n 15
 bash ./run_operator_locally.sh
 popd
 

--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -64,9 +64,29 @@ def create_application(config):
 
     # Use `GunicornPrometheusMetrics` when spawning a separate HTTP server for
     # the metrics scrape endpoing. Note that this sets the global singleton.
+    # This needs PROMETHEUS_MULTIPROC_DIR to be set to a path to a directory.
+    #
+    _inspect_prom_multiproc_dir()
     metrics = GunicornInternalPrometheusMetrics(app)
 
     return app
+
+
+def _inspect_prom_multiproc_dir():
+    """
+    Log information about the environment variable PROMETHEUS_MULTIPROC_DIR
+    and about the path it points to. This is helpful for debugging bad state.
+    """
+    path = os.environ.get("PROMETHEUS_MULTIPROC_DIR")
+    log.info("env PROMETHEUS_MULTIPROC_DIR: `%s`", path)
+
+    if not path:
+        return
+
+    try:
+        log.info("os.path.isdir('%s'): %s", path, os.path.isdir(path))
+    except OSError as exc:
+        log.info("os.path.isdir('%s') failed: %s", path, exc)
 
 
 def _init_application(application):

--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -3,10 +3,7 @@ import json
 import logging
 import os
 
-from prometheus_flask_exporter.multiprocess import (
-    GunicornPrometheusMetrics,
-    GunicornInternalPrometheusMetrics,
-)
+from prometheus_flask_exporter.multiprocess import GunicornInternalPrometheusMetrics
 
 import conbench.logger
 
@@ -65,18 +62,9 @@ def create_application(config):
     else:
         log.info(log_cfg_msg)
 
-    # m = GunicornPrometheusMetrics(app)
-    m = GunicornInternalPrometheusMetrics(app)
-    m.info("app_info", "Application info", version="1.0.3")
-    metrics = m
-
-    metrics.register_default(
-        metrics.counter(
-            "by_path_counter",
-            "Request count by request paths",
-            labels={"path": lambda: f.request.path},
-        )
-    )
+    # Use `GunicornPrometheusMetrics` when spawning a separate HTTP server for
+    # the metrics scrape endpoing. Note that this sets the global singleton.
+    metrics = GunicornInternalPrometheusMetrics(app)
 
     return app
 

--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -65,7 +65,6 @@ def create_application(config):
     # Use `GunicornPrometheusMetrics` when spawning a separate HTTP server for
     # the metrics scrape endpoing. Note that this sets the global singleton.
     # This needs PROMETHEUS_MULTIPROC_DIR to be set to a path to a directory.
-    #
     _inspect_prom_multiproc_dir()
     metrics = GunicornInternalPrometheusMetrics(app)
 

--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -22,9 +22,7 @@ del importlib_metadata
 conbench.logger.setup(level_stderr="DEBUG", level_file=None, level_sqlalchemy="WARNING")
 log = logging.getLogger(__name__)
 
-
-print(f'value of PROMETHEUS_MULTIPROC_DIR: {os.environ["PROMETHEUS_MULTIPROC_DIR"]}')
-
+# This is going to be an application-global singleton
 metrics = None
 
 
@@ -211,6 +209,9 @@ def dict_or_objattrs_to_nonsensitive_string(obj):
     return json.dumps(sanitized, sort_keys=True, default=str, indent=2)
 
 
+# Note(JP): when FLASK_APP is set then this here is not executed, but instead
+# gunicorn loads into the app using a stringified import instruction such as
+# `conbench:application` (codified in the gunicorn cmd line args).
 # see .flaskenv used by `$ flask run`
 if os.environ.get("FLASK_APP", None):
     from .config import Config

--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -1,9 +1,22 @@
+"""
+Note: this module gets loaded both, when
+
+- invoking the (legacy) Conbench CLI
+- running the Conbench web application
+
+There should be cleaner separation of concerns in the future, and cleanly
+separate dependency considerations.
+
+Certain modules which are needed only in the web application can be imported
+in `create_application()` below.
+
+Also see https://github.com/conbench/conbench/pull/662#discussion_r1097781344
+"""
+
 import importlib.metadata as importlib_metadata
 import json
 import logging
 import os
-
-from prometheus_flask_exporter.multiprocess import GunicornInternalPrometheusMetrics
 
 import conbench.logger
 
@@ -20,13 +33,16 @@ del importlib_metadata
 conbench.logger.setup(level_stderr="DEBUG", level_file=None, level_sqlalchemy="WARNING")
 log = logging.getLogger(__name__)
 
-# This is going to be an application-global singleton
+# This is going to be an application-global singleton (in the webapp, not the
+# CLI).
 metrics = None
 
 
 def create_application(config):
     global metrics
+
     import flask as f
+    from prometheus_flask_exporter.multiprocess import GunicornInternalPrometheusMetrics
 
     app = f.Flask(__name__)
     app.config.from_object(config)

--- a/conbench/api/index.py
+++ b/conbench/api/index.py
@@ -99,7 +99,13 @@ class PingAPI(ApiEndpoint):
                 # do not query in TESTING mode.
                 alembic_version = list(Session.execute(query))[0]["version_num"]
             except Exception as exc:
-                log.info("cannot determine alembic schema version: %s", exc)
+                # Reduce noise: do not log full error, and also only on debug
+                # level.
+                if "psycopg2.errors.UndefinedTable" in str(exc):
+                    log.debug("cannot determine alembic schema version: UndefinedTable")
+                else:
+                    log.info("cannot determine alembic schema version: %s", exc)
+
                 alembic_version = "err"
 
         return {

--- a/conbench/db.py
+++ b/conbench/db.py
@@ -91,7 +91,7 @@ def log_after_retry_attempt(retry_state: tenacity.RetryCallState):
 # retrying strategy.
 @tenacity.retry(
     retry=tenacity.retry_if_exception_type(sqlalchemy.exc.OperationalError),
-    stop=tenacity.stop_after_attempt(10),
+    stop=tenacity.stop_after_attempt(50),
     wait=tenacity.wait_fixed(1),
     before=tenacity.before_log(log, logging.DEBUG),
     after=log_after_retry_attempt,

--- a/conbench/db.py
+++ b/conbench/db.py
@@ -105,10 +105,12 @@ def create_all():
     # prize.
     try:
         Base.metadata.create_all(engine)
-    except sqlalchemy.exc.IntegrityError as exc:
+    except (sqlalchemy.exc.IntegrityError, sqlalchemy.exc.ProgrammingError) as exc:
+        # Seen in the wild:
+        # sqlalchemy.exc.ProgrammingError: (psycopg2.errors.DuplicateTable) relation "user" already exists
         if "already exists" in str(exc):
             log.info(
-                "db.create_all(): ignore sqlalchemy.exc.IntegrityError. "
+                "db.create_all(): ignore exception with 'already exists' in msg. "
                 "Probably concurrent create_all() execution. Err: %s",
                 str(exc),
             )

--- a/conbench/gunicorn-conf.py
+++ b/conbench/gunicorn-conf.py
@@ -1,0 +1,26 @@
+# # https://github.com/prometheus/client_python#multiprocess-mode-eg-gunicorn
+# from prometheus_client import multiprocess
+
+
+# def worker_exit(server, worker):
+#     multiprocess.mark_process_dead(worker.pid)
+
+# then in the Gunicorn config file:
+# from prometheus_flask_exporter.multiprocess import GunicornPrometheusMetrics
+
+
+# def when_ready(server):
+#     GunicornPrometheusMetrics.start_http_server_when_ready(8000, "0.0.0.0")
+#     print(
+#         'done with: GunicornPrometheusMetrics.start_http_server_when_ready(8000, "0.0.0.0")'
+#     )
+
+
+# def child_exit(server, worker):
+#     GunicornPrometheusMetrics.mark_process_dead_on_child_exit(worker.pid)
+
+from prometheus_flask_exporter.multiprocess import GunicornInternalPrometheusMetrics
+
+
+def child_exit(server, worker):
+    GunicornInternalPrometheusMetrics.mark_process_dead_on_child_exit(worker.pid)

--- a/conbench/gunicorn-conf.py
+++ b/conbench/gunicorn-conf.py
@@ -1,23 +1,42 @@
-# # https://github.com/prometheus/client_python#multiprocess-mode-eg-gunicorn
-# from prometheus_client import multiprocess
+"""
+Relevant docs:
 
+- https://github.com/rycus86/prometheus_flask_exporter#wsgi
+- https://github.com/prometheus/client_python#multiprocess-mode-eg-gunicorn
 
-# def worker_exit(server, worker):
-#     multiprocess.mark_process_dead(worker.pid)
+Note(JP): prometheus_flask_exporter provides a useful quickstart, exposing
+relevant metrics around HTTP request handlers. It is however potentially a
+little too opionated. I have not yet looked into adding custom metrics (like a
+custom gauge, or counter).
 
-# then in the Gunicorn config file:
+I'd also like to add that the 'multiprocess complication' is not great to have
+in the system. I think that generally these limitations are fine:
+https://github.com/prometheus/client_python#multiprocess-mode-eg-gunicorn
+
+But the added complexity compared to a more canonical setup is maybe hurtful in
+the future.
+
+Yet, I believe this is a great starting point. Within the 'multiprocess
+complication' there is a choice to make: expose the /metrics HTTP endpoint in
+the same HTTP server that handles regular HTTP requests, or spawn a separate
+HTTP server for that? The latter has the advantage of separation of concerns
+(metrics can still be obtained in case of a dead-locked main HTTP server).
+Maybe the access log is a relevant criterion, too. I'd love to see an
+access log showing the requests to the /metrics endpoint.
+"""
+
+# What's outcommented is a method that can be used when running a separate
+# gunicorn HTTP server for serving the metrics endpoing.
+#
 # from prometheus_flask_exporter.multiprocess import GunicornPrometheusMetrics
-
-
 # def when_ready(server):
 #     GunicornPrometheusMetrics.start_http_server_when_ready(8000, "0.0.0.0")
 #     print(
 #         'done with: GunicornPrometheusMetrics.start_http_server_when_ready(8000, "0.0.0.0")'
 #     )
-
-
 # def child_exit(server, worker):
 #     GunicornPrometheusMetrics.mark_process_dead_on_child_exit(worker.pid)
+#
 
 from prometheus_flask_exporter.multiprocess import GunicornInternalPrometheusMetrics
 

--- a/conbench/gunicorn-conf.py
+++ b/conbench/gunicorn-conf.py
@@ -4,10 +4,10 @@ Relevant docs:
 - https://github.com/rycus86/prometheus_flask_exporter#wsgi
 - https://github.com/prometheus/client_python#multiprocess-mode-eg-gunicorn
 
-Note(JP): prometheus_flask_exporter provides a useful quickstart, exposing
-relevant metrics around HTTP request handlers. It is however potentially a
-little too opionated. I have not yet looked into adding custom metrics (like a
-custom gauge, or counter).
+prometheus_flask_exporter provides a useful quickstart, exposing relevant
+metrics around HTTP request handlers. It is however potentially a little too
+opinionated. I have not yet looked into adding custom metrics (like a custom
+gauge, or counter).
 
 I'd also like to add that the 'multiprocess complication' is not great to have
 in the system. I think that generally these limitations are fine:
@@ -21,8 +21,8 @@ complication' there is a choice to make: expose the /metrics HTTP endpoint in
 the same HTTP server that handles regular HTTP requests, or spawn a separate
 HTTP server for that? The latter has the advantage of separation of concerns
 (metrics can still be obtained in case of a dead-locked main HTTP server).
-Maybe the access log is a relevant criterion, too. I'd love to see an
-access log showing the requests to the /metrics endpoint.
+Maybe the access log is a relevant criterion, too. I'd love to see an access
+log showing the requests to the /metrics endpoint.
 """
 
 # What's outcommented is a method that can be used when running a separate

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,7 +13,7 @@ services:
       "conbench:application",
       "--access-logfile=-",
       "--error-logfile=-",
-      "--preload"
+      "--reload"
       ]
     volumes:
       # Left-hand path: relative to this compose file. Mount the directory

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,14 +7,17 @@ services:
     # to make this more robust
     command: [
       "gunicorn",
+      "-c", "conbench/gunicorn-conf.py",
       "-b", "0.0.0.0:5000",
       "-w", "2",
       "conbench:application",
       "--access-logfile=-",
       "--error-logfile=-",
-      "--reload"
+      "--preload"
       ]
     volumes:
       # Left-hand path: relative to this compose file. Mount the directory
       # that this compose file resided in as `/app` into the container.
       - .:/app
+      # mount in /tmp for debuggability
+      - /tmp:/tmp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
     volumes:
       - ${PWD}/conbench/tests/containers/dex/config.yml:/etc/dex/config.docker.yaml
     ports:
-      - "5556:5556"
+      - "127.0.0.1::5556"
 
   db:
     image: library/postgres:12.4
@@ -83,4 +83,4 @@ services:
       timeout: 5s
       retries: 5
     ports:
-      - "5432:5432"
+      - "127.0.0.1::5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,8 @@ services:
       # DCOMP_CONBENCH_HOST_PORT to e.g. 127.0.0.1:5000 (that tries to bind to
       # port 5000 on the host).
       - ${DCOMP_CONBENCH_HOST_PORT:-127.0.0.1:}:5000
-      - ${DCOMP_CONBENCH_METRICS_HOST_PORT:-127.0.0.1:}:8000
+      # Do this when introducing separate HTTP server for serving metrics.
+      # - ${DCOMP_CONBENCH_METRICS_HOST_PORT:-127.0.0.1:}:8000
     volumes:
       - ${PWD}/_conbench-coverage-dir:/etc/conbench-coverage-dir
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,7 @@ services:
           "-w", "5",
           "conbench:application",
           "--access-logfile=-",
-          "--error-logfile=-",
-          "--preload"
+          "--error-logfile=-"
           ]
     ports:
       # When using the default value `127.0.0.1::5000` (two colons) then the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,16 @@ services:
       # Note that currently this Dockerfile defines the image that' used for
       # Conbench production environments.
       dockerfile: Dockerfile
-    command: ["gunicorn", "-b", "0.0.0.0:5000", "-w", "5", "conbench:application", "--access-logfile=-", "--error-logfile=-", "--preload"]
+    command: [
+          "gunicorn",
+          "-c", "conbench/gunicorn-conf.py",
+          "-b", "0.0.0.0:5000",
+          "-w", "5",
+          "conbench:application",
+          "--access-logfile=-",
+          "--error-logfile=-",
+          "--preload"
+          ]
     ports:
       # When using the default value `127.0.0.1::5000` (two colons) then the
       # container-internal port 5000 will be dynamically mapped to a free port
@@ -17,6 +26,7 @@ services:
       # DCOMP_CONBENCH_HOST_PORT to e.g. 127.0.0.1:5000 (that tries to bind to
       # port 5000 on the host).
       - ${DCOMP_CONBENCH_HOST_PORT:-127.0.0.1:}:5000
+      - ${DCOMP_CONBENCH_METRICS_HOST_PORT:-127.0.0.1:}:8000
     volumes:
       - ${PWD}/_conbench-coverage-dir:/etc/conbench-coverage-dir
     depends_on:
@@ -47,6 +57,7 @@ services:
       CONBENCH_OIDC_ISSUER_URL: http://dex:5556/dex-for-conbench
       CONBENCH_INTENDED_BASE_URL: http://127.0.0.1:5000/
       GITHUB_API_TOKEN: $GITHUB_API_TOKEN
+      PROMETHEUS_MULTIPROC_DIR: "/tmp/_conbench-promcl-coord-dir"
     healthcheck:
       test: "curl -sfS http://0.0.0.0:5000/api/ping/"
       interval: 5s

--- a/requirements-webapp.txt
+++ b/requirements-webapp.txt
@@ -15,6 +15,7 @@ marshmallow
 numpy
 oauthlib
 openapi-spec-validator
+prometheus-flask-exporter
 psutil
 psycopg2-binary
 py-cpuinfo


### PR DESCRIPTION
This is supposed to implement the milestones 1, 2, 3 laid out roughly in https://github.com/conbench/conbench/issues/493#issuecomment-1413770175.

I'd like to write in more detail about what this patch is doing because code and code comments do not easily reveal the bigger picture.

This **instruments our web application with Prometheus metrics**. These metrics are exposed at the `/metrics` HTTP path of the gunicorn HTTP server that also serves the regular Flask app.

That metrics HTTP endpoint needs to be periodically pulled / "scraped" by Prometheus (in the Prometheus ecosystem, metrics are usually communicated in a pull paradigm, not a push paradigm), which then writes into its own time series database. Further below I describe how I chose to do that scraping.

I chose to use [prometheus_flask_exporter](https://github.com/rycus86/prometheus_flask_exporter) for now to get going quickly. It automatically records/measures traditional metrics around HTTP request handlers, providing insight into the health of a web application. For example: the duration required for building HTTP responses (histogram metric), the count of HTTP responses emitted with specific status codes (there's much more, this is just to give an impression).

This PR **introduces [minikube](https://minikube.sigs.k8s.io/docs/) to CI as a foundation to test k8s-specific parts of Conbench**. This allows for testing Conbench-related k8s YAML manifests in pull request CI (valuable because we embrace k8s as a/the recommended way to run Conbench, and we run it on k8s in prod ourselves). This PR introduces a CI check that after all runs Conbench on minikube and confirms that it works. 

That's really an implementation detail, but for running PostgreSQL on minikube next to Conbench I chose to use [postgres-operator](https://postgres-operator.readthedocs.io), to not spend time on configuring the stateful nature of running a DB on k8s. Great docs, this was a real time saver.

In production, on our k8s clusters running Conbench, I'd like for us to run [prometheus-operator/kube-prometheus](https://github.com/prometheus-operator/kube-prometheus) asap. Being able to roll this out with ~confidence soon is the main motivator for introducing minikube here in CI. prometheus-operator/kube-prometheus "just works", but it needs to be configured properly. The configuration surface is rather big. It's a mature and established project (boring tech, by now). It runs [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator), Grafana, Prometheus itself, [Alertmanager](https://prometheus.io/docs/alerting/latest/alertmanager/), and other proven components. All wired up for **generic k8s cluster system monitoring as well as for k8s application monitoring**. This provides a lot of value for free. I do not try to list all the value and use here. Two highlights though:
* Pre-built Grafana dashboards for per-node and per-container resource monitoring (CPU utilization etc). So far this has been a bit of a blind spot for our Conbench deployments.
* This automatically adds useful k8s metadata labels to metrics, i.e. one can for example precisely filter for the state of _one of many_ pods in a ReplicaSet. Example: `rate(flask_http_request_total{status="500", pod='conbench-deployment-79cc79bfbf-nzt54'}[2m])` shows the rate of HTTP responses with status code 500 emitted by _one specific pod_.

How does prometheus-operator/kube-prometheus know how and where to periodically scrape the /metrics HTTP endpoint served by Conbench containers? Prometheus Operator comes with custom resource definitions, one of which is the [ServiceMonitior](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.ServiceMonitor). This tells Prometheus Operator to use one of its managed Prometheus instances to start scraping a custom metrics endpoint.

An exaggerated perspective is that after introducing `prometheus_flask_exporter` and  `prometheus-operator/kube-prometheus` the only code required to connect the pieces together is this:

```yaml
# This is a CRD defined by the prometheus-operator/kube-prometheus project
kind: ServiceMonitor
metadata:
  name: conbench-service-monitor
spec:
  selector:
    matchLabels:
      app: conbench
  endpoints:
    # It's important that ServiceMonitor i) refers to a Service port  and ii)
    # refers to it via its name.
    - port: conbench-service-port
      path: /metrics
      scheme: http
      # This defines the time resolution.
      interval: 30s
```

The new CI check introduced in this PR deploys all mentioned components on minikube and then confirms that
- Conbench comes up health in the k8s cluster (can interact with DB, etc)
- Conbench's `/metrics` endpoint indeed gets scraped.

Areas of friction / limitations:

* This new CI check adds quite a bit of complexity and therefore new failure paths. There is a lot of "fetch from remote" and "wait until ready", and quite a bit of coordination happening. Plenty of room for new instabilities to pop up. We will iron those out over time.
* The `/metrics` endpoint is now served by the same gunicorn HTTP server that also serves the regular web application logic. That's nice and simple initially, but we might want to change that later.
* I have for now embraced the fact that we run gunicorn with process workers -- resulting in the "multiprocess challenge" where Prometheus client metrics need to be coordinated between processes -- that coordination happens through the file system. You see `PROMETHEUS_MULTIPROC_DIR` pop up here and there in the code, that's related to this topic. In the future this complexity can disappear I hope. It's totally fine for now.
* The new CI check took ~5-7 minutes, and is therefore for now the dominating check in terms of duration. I am pretty sure it can be sped up by doing smarter coordination / concurrent deployment. The GitHub Action that I picked for running minikube itself consumes between 1 and 2 minutes. That was a bit surprising.

More work is required before we can take advantage of all this in prod. The rough plan forward from here is laid out in https://github.com/conbench/conbench/issues/493#issuecomment-1413770175, milestones 4 and onwards.

-----

Quick architecture summary in terms of information flow. This is really basic stuff, but when I learned about the Prometheus ecosystem I wish someone had explained the simple things:

### Creating metrics, writing metrics to time series DB (the write path)

- Web app code continuously updates its internal metrics state (increases counters, etc). It's always doing that.
- A scraping Prometheus instances periodically scrapes /metrics to get a _current snapshot_ (current state of all counters, gauges, etc). It knows when it does that. It persists that current state (timestamp, and all those metrics) into its internal time series database. The time resolution is only ever as big as the scrape interval allows. The scrape interval is typically 30 s or 60 s. That is, one can typically say "the mean incoming HTTP request rate in this 30 s time window was ...". That's usually sufficient!

### Reading metrics for dashboarding, alerting etc (the read path)

- Grafana has the concept of "data sources". Prometheus can be configured as a data source for Grafana. The Grafana UI can be used to explore the contents of a Prometheus time series database. It can be used to construct queries, and it can be used to build dashboards. And of course it can be used to display dashboards that were built before.

Happy to also give a tiny presentation to go through the architecture.

