### PR TITLE
Dockerfile: work on image size and cacheability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.11-slim
 
 # Curl is needed for docker-compose health checks.
-RUN apk add --update curl &&  rm -rf /var/cache/apk/*
+RUN apt-get update && apt-get install -y -q --no-install-recommends \
+    curl && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY requirements-webapp.txt /tmp/
 COPY requirements-dev.txt /tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ WORKDIR /app
 # to make most use of Docker container image layer caching.
 COPY conbench /app/conbench
 COPY migrations /app/migrations
+# TODO: make it so that .git is not needed
+# see https://github.com/conbench/conbench/pull/667
+COPY .git /app/.git
 COPY setup.py README.md requirements-cli.txt requirements-webapp.txt requirements-dev.txt alembic.ini /app/
 
 # Inspect contents of /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.11-slim
 
+# Curl is needed for docker-compose health checks.
+RUN apk add --update curl &&  rm -rf /var/cache/apk/*
+
 COPY requirements-webapp.txt /tmp/
 COPY requirements-dev.txt /tmp/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM python:3.11-slim
 
 # Curl is needed for docker-compose health checks.
+# and `git` is seemingly needed by some unit tests
 RUN apt-get update && apt-get install -y -q --no-install-recommends \
-    curl && apt-get clean && rm -rf /var/lib/apt/lists/*
+    curl git && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY requirements-webapp.txt /tmp/
 COPY requirements-dev.txt /tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
 FROM python:3.11-slim
 
-# Curl is needed for docker-compose health checks.
-# and `git` is seemingly needed by some unit tests
+# curl is needed for docker-compose health checks. `git` is needed by some unit
+# tests as of today.
 RUN apt-get update && apt-get install -y -q --no-install-recommends \
     curl git && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY requirements-webapp.txt /tmp/
 COPY requirements-dev.txt /tmp/
 
-# Delete pip cache in same image layer.
 RUN pip install -r /tmp/requirements-webapp.txt && \
     pip install -r /tmp/requirements-dev.txt && \
     rm -rf ./root/.cache
@@ -18,13 +17,13 @@ RUN pip install -r /tmp/requirements-webapp.txt && \
 # currently also being used to run CI tasks. For production, it's important
 # that the `app` directory is baked in, containing current Conbench code. For
 # local development, /app may be overridden to be a volume-mount.
-
 WORKDIR /app
 
 # Only copy in the files that are required (instead of the entire repo root),
-# to make most use of Docker container image layer caching.
+# to make more use of Docker container image layer caching.
 COPY conbench /app/conbench
 COPY migrations /app/migrations
+
 # TODO: make it so that .git is not needed
 # see https://github.com/conbench/conbench/pull/667
 COPY .git /app/.git
@@ -35,10 +34,10 @@ RUN pwd && /bin/ls -1 .
 
 # Installing this package as of now is necessary not for installing
 # dependencies, but for preventing:
-# Answer: otherwise this happens:
 # importlib.metadata.PackageNotFoundError: No package metadata was found for conbench
 RUN pip install .
 
+# Re-active this to get ideas for how the image size can be further reduced.
 #RUN echo "biggest dirs"
 #RUN cd / && du -ha . | sort -r -h | head -n 50 || true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ WORKDIR /app
 # Only copy in the files that are required (instead of the entire repo root),
 # to make most use of Docker container image layer caching.
 COPY conbench /app/conbench
+COPY migrations /app/migrations
 COPY setup.py README.md requirements-cli.txt requirements-webapp.txt requirements-dev.txt alembic.ini /app/
 
 # Inspect contents of /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /app
 # Only copy in the files that are required (instead of the entire repo root),
 # to make most use of Docker container image layer caching.
 COPY conbench /app/conbench
-COPY setup.py README.md requirements-cli.txt requirements-webapp.txt requirements-dev.txt /app/
+COPY setup.py README.md requirements-cli.txt requirements-webapp.txt requirements-dev.txt alembic.ini /app/
 
 # Inspect contents of /app
 RUN pwd && /bin/ls -1 .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,35 @@
-FROM python:3.11
+FROM python:3.11-slim
 
 COPY requirements-webapp.txt /tmp/
 COPY requirements-dev.txt /tmp/
-RUN pip install -r /tmp/requirements-webapp.txt
-RUN pip install -r /tmp/requirements-dev.txt
+
+# Delete pip cache in same image layer.
+RUN pip install -r /tmp/requirements-webapp.txt && \
+    pip install -r /tmp/requirements-dev.txt && \
+    rm -rf ./root/.cache
 
 # This Dockerfile currently defines the image used for production environments.
 # It also contains all test dependencies and most CI dependencies because it's
 # currently also being used to run CI tasks. For production, it's important
 # that the `app` directory is baked in, containing current Conbench code. For
 # local development, /app may be overridden to be a volume-mount.
+
 WORKDIR /app
-ADD . /app
+
+# Only copy in the files that are required (instead of the entire repo root),
+# to make most use of Docker container image layer caching.
+COPY conbench /app/conbench
+COPY setup.py README.md requirements-cli.txt requirements-webapp.txt requirements-dev.txt /app/
+
+# Inspect contents of /app
+RUN pwd && /bin/ls -1 .
+
+# Installing this package as of now is necessary not for installing
+# dependencies, but for preventing:
+# Answer: otherwise this happens:
+# importlib.metadata.PackageNotFoundError: No package metadata was found for conbench
 RUN pip install .
+
+#RUN echo "biggest dirs"
+#RUN cd / && du -ha . | sort -r -h | head -n 50 || true
+

--- a/conbench/tests/benchmark/test_runner.py
+++ b/conbench/tests/benchmark/test_runner.py
@@ -1,4 +1,5 @@
 import copy
+import os
 
 import pytest
 
@@ -11,6 +12,13 @@ from ._example_benchmarks import (
     SimpleBenchmark,
     SimpleBenchmarkThatFails,
     SimpleBenchmarkWithClusterInfo,
+)
+
+# this makes an implicit dependency become an explicit one, to save time
+# debugging test failures.
+assert os.path.exists(".git"), (
+    "expecting .git in current working directory, see "
+    "https://github.com/conbench/conbench/issues/668"
 )
 
 pytestmark = pytest.mark.filterwarnings("ignore::conbench.machine_info.GitParseWarning")


### PR DESCRIPTION
Breaking this out of https://github.com/conbench/conbench/pull/662.

This reduces the container image size:

before:
```
docker images --format "{{.Size}}" conbench/conbench:5a05aff71-dev 
1.49GB
```

after:
```
docker images --format "{{.Size}}" conbench/conbench:5a05aff71-dev
594MB
```

And, maybe even more importantly, it does not try to add the repo root directory content entirely into the image. This resulted in cache invalidation during local dev in many cases when it wasn't needed.

Why is this valuable for #662? There we use `minikube image load` to make a Docker image available in the k8s cluster. This command is slow, and the time it takes is linearly related to image size. The container image size reduction in this PR wins ~1 min!