### PR TITLE
benchadapt: gbench grouping and run_name default

### DIFF
--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -139,6 +139,12 @@ class BenchmarkResult:
         self._maybe_set_run_name()
 
     def _maybe_set_run_name(self) -> None:
+        """
+        Set a default value for `run_name` if not populated and `github["commit"]` is.
+        Uses `run_reason`, but does not check if it's set, so may produce
+        `None: <commit hash>`. Since all three are required by the API, this should in
+        most situations produce a reasonably useful `run_name`.
+        """
         if not self.run_name and self.github.get("commit"):
             self.run_name = f"{self.run_reason}: {self.github['commit']}"
 

--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -136,6 +136,9 @@ class BenchmarkResult:
     github: Dict[str, Any] = field(default_factory=_machine_info.github_info)
 
     def __post_init__(self) -> None:
+        self._maybe_set_run_name()
+
+    def _maybe_set_run_name(self) -> None:
         if not self.run_name and self.github.get("commit"):
             self.run_name = f"{self.run_reason}: {self.github['commit']}"
 
@@ -148,6 +151,7 @@ class BenchmarkResult:
         if value is None:
             value = _machine_info.detect_github_info()
         self._github_cache = value
+        self._maybe_set_run_name()
 
     @property
     def _cluster_info_property(self) -> Dict[str, Any]:

--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -142,8 +142,8 @@ class BenchmarkResult:
         """
         Set a default value for `run_name` if not populated and `github["commit"]` is.
         Uses `run_reason`, but does not check if it's set, so may produce
-        `None: <commit hash>`. Since all three are required by the API, this should in
-        most situations produce a reasonably useful `run_name`.
+        `None: <commit hash>`. Since `run_reason` and commit are required by the API,
+        this should in most situations produce a reasonably useful `run_name`.
         """
         if not self.run_name and self.github.get("commit"):
             self.run_name = f"{self.run_reason}: {self.github['commit']}"
@@ -194,6 +194,7 @@ class BenchmarkResult:
             )
 
         for attr in [
+            "run_name",
             "optional_benchmark_info",
             "machine_info",
             "cluster_info",

--- a/benchadapt/python/benchadapt/run.py
+++ b/benchadapt/python/benchadapt/run.py
@@ -89,6 +89,15 @@ class BenchmarkRun:
     error_info: Dict[str, Any] = None
 
     def __post_init__(self) -> None:
+        self._maybe_set_name()
+
+    def _maybe_set_name(self) -> None:
+        """
+        Set a default value for `name` if not populated and `github["commit"]` is.
+        Uses `reason`, but does not check if it's set, so may produce
+        `None: <commit hash>`. Since reason and commit are required by the API, this
+        should in most situations produce a reasonably useful `name`.
+        """
         if not self.name and self.github.get("commit"):
             self.name = f"{self.reason}: {self.github['commit']}"
 
@@ -101,6 +110,7 @@ class BenchmarkRun:
         if value is None:
             value = _machine_info.detect_github_info()
         self._github_cache = value
+        self._maybe_set_name()
 
     @property
     def _cluster_info_property(self) -> Dict[str, Any]:
@@ -132,6 +142,7 @@ class BenchmarkRun:
             )
 
         for attr in [
+            "name",
             "machine_info",
             "cluster_info",
             "finished_timestamp",

--- a/benchadapt/python/tests/adapters/test_gbench.py
+++ b/benchadapt/python/tests/adapters/test_gbench.py
@@ -221,6 +221,7 @@ class TestGbenchAdapter:
         assert len(set(res.batch_id for res in results)) == 2
         for result in results:
             assert isinstance(result, BenchmarkResult)
+            assert isinstance(result.run_name, str)
             assert result.tags["name"].endswith("MajorTensorConversionFixture")
             assert result.context == {"benchmark_language": "C++"}
             assert "params" in result.tags

--- a/benchadapt/python/tests/test_result.py
+++ b/benchadapt/python/tests/test_result.py
@@ -104,6 +104,24 @@ class TestBenchmarkResult:
             ):
                 BenchmarkResult().to_publishable_dict()
 
+    def test_run_name_defaulting(self, monkeypatch):
+        monkeypatch.delenv("CONBENCH_PROJECT_REPOSITORY", raising=False)
+        monkeypatch.delenv("CONBENCH_PROJECT_PR_NUMBER", raising=False)
+        monkeypatch.delenv("CONBENCH_PROJECT_COMMIT", raising=False)
+
+        with pytest.warns(
+            UserWarning,
+            match="Both CONBENCH_PROJECT_REPOSITORY and CONBENCH_PROJECT_COMMIT must be set if `github` is not specified",
+        ):
+            res = BenchmarkResult(run_reason=res_json["run_reason"])
+
+        assert res.github == {"commit": None, "repository": None, "pr_number": None}
+        assert res.run_name is None
+        res.github = res_json["github"]
+        assert (
+            res.run_name == f"{res_json['run_reason']}: {res_json['github']['commit']}"
+        )
+
     def test_host_detection(self, monkeypatch):
         machine_info_name = "fake-computer-name"
         monkeypatch.setenv("CONBENCH_MACHINE_INFO_NAME", machine_info_name)

--- a/benchadapt/python/tests/test_run.py
+++ b/benchadapt/python/tests/test_run.py
@@ -86,3 +86,19 @@ class TestBenchmarkRun:
 
         assert run.machine_info["name"] == machine_info_name
         assert run.machine_info["name"] != run_json["machine_info"]["name"]
+
+    def test_name_defaulting(self, monkeypatch):
+        monkeypatch.delenv("CONBENCH_PROJECT_REPOSITORY", raising=False)
+        monkeypatch.delenv("CONBENCH_PROJECT_PR_NUMBER", raising=False)
+        monkeypatch.delenv("CONBENCH_PROJECT_COMMIT", raising=False)
+
+        with pytest.warns(
+            UserWarning,
+            match="Both CONBENCH_PROJECT_REPOSITORY and CONBENCH_PROJECT_COMMIT must be set if `github` is not specified",
+        ):
+            run = BenchmarkRun(reason=run_json["reason"])
+
+        assert run.github == {"commit": None, "repository": None, "pr_number": None}
+        assert run.name is None
+        run.github = run_json["github"]
+        assert run.name == f"{run_json['reason']}: {run_json['github']['commit']}"


### PR DESCRIPTION
Fixing a couple little benchadapt bugs; closes #701 and #702. Apologies for not splitting this in two, I initially thought they were more related than they turned out to be.