### PR TITLE
k8s: add custom Grafana dashboard for Conbench webapp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,16 +220,14 @@ set-build-info:
 
 
 # This uses JSONNET build tooling to rebuild all kube-prometheus manifest YAML
-# files from scratch, based on the file `conbench-flavor.jsonnet` (i.e,
-# including conbench-specific customizations). As long as the only type of
-# customization that we do is 'inject custom dashboards' we might not need this
-# method here (but can inject via k8s configmaps(s) directly). But it took me a
-# longish while to get this working (and to briefly understand the JSONNET
-# build chain), so I want to keep this Makefile target around for now. The
-# coreos/jsonnet-ci container image comes with `jq` (one could install this
-# locally with e.g. sudo dnf install jsonnet) and also with gojsontoyaml (which
-# is where I resorted to looking for a container image that has all
-# dependencies baked in).
+# files based on the file `conbench-flavor.jsonnet` (i.e, including
+# conbench-specific customizations). It took me a longish while to get this
+# working (and to briefly understand the JSONNET build chain). This method here
+# is what we currently use for kube-prometheus customization. Note that the
+# coreos/jsonnet-ci container image used below comes with `jq` (one could
+# install this locally with e.g. sudo dnf install jsonnet) and also with
+# gojsontoyaml (which is where I resorted to looking for a container image that
+# has all dependencies baked in).
 .PHONY: jsonnet-kube-prom-manifests
 jsonnet-kube-prom-manifests:
 #	rm -rf _kpbuild

--- a/Makefile
+++ b/Makefile
@@ -245,11 +245,16 @@ jsonnet-kube-prom-manifests:
 	echo "compiled manifest files: _kpbuild/cb-kube-prometheus/manifests"
 
 
-# kudos to https://askubuntu.com/a/1442898
-# sed `r` command to read the contents of a file to insert them
-# `d;` deleting the original matching line afterwards.
+# The Grafana dashboard JSON comes straight from the Grafana UI via copy/paste
+# into a local file. The awk command adds six-space indentation to the
+# dashboard JSON. The sed command then inserts the (indented) JSON the YAML
+# template. The indentation is important to keep the YAML valid. Kudos to
+# https://askubuntu.com/a/1442898 for the sed technique. Explanation: sed `r`
+# command to read the contents of a file to insert them `d;` deleting the
+# original matching line afterwards.
 .PHONY: build-cb-grafana-dashboard-cfgmap-yml
 build-cb-grafana-dashboard-cfgmap-yml:
-	sed -e '/<CONBENCH_GRAFANA_DASHBOARD_JSON>/{r k8s/kube-prometheus/conbench-grafana-dashboard.json' -e 'd;}' \
+	awk '{print "      " $$0}' k8s/kube-prometheus/conbench-grafana-dashboard.json > conbench-grafana-dashboard.json.indented
+	sed -e '/<CONBENCH_GRAFANA_DASHBOARD_JSON>/{r conbench-grafana-dashboard.json.indented' -e 'd;}' \
 		k8s/conbench-grafana-dashboard-configmap.template.yml \
 			> conbench-grafana-dashboard-configmap.yml

--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,11 @@ deploy-on-minikube:
 .PHONY: conbench-on-minikube
 conbench-on-minikube: build-conbench-container-image start-minikube
 	rm -rf _build && mkdir -p _build && cd _build && bash ../ci/minikube/test-conbench-on-mk.sh
+	@echo "run: kubectl --namespace monitoring port-forward svc/grafana 3000"
+	@echo "then open the Grafana UI at: http://localhost:3000 "
+	@echo "log in with admin/admin"
+	@echo "run: kubectl port-forward svc/conbench-service 8000:conbench-service-port"
+	@echo "then open the Conbench UI at: http://localhost:8000 "
 
 
 # Currently not covered by CI. This is for now only meant for local dev

--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,8 @@ set-build-info:
 	rm buildinfo.json.bak
 	echo "(re)generated buildinfo.json"
 	cat buildinfo.json
