### PR TITLE
README: clearer Makefile target docs, some clarifications and corrections, Makefile cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ db-populate:
 # This is used by CI for running the test suite. Documentation should encourage
 # developers to run this command locally, too.
 .PHONY: tests
-tests:
+tests: require-env-ghtoken
 	docker compose down --remove-orphans && \
 	docker compose build app && \
 	docker compose run \
@@ -86,6 +86,11 @@ lint-ci:
 	black --check --diff .
 	mypy conbench
 
+
+require-env-ghtoken:
+ifndef GITHUB_API_TOKEN
+	$(error the environment variable GITHUB_API_TOKEN must be set)
+endif
 
 
 .PHONY: run-app-bg

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-# Note(JP): we will have to figure out which of these targets will transition
-# to be 'public interface', i.e. used by developers. Those should only
-# conservatively be changed (in terms of naming and behavior). Other Makefile
-# targets might be considered 'private interface', to make things in CI simpler
-# -- those targets can change at will, often and brutally (their names, their
-# meaning, and their implementation)
+# Note(JP): we try to distinguish targets that are 'public interface' (i.e.
+# commonly used by developers) from targets that are 'private interface' (used
+# by CI, very rarely used by humans). 'public interface' targets should only
+# conservatively be changed (with conscious iteration on naming and behavior).
+# The other targets can change often and brutally (their names, their meaning,
+# and their implementation).
 
 # The use case that this target mainly has in mind: starting the application
 # locally to play around with this. This is not primarily meant for
@@ -61,15 +61,6 @@ lint:
 	mypy conbench
 
 
-# Run by CI, these commands should not modify files, but only check compliance.
-.PHONY: lint-ci
-lint-ci:
-	flake8
-	isort --check .
-	black --check --diff .
-	mypy conbench
-
-
 .PHONY: rebuild-expected-api-docs
 rebuild-expected-api-docs: run-app-bg
 	echo "using $(shell docker compose port app 5000) to reach app"
@@ -82,6 +73,19 @@ rebuild-expected-api-docs: run-app-bg
 	mv -f _new_api_docs.py ./conbench/tests/api/_expected_docs.py
 	rm _new_api_docs.json
 	git diff ./conbench/tests/api/_expected_docs.py
+
+# The targets above this comment have been in use by humans. Change
+# conservatively.
+
+
+# Run by CI, these commands should not modify files, but only check compliance.
+.PHONY: lint-ci
+lint-ci:
+	flake8
+	isort --check .
+	black --check --diff .
+	mypy conbench
+
 
 
 .PHONY: run-app-bg

--- a/README.md
+++ b/README.md
@@ -61,8 +61,10 @@ repository, and the results are hosted on the
 
 ## Developer environment
 
+### Dependencies
 
