### PR TITLE
gha: use personal token (issue 660)

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -7,7 +7,11 @@ on:
   pull_request:
 
 env:
-  GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # secrets.GITHUB_TOKEN is provided by GitHub Actions and not
+  # bound to a personal user account. It allows for 1000 
+  # GitHub HTTP API requests per hour. A personal token
+  # allows for 5000 of those.
+  GITHUB_API_TOKEN: ${{ secrets.PERSONAL_GITHUB_API_TOKEN }}
 
 jobs:
   lint:

--- a/.github/workflows/auto-assign-issues-prs.yml
+++ b/.github/workflows/auto-assign-issues-prs.yml
@@ -4,7 +4,11 @@ on:
     types: [opened, reopened, edited]
 
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # secrets.GITHUB_TOKEN is provided by GitHub Actions and not
+  # bound to a personal user account. It allows for 1000
+  # GitHub HTTP API requests per hour. A personal token
+  # allows for 5000 of those.
+  GITHUB_API_TOKEN: ${{ secrets.PERSONAL_GITHUB_API_TOKEN }}
 
 jobs:
   assign-issue-and-pr-author:
@@ -40,4 +44,3 @@ jobs:
           echo '${{ steps.get_linked_issue.outputs.data }}' | \
           jq -c '.. | objects | select(has("edges")) | .edges | .[].node.number' | \
           xargs -I{} gh api repos/voltrondata/perfengtools/issues/{}/assignees -f assignees="${{ github.event.pull_request.user.login }}"
-


### PR DESCRIPTION
This is an attempt to make #660 less problematic for now. It's my personal access token, created for this purpose here. It has 'read' privileges for "Contents" (https://docs.github.com/en/rest/overview/permissions-required-for-fine-grained-personal-access-tokens?apiVersion=2022-11-28#contents). 

Let's see if this works at all.

update: the token expires in ~1 year.