+
+
 # This uses JSONNET build tooling to rebuild all kube-prometheus manifest YAML
 # files from scratch, based on the file `conbench-flavor.jsonnet` (i.e,
 # including conbench-specific customizations). As long as the only type of
@@ -241,3 +243,13 @@ jsonnet-kube-prom-manifests:
 		docker run --user $$(id -u):$$(id -g) --rm -v $$(pwd):$$(pwd) --workdir $$(pwd) quay.io/coreos/jsonnet-ci \
 			bash build.sh conbench-flavor.jsonnet
 	echo "compiled manifest files: _kpbuild/cb-kube-prometheus/manifests"
+
+
+# kudos to https://askubuntu.com/a/1442898
+# sed `r` command to read the contents of a file to insert them
+# `d;` deleting the original matching line afterwards.
+.PHONY: build-cb-grafana-dashboard-cfgmap-yml
+build-cb-grafana-dashboard-cfgmap-yml:
+	sed -e '/<CONBENCH_GRAFANA_DASHBOARD_JSON>/{r k8s/kube-prometheus/conbench-grafana-dashboard.json' -e 'd;}' \
+		k8s/conbench-grafana-dashboard-configmap.template.yml \
+			> conbench-grafana-dashboard-configmap.yml

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -25,9 +25,16 @@ if [ -z "${GITHUB_ACTION:=}" ]; then
     export MINIKUBE_PROFILE_NAME="mk-conbench"
 fi
 
-
 minikube config view
 minikube status --profile "${MINIKUBE_PROFILE_NAME}"
+
+
+# Needed later, but fail fast.
+# Expected output: conbench-grafana-dashboard-configmap.yml in repo root.
+( cd "${CONBENCH_REPO_ROOT_DIR}" && make build-cb-grafana-dashboard-cfgmap-yml )
+cat ${CONBENCH_REPO_ROOT_DIR}/conbench-grafana-dashboard-configmap.yml | wc -l
+kubectl apply -f ${CONBENCH_REPO_ROOT_DIR}/conbench-grafana-dashboard-configmap.yml
+
 
 # A small cleanup recommended by
 # https://github.com/prometheus-operator/kube-prometheus

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -34,6 +34,15 @@ minikube status --profile "${MINIKUBE_PROFILE_NAME}"
 ( cd "${CONBENCH_REPO_ROOT_DIR}" && make build-cb-grafana-dashboard-cfgmap-yml )
 cat ${CONBENCH_REPO_ROOT_DIR}/conbench-grafana-dashboard-configmap.yml | wc -l
 
+# Create `monitoring` namespace if it does not exist:
+# https://stackoverflow.com/a/65411733
+kubectl create namespace monitoring --dry-run=client -o yaml | kubectl apply -f -
+
+# Requires namespace `monitoring` to exist by now.
+# Needs to be submitted before applying other kube-prometheus manifests.
+# Otherwise this dashboard isn't picked up (?)
+kubectl apply -f ${CONBENCH_REPO_ROOT_DIR}/conbench-grafana-dashboard-configmap.yml
+
 
 # A small cleanup recommended by
 # https://github.com/prometheus-operator/kube-prometheus
@@ -109,10 +118,6 @@ pushd kube-prometheus
         --namespace=monitoring
     kubectl apply -f manifests/
 popd
-
-
-# Requires namespace `monitoring` to exist by now.
-kubectl apply -f ${CONBENCH_REPO_ROOT_DIR}/conbench-grafana-dashboard-configmap.yml
 
 
 # On minikube with cpus=2 and memory=2000 (which is the github actions resource

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -33,7 +33,6 @@ minikube status --profile "${MINIKUBE_PROFILE_NAME}"
 # Expected output: conbench-grafana-dashboard-configmap.yml in repo root.
 ( cd "${CONBENCH_REPO_ROOT_DIR}" && make build-cb-grafana-dashboard-cfgmap-yml )
 cat ${CONBENCH_REPO_ROOT_DIR}/conbench-grafana-dashboard-configmap.yml | wc -l
