### PR TITLE
Dockerfile: use --platform=linux/amd64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@
 FROM --platform=linux/amd64 python:3.11-slim
 
 # curl is needed for docker-compose health checks. `git` is needed by some unit
-# tests as of today. `gcc` may be needed to build psutil C ext on some
-# platforms.
+# tests as of today.
 RUN apt-get update && apt-get install -y -q --no-install-recommends \
     curl git && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,16 @@
-FROM python:3.11-slim
+# Specify platform so that developers using this on ARM MacOS get to use the
+# same Python wheels (platform-specific binaries) that we use when running this
+# on Linux. Otherwise, some wheels might not exist on PyPI (psutil) and
+# compilation tools are required for building C extensions. Downside: when
+# executing an AMD64 image on ARM the QEMU emulation layer inficts a small
+# slowdown. Also see https://github.com/conbench/conbench/issues/709 and
+# https://docs.docker.com/engine/reference/builder/#from
+# https://www.docker.com/blog/multi-platform-docker-builds/
+FROM --platform=linux/amd64 python:3.11-slim
 
 # curl is needed for docker-compose health checks. `git` is needed by some unit
-# tests as of today.
+# tests as of today. `gcc` may be needed to build psutil C ext on some
+# platforms.
 RUN apt-get update && apt-get install -y -q --no-install-recommends \
     curl git && apt-get clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
I hope this resolves https://github.com/conbench/conbench/issues/709.

Docker uses good old QEMU that allows for running x86_64 code on ARM64. Tiny slowdown, but works. Good enough
for local dev. 

https://www.docker.com/blog/multi-platform-docker-builds/

Good blog post: https://pythonspeed.com/articles/docker-build-problems-mac/

By the way, `psutil` entered the dependency graph with https://github.com/conbench/conbench/pull/662 when adding flask-prometheus-exporter. psutil is however not really used because of the multiprocessing challenge described in #662.