-### Developer environment
+- [`make`](https://www.gnu.org/software/make/), [`docker compose`](https://docs.docker.com/compose/install/): common developer tasks depend on these tools. They need to be set up on your system.
+- `GITHUB_API_TOKEN` environment variable: set up a GitHub API token using [GitHub's instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). It's recommended to only give the token read-only permissions to public repositories (which is the default for fine-grained personal access tokens). Run `export GITHUB_API_TOKEN="token"` in your current shell.
 
 Common developer workflows are simplified using `make` and `docker compose`.
 These need to be set up in your environment.

--- a/README.md
+++ b/README.md
@@ -66,42 +66,27 @@ repository, and the results are hosted on the
 - [`make`](https://www.gnu.org/software/make/), [`docker compose`](https://docs.docker.com/compose/install/): common developer tasks depend on these tools. They need to be set up on your system.
 - `GITHUB_API_TOKEN` environment variable: set up a GitHub API token using [GitHub's instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). It's recommended to only give the token read-only permissions to public repositories (which is the default for fine-grained personal access tokens). Run `export GITHUB_API_TOKEN="token"` in your current shell.
 
-### `make` targets
+### Makefile targets
 
-The following Makefile targets assume to be run in the root folder of a local repository clone.
+The following Makefile targets implement common developer tasks. They assume to be run in the root folder of the repository.
 
-#### `make run-app`
-
-This command lets you experiment with Conbench locally.
+* `make run-app`: This command lets you experiment with Conbench locally.
 It runs the stack in a containerized fashion.
 It rebuilds container images from the current checkout, spawns
-multiple containers (including one for PostgreSQL), and then exposes Conbench's
+multiple containers (including one for the database), and then exposes Conbench's
 HTTP server on the host at http://127.0.0.1:5000.
-
-`make run-app` will stay in the foreground of your terminal, showing log output of all containers.
-
-Once you see access log lines like `GET /api/ping/ HTTP/1.1" 200` in the log output you can point your browser to http://127.0.0.1:5000.
-
-You can use `Ctrl+C` to terminate the containerized stack.
-Note that this only stops containers, and the next invocation of `make run-app` will use previous database state.
-
-Invoke `make teardown-app` to stop and remove containers.
-
+The command will stay in the foreground of your terminal, showing log output of all containers.
+Once you see access log lines like `GET /api/ping/ HTTP/1.1" 200` you can point your browser to http://127.0.0.1:5000.
+You can use `Ctrl+C` to terminate the containerized stack (this only stops containers, and the next invocation of `make run-app` will use previous database state -- invoke `make teardown-app` to stop and remove containers).
 If you wish to clear all database tables during local development you can hit http://127.0.0.1:5000/api/wipe-db with the browser or with e.g. curl.
 
-#### `make run-app-dev`
-
-Similar to `make run-app`, but also mounts the repository's root directory into the container.
+* `make run-app-dev`: Similar to `make run-app`, but also mounts the repository's root directory into the container.
 Code changes are (should be) detected automatically and result in automatic code reload.
 
-#### `make tests`
-
-The nobrainer command to run the test suite just like CI does.
+* `make tests`:The nobrainer command to run the test suite just like CI does.
 For more fine-grained control see further below.
 
-#### `make lint`
-
-Performs invasive code linting in your local checkout.
+* `make lint`: Performs invasive code linting in your local checkout.
 May modify files. Analogue to what CI requires.
 It requires for some commands to be available in your current shell.
 Dependencies can be installed with `pip install -r requirements-dev.txt`.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ repository, and the results are hosted on the
 ### Dependencies
 
 - [`make`](https://www.gnu.org/software/make/), [`docker compose`](https://docs.docker.com/compose/install/): common developer tasks depend on these tools. They need to be set up on your system.
-- `GITHUB_API_TOKEN` environment variable: set up a GitHub API token using [GitHub's instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). It's recommended to only give the token read-only permissions to public repositories (which is the default for fine-grained personal access tokens). Run `export GITHUB_API_TOKEN="token"` in your current shell.
+- `GITHUB_API_TOKEN` environment variable: set up a GitHub API token using [GitHub's instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). It's recommended to only give the token read-only permissions to public repositories (which is the default for fine-grained personal access tokens). Run `export GITHUB_API_TOKEN="{token}"` in your current shell.
 
 ### Makefile targets
 

--- a/README.md
+++ b/README.md
@@ -114,23 +114,28 @@ Point your browser to http://127.0.0.1:5000/api/docs/.
 
 CI and common developer commands use containerized workflows where dependencies are defined and easy to reason about via `Dockerfile`s.
 
-Some developer tasks however involve running Conbench tooling straight on the host.
+Note that the CPython version that Conbench is tested with in CI and that it is recommended to be deployed with is currently the latest 3.11.x release, as also defined in `Dockerfile` at the root of this repository.
 
-Here is how to install Python dependencies:
+Some developer tasks may involve running Conbench tooling straight on the host.
+Here is how to install the Python dependencies for the Conbench web application:
 
 ```bash
-pip install conbench[dev]
+pip install -r requirements-webapp.txt
 ```
 
-Note that the CPython version that Conbench is tested with in CI and that it is recommended to be deployed with is currently the latest 3.10.x release, as also defined in `Dockerfile` at the root of this repository.
+Dependencies for running code analysis and tests straight on the host can be installed with
 
-Other install options:
+```bash
+pip install -r requirements-dev.txt
+```
 
-* `pip install conbench`: installs CLI dependencies
-* `pip install conbench[server]`: installs CLI and server dependencies
-* `pip install conbench[dev]`: ` installs CLI, server, and testing/CI dependencies
+Dependencies for the (legacy) `conbench` CLI can be installed with
 
-#### Fine-grained test invocation
+```bash
+pip install -r requirements-cli.txt
+```
+
+### Fine-grained test invocation
 
 If `make test` is too coarse-grained, then this is how to take control of the containerized `pytest` test runner:
 

--- a/README.md
+++ b/README.md
@@ -154,31 +154,11 @@ Useful command line arguments for local development (can be combined as desired)
 * `... pytest -s`: do not swallow log output during run
 * `... run -e CONBENCH_LOG_LEVEL_STDERR=DEBUG app ...`
 
-#### Legacy commands
+### Legacy commands
 
 The following commands are not guaranteed to work as documented, but provide valuable inspiration:
 
-##### Generate coverage report
-
-    (conbench) $ coverage run --source conbench -m pytest conbench/tests/
-    (conbench) $ coverage report -m
-
-##### Test migrations with the database running using brew
-
-    (conbench) $ brew services start postgres
-    (conbench) $ dropdb conbench_prod
-    (conbench) $ createdb conbench_prod
-    (conbench) $ alembic upgrade head
-
-##### Test migrations with the database running as a docker container
-
-    (conbench) $ brew services stop postgres
-    (conbench) $ docker compose down
-    (conbench) $ docker compose build
-    (conbench) $ docker compose run migration
-
-
-##### To autogenerate a migration
+#### To autogenerate a migration
 
     (conbench) $ brew services start postgres
     (conbench) $ dropdb conbench_prod
@@ -189,7 +169,7 @@ The following commands are not guaranteed to work as documented, but provide val
     (conbench) $ alembic revision --autogenerate -m "new"
 
 
-##### To populate local conbench with sample runs and benchmarks
+#### To populate local conbench with sample runs and benchmarks
 
 1. Start conbench app in Terminal window 1:
 

--- a/README.md
+++ b/README.md
@@ -196,9 +196,9 @@ The following commands are not guaranteed to work as documented, but provide val
 
 New version of conbench package will be uploaded into PyPI by a new build for [conbench-deploy](.buildkite/conbench-deploy/pipeline.yml) Buildkite pipeline
 
-## Configuring the server
+## Configuring the web application
 
-The conbench server can be configured with various environment variables as
+The conbench web application can be configured with various environment variables as
 defined in [config.py](./conbench/config.py). Instructions are in that file.
 
 ## Creating accounts

--- a/README.md
+++ b/README.md
@@ -66,16 +66,13 @@ repository, and the results are hosted on the
 - [`make`](https://www.gnu.org/software/make/), [`docker compose`](https://docs.docker.com/compose/install/): common developer tasks depend on these tools. They need to be set up on your system.
 - `GITHUB_API_TOKEN` environment variable: set up a GitHub API token using [GitHub's instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). It's recommended to only give the token read-only permissions to public repositories (which is the default for fine-grained personal access tokens). Run `export GITHUB_API_TOKEN="token"` in your current shell.
 
-Common developer workflows are simplified using `make` and `docker compose`.
-These need to be set up in your environment.
+### `make` targets
 
-The following `make` commands assume to be run in the root folder of a local repository clone.
+The following Makefile targets assume to be run in the root folder of a local repository clone.
 
-Before using these commands, set up a GitHub API token using [GitHub's instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). It's recommended to only give the token read-only permissions to public repositories (which is the default for fine-grained personal access tokens). Set the `GITHUB_API_TOKEN` environment variable to that token value. If you do not have the token set, certain behaviors may not function correctly.
+#### `make run-app`
 
-#### Start application
-
-`make run-app` is a simple way to start and experiment with Conbench locally.
+This command lets you experiment with Conbench locally.
 It runs the stack in a containerized fashion.
 It rebuilds container images from the current checkout, spawns
 multiple containers (including one for PostgreSQL), and then exposes Conbench's
@@ -92,21 +89,28 @@ Invoke `make teardown-app` to stop and remove containers.
 
 If you wish to clear all database tables during local development you can hit http://127.0.0.1:5000/api/wipe-db with the browser or with e.g. curl.
 
-#### View API documentation
+#### `make run-app-dev`
+
+Similar to `make run-app`, but also mounts the repository's root directory into the container.
+Code changes are (should be) detected automatically and result in automatic code reload.
+
+#### `make tests`
+
+The nobrainer command to run the test suite just like CI does.
+For more fine-grained control see further below.
+
+#### `make lint`
+
+Performs invasive code linting in your local checkout.
+May modify files. Analogue to what CI requires.
+It requires for some commands to be available in your current shell.
+Dependencies can be installed with `pip install -r requirements-dev.txt`.
+
+### View API documentation
 
 Point your browser to http://127.0.0.1:5000/api/docs/.
 
-#### Run test suite
-
-`make tests` is the nobrainer command to run the entire test suite just like CI does.
-For more fine-grained control see further below.
-
-#### Lint codebase
-
-`make lint` performs invasive code linting in your local checkout (it may modify files), analogue to what CI requires.
-It requires for some commands to be available (`flake8`, `black`, `isort`).
-
-#### Python environment on the host
+### Python environment on the host
 
 CI and common developer commands use containerized workflows where dependencies are defined and easy to reason about via `Dockerfile`s.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ repository, and the results are hosted on the
 
 ## Index
 
-* [Contributing](https://github.com/conbench/conbench#contributing)
+* [Developer environment](https://github.com/conbench/conbench#developer-environment)
 * [Configuring the server](https://github.com/conbench/conbench#configuring-the-server)
 * [Creating accounts](https://github.com/conbench/conbench#creating-accounts)
 * [Authoring benchmarks](https://github.com/conbench/conbench#authoring-benchmarks)
@@ -59,7 +59,7 @@ repository, and the results are hosted on the
   * [R benchmarks](https://github.com/conbench/conbench#example-r-benchmarks)
 
 
-## Contributing
+## Developer environment
 
 
 ### Developer environment


### PR DESCRIPTION
Adds a bit of clarity/precision to README:
- enumeration of dependencies.
- enumeration of makefile targets (also shows `run-app-dev` which was so far not documented)
- uses somwhat clearer captions

A screenshot showing the captions and enumeration:

![image](https://user-images.githubusercontent.com/265630/216944933-da9bd45b-8cb4-4c8f-9da7-3f4a44c20d90.png)

Also makes GITHUB_API_TOKEN a hard dependency for now for `make tests` to enhance clarity / remove ambiguity for new contributors.

There are a few more smaller changes in this PR, also see commit msgs.