-kubectl apply -f ${CONBENCH_REPO_ROOT_DIR}/conbench-grafana-dashboard-configmap.yml
 
 
 # A small cleanup recommended by
@@ -110,6 +109,10 @@ pushd kube-prometheus
         --namespace=monitoring
     kubectl apply -f manifests/
 popd
+
+
+# Requires namespace `monitoring` to exist by now.
+kubectl apply -f ${CONBENCH_REPO_ROOT_DIR}/conbench-grafana-dashboard-configmap.yml
 
 
 # On minikube with cpus=2 and memory=2000 (which is the github actions resource

--- a/conbench/tests/populate_local_conbench.py
+++ b/conbench/tests/populate_local_conbench.py
@@ -217,7 +217,7 @@ def register():
         "secret": "innocent-registration-key",
     }
     r = session.post(url, json=data)
-    if r.text and "Email address already in use":
+    if r.text and "Email address already in use" in r.text:
         return
 
     assert str(r.status_code).startswith("2"), f"register failed:\n{r.text}"

--- a/k8s/conbench-grafana-dashboard-configmap.template.yml
+++ b/k8s/conbench-grafana-dashboard-configmap.template.yml
@@ -5,6 +5,7 @@ data:
     <CONBENCH_GRAFANA_DASHBOARD_JSON>
 metadata:
   labels:
+    grafana_dashboard: 1
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: kube-prometheus

--- a/k8s/conbench-grafana-dashboard-configmap.template.yml
+++ b/k8s/conbench-grafana-dashboard-configmap.template.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+data:
+  conbench-grafana-dashboard.json: |
+    <CONBENCH_GRAFANA_DASHBOARD_JSON>
+metadata:
+  labels:
+    app.kubernetes.io/component: grafana
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 9.3.2
+  name: grafana-dashboard-conbench-grafana-dashboard
+  namespace: monitoring

--- a/k8s/conbench-grafana-dashboard-configmap.template.yml
+++ b/k8s/conbench-grafana-dashboard-configmap.template.yml
@@ -5,10 +5,10 @@ data:
     <CONBENCH_GRAFANA_DASHBOARD_JSON>
 metadata:
   labels:
-    grafana_dashboard: 1
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 9.3.2
+    grafana_dashboard: "1"
   name: grafana-dashboard-conbench-grafana-dashboard
   namespace: monitoring

