### PR TITLE
benchadapt: GoogleBenchmarkAdapter: Set batch_id at benchmark level

### DIFF
--- a/benchadapt/python/benchadapt/adapters/gbench.py
+++ b/benchadapt/python/benchadapt/adapters/gbench.py
@@ -163,12 +163,12 @@ class GoogleBenchmarkAdapter(BenchmarkAdapter):
 
     def _parse_results(self, results: dict, extra_tags: dict) -> List[BenchmarkResult]:
         """Parse a blob of results from gbench into a list of `BenchmarkResult` instances"""
-        # all results share a batch id
-        batch_id = uuid.uuid4().hex
         gbench_context, benchmark_groups = self._parse_gbench_json(results)
 
         parsed_results = []
         for benchmark in benchmark_groups:
+            # all results for a benchmark name share a batch id
+            batch_id = uuid.uuid4().hex
             result_parsed = self._parse_benchmark(
                 result=benchmark,
                 batch_id=batch_id,

--- a/benchadapt/python/tests/adapters/test_gbench.py
+++ b/benchadapt/python/tests/adapters/test_gbench.py
@@ -216,6 +216,9 @@ class TestGbenchAdapter:
         results = gbench_adapter.transform_results()
 
         assert len(results) == 2
+        # each benchmark name should have a different batch_id regardless of the number of results
+        assert len(set(res.tags["name"] for res in results)) == 2
+        assert len(set(res.batch_id for res in results)) == 2
         for result in results:
             assert isinstance(result, BenchmarkResult)
             assert result.tags["name"].endswith("MajorTensorConversionFixture")


### PR DESCRIPTION
Closes #695 by moving `batch_id` into the `for` loop so each benchmark group gets its own new `batch_id`. Adds tests to ensure the number of unique values for `result.tags.name` and `result.batch_id` correspond.