### PR TITLE
webapp: increase worker timeout, fix KeyError

### DIFF
--- a/conbench/app/compare.py
+++ b/conbench/app/compare.py
@@ -72,7 +72,8 @@ class Compare(AppEndpoint, BenchmarkMixin, RunMixin, TimeSeriesPlotMixin):
                 augment(benchmark)
             outliers, outlier_ids, outlier_names = self.get_outliers(benchmarks)
             outlier_urls = [
-                comparisons_by_id[x]["compare_benchmarks_url"] for x in outlier_ids
+                comparisons_by_id.get(x, {}).get("compare_benchmarks_url", "")
+                for x in outlier_ids
             ]
             plot_history = [
                 self.get_history_plot(b, contender_run, i)

--- a/conbench/entities/commit.py
+++ b/conbench/entities/commit.py
@@ -584,7 +584,7 @@ class GitHub:
 
         Do not try for too long because there is an HTTP client waiting for
         _us_ to generate an HTTP response in a more or less timely fashion.
-        Gunicorn has a worker timeout behavior (as of the time of writing: 30
+        Gunicorn has a worker timeout behavior (as of the time of writing: 120
         seconds) and the retrying method below must come to a conclusion before
         that.
 

--- a/deploy.yml
+++ b/deploy.yml
@@ -20,7 +20,7 @@ spec:
       containers:
       - name: conbench
         image: "{{DOCKER_REGISTRY}}/{{FLASK_APP}}:{{BUILDKITE_COMMIT}}"
-        command: ["gunicorn", "-b", "0.0.0.0:5000", "-w", "5", "conbench:application", "--access-logfile=-", "--error-logfile=-", "--preload"]
+        command: ["gunicorn", "-b", "0.0.0.0:5000", "-w", "5", "-t", "120", "conbench:application", "--access-logfile=-", "--error-logfile=-", "--preload"]
         imagePullPolicy: "Always"
         ports:
           - containerPort: 5000

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,6 +9,7 @@ services:
       "gunicorn",
       "-b", "0.0.0.0:5000",
       "-w", "2",
+      "-t", "120",
       "conbench:application",
       "--access-logfile=-",
       "--error-logfile=-",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       # Note that currently this Dockerfile defines the image that' used for
       # Conbench production environments.
       dockerfile: Dockerfile
-    command: ["gunicorn", "-b", "0.0.0.0:5000", "-w", "5", "conbench:application", "--access-logfile=-", "--error-logfile=-", "--preload"]
+    command: ["gunicorn", "-b", "0.0.0.0:5000", "-w", "5", "-t", "120", "conbench:application", "--access-logfile=-", "--error-logfile=-", "--preload"]
     ports:
       # When using the default value `127.0.0.1::5000` (two colons) then the
       # container-internal port 5000 will be dynamically mapped to a free port


### PR DESCRIPTION
After deploying the last 34 commits to our production environments, I noticed a couple of problems.

1. #636 introduced an expected performance slowdown. This causes 502s on pages like https://conbench.ursa.dev/compare/runs/a02a6dc9375543fea2f9a003f3bb341f...5c32ae93b4dd47ec854cb84ff040a770/ because of the 30-second default gunicorn worker timeout. I propose lifting that timeout to 120 seconds. Based on some local testing, I think this will solve the issue for now while we work on performance of those pages.
2. After the deployment (could be the same PR) we started receiving a 500 on this page: https://velox-conbench.voltrondata.run/compare/runs/GHA-4071695296-1...GHA-4106991798-1/
The logs show a KeyError when we're constructing the URLs to link from the outlier plots. I tried it on a commit before that PR, and the plots simply don't show up. So I'm not sure this code ever worked properly. As a band-aid, I set the default `outlier_url` to "", which just refreshes the page if you click on the plot title. At least we won't be returning a 500 anymore.