--- a/k8s/kube-prometheus/conbench-flavor.jsonnet
+++ b/k8s/kube-prometheus/conbench-flavor.jsonnet
@@ -1,0 +1,51 @@
+// Note(JP): Starting point was a raw copy of
+// https://github.com/prometheus-operator/kube-prometheus/blob/v0.12.0/example.jsonnet
+// I then tried to understand some of
+// https://github.com/prometheus-operator/kube-prometheus/tree/main/docs/customizations
+// to do some modifications (mainly: inject custom dashboard)
+// I use use auto-format in VSCode with the 'jsonnet Formatter' extension
+local kp =
+  (import 'kube-prometheus/main.libsonnet') +
+  // Uncomment the following imports to enable its patches
+  // (import 'kube-prometheus/addons/anti-affinity.libsonnet') +
+  // (import 'kube-prometheus/addons/managed-cluster.libsonnet') +
+  // (import 'kube-prometheus/addons/node-ports.libsonnet') +
+  // (import 'kube-prometheus/addons/static-etcd.libsonnet') +
+  // (import 'kube-prometheus/addons/custom-metrics.libsonnet') +
+  // (import 'kube-prometheus/addons/external-metrics.libsonnet') +
+  // (import 'kube-prometheus/addons/pyrra.libsonnet') +
+  {
+    values+:: {
+      common+: {
+        namespace: 'monitoring',
+      },
+      grafana+: {
+        rawDashboards+:: {
+          // This expects the file `conbench-grafana-dashboard.json` to be
+          // present in the current working directory when running
+          // `bash build.sh conbench-flavor.jsonnet`
+          'conbench-grafana-dashboard.json': (importstr 'conbench-grafana-dashboard.json'),
+        },
+      },
+    },
+  };
+
+{ 'setup/0namespace-namespace': kp.kubePrometheus.namespace } +
+{
+  ['setup/prometheus-operator-' + name]: kp.prometheusOperator[name]
+  for name in std.filter((function(name) name != 'serviceMonitor' && name != 'prometheusRule'), std.objectFields(kp.prometheusOperator))
+} +
+// { 'setup/pyrra-slo-CustomResourceDefinition': kp.pyrra.crd } +
+// serviceMonitor and prometheusRule are separated so that they can be created after the CRDs are ready
+{ 'prometheus-operator-serviceMonitor': kp.prometheusOperator.serviceMonitor } +
+{ 'prometheus-operator-prometheusRule': kp.prometheusOperator.prometheusRule } +
+{ 'kube-prometheus-prometheusRule': kp.kubePrometheus.prometheusRule } +
+{ ['alertmanager-' + name]: kp.alertmanager[name] for name in std.objectFields(kp.alertmanager) } +
+{ ['blackbox-exporter-' + name]: kp.blackboxExporter[name] for name in std.objectFields(kp.blackboxExporter) } +
+{ ['grafana-' + name]: kp.grafana[name] for name in std.objectFields(kp.grafana) } +
+// { ['pyrra-' + name]: kp.pyrra[name] for name in std.objectFields(kp.pyrra) if name != 'crd' } +
+{ ['kube-state-metrics-' + name]: kp.kubeStateMetrics[name] for name in std.objectFields(kp.kubeStateMetrics) } +
+{ ['kubernetes-' + name]: kp.kubernetesControlPlane[name] for name in std.objectFields(kp.kubernetesControlPlane) }
+{ ['node-exporter-' + name]: kp.nodeExporter[name] for name in std.objectFields(kp.nodeExporter) } +
+{ ['prometheus-' + name]: kp.prometheus[name] for name in std.objectFields(kp.prometheus) } +
+{ ['prometheus-adapter-' + name]: kp.prometheusAdapter[name] for name in std.objectFields(kp.prometheusAdapter) }

--- a/k8s/kube-prometheus/conbench-grafana-dashboard.json
+++ b/k8s/kube-prometheus/conbench-grafana-dashboard.json
@@ -2,6 +2,10 @@
   "annotations": {
     "list": []
   },
