### PR TITLE
[benchadapt] GoogleBenchmarkAdapter: Put gbench_context in optional_benchmark_info

### DIFF
--- a/benchadapt/python/benchadapt/adapters/gbench.py
+++ b/benchadapt/python/benchadapt/adapters/gbench.py
@@ -181,7 +181,17 @@ class GoogleBenchmarkAdapter(BenchmarkAdapter):
 
     @staticmethod
     def _parse_gbench_json(raw_json: dict) -> Tuple[dict, list]:
-        """Parse gbench result json into a context dict and a list of grouped benchmarks"""
+        """
+        Parse gbench result json into a context dict and a list of grouped benchmarks
+
+        See https://github.com/google/benchmark/blob/main/docs/user_guide.md#output-formats
+        for a (very minimal!) example of gbench output json. This method splits out
+        the `context` attribute, which "contains information about the run in general,
+        including information about the CPU and the date" from the `benchmarks` one, which
+        contains a dict for all benchmarks in the run.
+
+        Aggregate benchmarks are excluded, as they are duplicative of the raw benchmarks.
+        """
         gbench_context = raw_json.get("context")
 
         # Follow archery approach in ignoring aggregate results

--- a/benchadapt/python/benchadapt/adapters/gbench.py
+++ b/benchadapt/python/benchadapt/adapters/gbench.py
@@ -166,7 +166,6 @@ class GoogleBenchmarkAdapter(BenchmarkAdapter):
         # all results share a batch id
         batch_id = uuid.uuid4().hex
         gbench_context, benchmark_groups = self._parse_gbench_json(results)
-        extra_tags["gbench_context"] = gbench_context
 
         parsed_results = []
         for benchmark in benchmark_groups:
@@ -175,6 +174,7 @@ class GoogleBenchmarkAdapter(BenchmarkAdapter):
                 batch_id=batch_id,
                 extra_tags=extra_tags,
             )
+            result_parsed.optional_benchmark_info = {"gbench_context": gbench_context}
             parsed_results.append(result_parsed)
 
         return parsed_results

--- a/benchadapt/python/tests/adapters/test_gbench.py
+++ b/benchadapt/python/tests/adapters/test_gbench.py
@@ -223,6 +223,7 @@ class TestGbenchAdapter:
             assert "params" in result.tags
             assert result.machine_info is not None
             assert result.stats["iterations"] == 3
+            assert "gbench_context" in result.optional_benchmark_info
 
     def test_run(self, gbench_adapter) -> None:
         results = gbench_adapter.run()


### PR DESCRIPTION
Closes #686 by moving `gbench_context` in `benchadapt.adapter.GoogleBenchmarkAdapter` results from `tags` (where it was breaking history) to `optional_benchmark_info`, so it's still there if you want it, but not breaking anything.