### PR TITLE
webapp metrics: use custom request latency bucket boundaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ jsonnet-kube-prom-manifests:
 		docker run --user $$(id -u):$$(id -g) --rm -v $$(pwd):$$(pwd) --workdir $$(pwd) quay.io/coreos/jsonnet-ci \
 			jb init || echo "exists"
 	cd _kpbuild/cb-kube-prometheus && \
-		docker run --user $$(id -u):$$(id -g) --rm -v $$(pwd):$$(pwd) --workdir $$(pwd) quay.io/coreos/jsonnet-ci \
+		time docker run --user $$(id -u):$$(id -g) --rm -v $$(pwd):$$(pwd) --workdir $$(pwd) quay.io/coreos/jsonnet-ci \
 			jb install github.com/prometheus-operator/kube-prometheus/jsonnet/kube-prometheus@v0.12.0
 	cd _kpbuild/cb-kube-prometheus && \
 		wget https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.12.0/build.sh -O build.sh

--- a/Makefile
+++ b/Makefile
@@ -244,6 +244,6 @@ jsonnet-kube-prom-manifests:
 	cp k8s/kube-prometheus/conbench-flavor.jsonnet _kpbuild/cb-kube-prometheus
 	cp k8s/kube-prometheus/conbench-grafana-dashboard.json _kpbuild/cb-kube-prometheus
 	cd _kpbuild/cb-kube-prometheus && \
-		docker run --user $$(id -u):$$(id -g) --rm -v $$(pwd):$$(pwd) --workdir $$(pwd) quay.io/coreos/jsonnet-ci \
+		time docker run --user $$(id -u):$$(id -g) --rm -v $$(pwd):$$(pwd) --workdir $$(pwd) quay.io/coreos/jsonnet-ci \
 			bash build.sh conbench-flavor.jsonnet
 	echo "compiled manifest files: _kpbuild/cb-kube-prometheus/manifests"

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -190,5 +190,21 @@ kubectl logs deployment/conbench-deployment --all-containers > conbench_containe
 cat conbench_container_output.log
 
 # Require access log line confirming that the /metrics endpoint was hit.
-sleep 2
-grep '"GET /metrics HTTP/1.1" 200' conbench_container_output.log
+# Temporarily disable the errexit guardrail.
+attempt=0
+retries=10
+wait_seconds=3
+set +e
+until ( kubectl logs deployment/conbench-deployment --all-containers | grep '"GET /metrics HTTP/1.1" 200' )
+do
+    retcode=$?
+    attempt=$(($attempt + 1))
+    if [ $attempt -lt $retries ]; then
+        echo "pipeline returncode: $retcode -- probe not yet found in log, retry soon"
+        sleep $wait_seconds
+    else
+        exit 1
+    fi
+done
+set +e
+

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -190,11 +190,13 @@ kubectl logs deployment/conbench-deployment --all-containers > conbench_containe
 cat conbench_container_output.log
 
 # Require access log line confirming that the /metrics endpoint was hit.
-# Temporarily disable the errexit guardrail.
+# Temporarily disable the errexit guardrail, and also disable xtrace for
+# verbosity control.
+set +e
+set +x
 attempt=0
 retries=10
 wait_seconds=3
-set +e
 until ( kubectl logs deployment/conbench-deployment --all-containers | grep '"GET /metrics HTTP/1.1" 200' )
 do
     retcode=$?
@@ -206,5 +208,6 @@ do
         exit 1
     fi
 done
-set +e
+set -e
+set -x
 

--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -83,7 +83,20 @@ def create_application(config):
     # the metrics scrape endpoing. Note that this sets the global singleton.
     # This needs PROMETHEUS_MULTIPROC_DIR to be set to a path to a directory.
     _inspect_prom_multiproc_dir()
-    metrics = GunicornInternalPrometheusMetrics(app)
+    metrics = GunicornInternalPrometheusMetrics(
+        app=app,
+        # Set bucket boundaries (unit: seconds) for tracking the distribution
+        # of HTTP request processing durations (Prometheus metric of type
+        # histogram). The default histogram buckets are not so useful for
+        # Conbench as of today, because they are optimized for low-latency
+        # APIs. Set bucket boundaries so that we have some resolution on the
+        # high latency tail end. Once we push request processing times more or
+        # less reliably below 10 seconds we can change these again. Each value
+        # defines the upper inclusive bound for the corresponding histogram
+        # bucket. Note that there is an implicit last/upper end bucket here
+        # catching all observations up to +inf.
+        buckets=(0.05, 0.1, 0.2, 0.5, 1.0, 3.0, 6.0, 10.0, 15.0, 20.0, 30.0, 50.0),
+    )
 
     return app
 


### PR DESCRIPTION
Taken straight from diff: the new buckets, and also an explanation for why that matters:
```
        # Set bucket boundaries (unit: seconds) for tracking the distribution
        # of HTTP request processing durations (Prometheus metric of type
        # histogram). The default histogram buckets are not so useful for
        # Conbench as of today, because they are optimized for low-latency
        # APIs. Set bucket boundaries so that we have some resolution on the
        # high latency tail end. Once we push request processing times more or
        # less reliably below 10 seconds we can change these again. Each value
        # defines the upper inclusive bound for the corresponding histogram
        # bucket. Note that there is an implicit last/upper end bucket here
        # catching all observations up to +inf.
        buckets=(0.05, 0.1, 0.2, 0.5, 1.0, 3.0, 6.0, 10.0, 15.0, 20.0, 30.0, 50.0),
```

Before this patch, the current buckets:
```
0.005
0.01
0.025
0.05
0.075
0.1
0.25
0.5
0.75
1.0
2.5
5.0
7.5
10.0
```
I'd love to have a little more resolution between 10 seconds and infinity, and we're OK with less resolution in the low latency regime.