+  "refresh": "5s",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": ["conbench"],
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
@@ -475,10 +479,6 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "5s",
-  "schemaVersion": 37,
-  "style": "dark",
-  "tags": ["conbench"],
   "templating": {
     "list": [
       {

--- a/k8s/kube-prometheus/conbench-grafana-dashboard.json
+++ b/k8s/kube-prometheus/conbench-grafana-dashboard.json
@@ -541,7 +541,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Conbench web application insights",
+  "title": "Conbench / Web application overview",
   "uid": "oEevQ804k",
   "version": 5,
   "weekStart": ""

--- a/k8s/kube-prometheus/conbench-grafana-dashboard.json
+++ b/k8s/kube-prometheus/conbench-grafana-dashboard.json
@@ -497,7 +497,7 @@
   "refresh": "5s",
   "schemaVersion": 37,
   "style": "dark",
-  "tags": [],
+  "tags": ["conbench"],
   "templating": {
     "list": [
       {

--- a/k8s/kube-prometheus/conbench-grafana-dashboard.json
+++ b/k8s/kube-prometheus/conbench-grafana-dashboard.json
@@ -1,0 +1,548 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 27,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "series",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 3,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "hertz"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(flask_http_request_total{}[$timewindow]))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Flask response generation rate [1/s], $timewindow mean",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "calculate": false,
+        "calculation": {
+          "xBuckets": {
+            "mode": "size"
+          },
+          "yBuckets": {
+            "mode": "size"
+          }
+        },
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 99
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "show": true,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "pluginVersion": "9.3.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "sum by (le) (rate(flask_http_request_duration_seconds_bucket{method!=\"GET\"}[$timewindow]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "non-GET requests: Flask HTTP response generation duration, event rate [1/s]. Observation period: $timewindow",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "series",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 10,
+              "type": "symlog"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "hertz"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "sum by (status) (rate(flask_http_request_total[$timewindow]))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Flask response generation rate by status code [1/s], $timewindow mean",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "calculate": false,
+        "calculation": {
+          "xBuckets": {
+            "mode": "size"
+          },
+          "yBuckets": {
+            "mode": "size"
+          }
+        },
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 99
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "show": true,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "pluginVersion": "9.3.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "sum by (le) (rate(flask_http_request_duration_seconds_bucket{method=\"GET\"}[$timewindow]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GET requests: Flask HTTP response generation duration, event rate [1/s]. Observation period: $timewindow",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "description": "\n",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "red",
+            "mode": "thresholds",
+            "seriesBy": "last"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "series",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 4,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 5,
+            "pointSize": 6,
+            "scaleDistribution": {
+              "log": 10,
+              "type": "symlog"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "hertz"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "rate(flask_http_request_exceptions_total[$timewindow])",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Rate of exceptions thrown by request handlers [1/s], $timewindow mean",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "1m",
+          "value": "1m"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Time window width",
+        "multi": false,
+        "name": "timewindow",
+        "options": [
+          {
+            "selected": true,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "2m",
+            "value": "2m"
+          },
+          {
+            "selected": false,
+            "text": "5m",
+            "value": "5m"
+          }
+        ],
+        "query": "1m, 2m, 5m",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Conbench web application insights",
+  "uid": "oEevQ804k",
+  "version": 5,
+  "weekStart": ""
+}

--- a/k8s/kube-prometheus/conbench-grafana-dashboard.json
+++ b/k8s/kube-prometheus/conbench-grafana-dashboard.json
@@ -1,25 +1,6 @@
 {
   "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "target": {
-          "limit": 100,
-          "matchAny": false,
-          "tags": [],
-          "type": "dashboard"
-        },
-        "type": "dashboard"
-      }
-    ]
+    "list": []
   },
   "editable": true,
   "fiscalYearStartMonth": 0,

--- a/k8s/kube-prometheus/conbench-grafana-dashboard.json
+++ b/k8s/kube-prometheus/conbench-grafana-dashboard.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 27,
+  "id": null,
   "links": [],
   "liveNow": false,
   "panels": [

--- a/k8s/kube-prometheus/conbench-grafana-dashboard.json
+++ b/k8s/kube-prometheus/conbench-grafana-dashboard.json
@@ -523,7 +523,7 @@
   "timepicker": {},
   "timezone": "",
   "title": "Conbench / Web application overview",
-  "uid": "oEevQ804k",
-  "version": 5,
+  "uid": "b13a04d1c1424f4daa7b08c33d45ad51",
+  "version": 0,
   "weekStart": ""
 }


### PR DESCRIPTION
That bigger JSON file in this PR: It's this file here that I invested time in. The rest of this PR is just necessarily tooling/noise. For building the histogram-over-time panel in this dashboard I followed my own instructions from this blog post: https://opstrace.com/blog/grafana-histogram-howto

A screenshot from local dev / in browser:
![Screenshot from 2023-02-07 15-25-36](https://user-images.githubusercontent.com/265630/217286952-d5ec00a2-8b50-464e-a6f6-3ac2fc797d20.png)

Architecturally, this PR adds a so-called JSONNET build of kube-prometheus to the minikube CI check. This build step follows the recommended method of customizing kube-prometheus. In this case here the only customization is to add one custom Grafana dashboard. Much more can be customized.