### PR TITLE
deployment: add PROMETHEUS_MULTIPROC_DIR to k8s config

### DIFF
--- a/conbench-config.yml
+++ b/conbench-config.yml
@@ -13,3 +13,5 @@ data:
   DB_PORT: "{{DB_PORT}}"
   FLASK_APP: "{{FLASK_APP}}"
   DISTRIBUTION_COMMITS: "{{DISTRIBUTION_COMMITS}}"
+  # Hardcoding this for now. We can always make it configurable in the future.
+  PROMETHEUS_MULTIPROC_DIR: /tmp/_conbench-promcl-coord-dir


### PR DESCRIPTION
Probably fixes #699.

This PR adds `PROMETHEUS_MULTIPROC_DIR` to the production ConfigMap so that deployment can succeed. It hardcodes the value for now. We could make it configurable in the future if we wish.