### PR TITLE
ci: use secrets.GITHUB_TOKEN again for auto-assign

### DIFF
--- a/.github/workflows/auto-assign-issues-prs.yml
+++ b/.github/workflows/auto-assign-issues-prs.yml
@@ -4,11 +4,9 @@ on:
     types: [opened, reopened, edited]
 
 env:
-  # secrets.GITHUB_TOKEN is provided by GitHub Actions and not
-  # bound to a personal user account. It allows for 1000
-  # GitHub HTTP API requests per hour. A personal token
-  # allows for 5000 of those.
-  GITHUB_API_TOKEN: ${{ secrets.PERSONAL_GITHUB_API_TOKEN }}
+  # secrets.GITHUB_TOKEN is provided by GitHub Actions.
+  # It allows for 1000 GitHub HTTP API requests per hour.
+  GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_API_TOKEN }}
 
 jobs:
   assign-issue-and-pr-author:

--- a/.github/workflows/auto-assign-issues-prs.yml
+++ b/.github/workflows/auto-assign-issues-prs.yml
@@ -6,7 +6,7 @@ on:
 env:
   # secrets.GITHUB_TOKEN is provided by GitHub Actions.
   # It allows for 1000 GitHub HTTP API requests per hour.
-  GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_API_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   assign-issue-and-pr-author:


### PR DESCRIPTION
This primarily fixes #673.

Could have done
```
GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_API_TOKEN }}
```

But that fails with
```
> owner: conbench
> repo: conbench
> pr_number: 674
Error: Personal access tokens with fine grained access do not support the GraphQL API
```

And I think it makes sense to use `secrets.GITHUB_TOKEN` again here so that we have two separate quota pools in CI. That has the advantage that this task will continue to work fine in the event when we exhaust the 5000 hourly requests associated with `secrets.PERSONAL_GITHUB_API_TOKEN`.