### PR TITLE
minikube: set k8s version, use dedicated profile, add `make conbench-on-minikube` target for local dev

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -171,6 +171,7 @@ jobs:
         id: minikube
         uses: medyagh/setup-minikube@latest
         with:
+          kubernetes-version: v1.24.10
           # from https://github.com/prometheus-operator/kube-prometheus#minikube
           extra-config: kubelet.authentication-token-webhook=true,kubelet.authorization-mode=Webhook,scheduler.bind-address=0.0.0.0,controller-manager.bind-address=0.0.0.0
           cpus: max

--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,7 @@ deploy-on-minikube:
 	sed -i.bak "s|<CONBENCH_CONTAINER_IMAGE_SPEC>|${CONTAINER_IMAGE_SPEC}|g" _build/deploy-conbench.yml
 	time minikube image load ${CONTAINER_IMAGE_SPEC}
 	minikube kubectl -- apply -f _build/deploy-conbench.yml
+		--kubernetes-version=v1.24.10 \
 
 
 .PHONY: set-build-info

--- a/Makefile
+++ b/Makefile
@@ -131,20 +131,24 @@ build-conbench-container-image: set-build-info
 	# docker push ${CONTAINER_IMAGE_SPEC}
 
 
-# This target is used by ci/minikube/test-conbench-on-mk.sh. The `minikube
-# image load` technique allows for using local Docker images in k8s deployments
-# (as long as they specify `imagePullPolicy: Never`). That command however
-# takes a while for bigger images (about 1 min per GB, on my machine).
+# On GHA, the default minikube profile name is used, cannot be overridden yet
+# (see https://github.com/medyagh/setup-minikube/issues/59). Locally, we use a
+# specific profile name though. Note that this target here is invoked in the
+# context of ci/minikube/test-conbench-on-mk.sh. That wrapper is expected to set  The `minikube image load`
+# technique allows for using local Docker images in k8s deployments (as long as
+# they specify `imagePullPolicy: Never`). That command however takes a while
+# for bigger images (about 1 min per GB, on my machine).
 # https://minikube.sigs.k8s.io/docs/handbook/pushing/
 # https://stackoverflow.com/a/62303945
 .PHONY: deploy-on-minikube
 deploy-on-minikube:
-	minikube status
+	minikube status || minikube status --profile mk-conbench
 	mkdir -p _build
 	cp ci/minikube/deploy-conbench.template.yml _build/deploy-conbench.yml
 	sed -i.bak "s|<CONBENCH_CONTAINER_IMAGE_SPEC>|${CONTAINER_IMAGE_SPEC}|g" _build/deploy-conbench.yml
-	time minikube image load ${CONTAINER_IMAGE_SPEC}
-	minikube kubectl -- apply -f _build/deploy-conbench.yml
+	time minikube --profile "${MINIKUBE_PROFILE_NAME}" image load ${CONTAINER_IMAGE_SPEC}
+	minikube --profile "${MINIKUBE_PROFILE_NAME}" kubectl -- apply -f _build/deploy-conbench.yml
+
 		--kubernetes-version=v1.24.10 \
 
 


### PR DESCRIPTION
This is towards milestone 4 in https://github.com/conbench/conbench/issues/493#issuecomment-1413770175.