### PR TITLE
Makefile: fix run-app-dev (tmpdir), do not run db populate on minikube for now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ run-app-bg: set-build-info
 # fails then emit container logs before fast-failing the makefile target.
 .PHONY: test-run-app-dev
 test-run-app-dev: set-build-info
+	mkdir -p /tmp/_conbench-promcl-coord-dir
 	docker compose down --remove-orphans
 	docker compose -f docker-compose.yml -f docker-compose.dev.yml \
 		up --build --wait --detach || (docker compose logs --since 30m; exit 1)

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ tests: require-env-ghtoken set-build-info
 # That mounts the local checkout into the Conbench container.
 .PHONY: run-app-dev
 run-app-dev: set-build-info
+	mkdir -p /tmp/_conbench-promcl-coord-dir
 	export DCOMP_CONBENCH_HOST_PORT=127.0.0.1:5000 && \
 		docker compose down && \
 			docker compose -f docker-compose.yml -f docker-compose.dev.yml \
@@ -106,7 +107,6 @@ run-app-bg: set-build-info
 # fails then emit container logs before fast-failing the makefile target.
 .PHONY: test-run-app-dev
 test-run-app-dev: set-build-info
-	mkdir -p /tmp/_conbench-promcl-coord-dir
 	docker compose down --remove-orphans
 	docker compose -f docker-compose.yml -f docker-compose.dev.yml \
 		up --build --wait --detach || (docker compose logs --since 30m; exit 1)

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -181,9 +181,8 @@ kubectl get pods -A
 sleep 1
 kubectl wait --timeout=90s --for=condition=Ready pods -l app=conbench
 
-#
 export CONBENCH_BASE_URL=$(minikube --profile "${MINIKUBE_PROFILE_NAME}" service conbench-service --url) && echo $CONBENCH_BASE_URL
-(cd "${CONBENCH_REPO_ROOT_DIR}" && make db-populate)
+# (cd "${CONBENCH_REPO_ROOT_DIR}" && make db-populate)
 
 sleep 5
 kubectl logs deployment/conbench-deployment --all-containers > conbench_container_output.log


### PR DESCRIPTION
This is to address https://github.com/conbench/conbench/issues/709#issuecomment-1424029036 observed by @sayantikabanik.