### PR TITLE
deployment: fix deploy script

### DIFF
--- a/.buildkite/utils.sh
+++ b/.buildkite/utils.sh
@@ -2,6 +2,7 @@
 
 build_and_push() {
   set -x
+  make set-build-info
   docker build -t ${FLASK_APP} .
   docker tag ${FLASK_APP}:latest ${DOCKER_REGISTRY}/${FLASK_APP}:${BUILDKITE_COMMIT}
   aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin ${DOCKER_REGISTRY}


### PR DESCRIPTION
After #678, we always need to `make set-build-info` before we `docker build`. In PR CI, we always do that through the Makefile. Since the Buildkite deployment scripts do not use the Makefile, we need to explicitly call that then. Fixes #697 