### PR TITLE
Makefile: test-run-app-dev: emit logs on error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,11 +92,12 @@ run-app-bg:
 # This is here for the purpose of testing most of `run-app-dev` in CI. A copy
 # of `run-app-dev` but not requiring a specific port on the host, and using
 # --wait and --detach. That means that `docker compose up...` will return with
-# exit code 0 once the app appears to be healthy. At this point we can run
-# the teardown which is also expected to return with code 0.
+# exit code 0 once the app appears to be healthy. At this point we can run the
+# teardown which is also expected to return with code 0. If the `up` command
+# fails then emit container logs before fast-failing the makefile target.
 .PHONY: test-run-app-dev
 test-run-app-dev:
 	docker compose down
 	docker compose -f docker-compose.yml -f docker-compose.dev.yml \
-		up --build --wait --detach
+		up --build --wait --detach || (docker compose logs --since 30m; exit 1)
 	docker compose down


### PR DESCRIPTION
Important for debuggability. 

Otherwise all we see is
```
Container conbench-db-1  Healthy
container for service "app" exited (1)
make: *** [Makefile:101: test-run-app-dev] Error 1
Error: Process completed with exit code 2.
```
Example: https://github.com/conbench/conbench/actions/runs/4091904407/jobs/7056284732#step:8:96