### PR TITLE
benchadapt: fix GoogleBenchmarkAdapter grouping

### DIFF
--- a/benchadapt/python/tests/adapters/test_gbench.py
+++ b/benchadapt/python/tests/adapters/test_gbench.py
@@ -190,6 +190,95 @@ gbench_json = {
     ],
 }
 
+big_gbench_json = {
+    "context": {
+        "date": "2023-02-07T16:16:18+01:00",
+        "host_name": "aLaptop",
+        "executable": "../../cpp/build/gbenchmarks/do_fun_things_benchmark",
+        "num_cpus": 16,
+        "mhz_per_cpu": 4600,
+        "cpu_scaling_enabled": True,
+        "caches": [
+            {"type": "Data", "level": 1, "size": 49152, "num_sharing": 2},
+            {"type": "Instruction", "level": 1, "size": 32768, "num_sharing": 2},
+            {"type": "Unified", "level": 2, "size": 1310720, "num_sharing": 2},
+            {"type": "Unified", "level": 3, "size": 25165824, "num_sharing": 16},
+        ],
+        "load_avg": [2.76, 2.33, 1.56],
+        "library_build_type": "release",
+    },
+    "benchmarks": [
+        *[
+            {
+                "name": "DoThingAndThenUndoIt/param_1:0/param_2:1024/param_3:1600/real_time/threads:1",
+                "family_index": 0,
+                "per_family_instance_index": 0,
+                "run_name": "DoThingAndThenUndoIt/param_1:0/param_2:1024/param_3:1600/real_time/threads:1",
+                "run_type": "iteration",
+                "repetitions": 1,
+                "repetition_index": 0,
+                "threads": 1,
+                "iterations": 1396,
+                "real_time": 4.7759552005683666e05,
+                "cpu_time": 4.7759015257879649e05,
+                "time_unit": "ns",
+            }
+        ]
+        * 3,
+        *[
+            {
+                "name": "DoThingAndThenUndoIt/param_1:0/param_2:1024/param_3:1600/real_time/threads:2",
+                "family_index": 0,
+                "per_family_instance_index": 1,
+                "run_name": "DoThingAndThenUndoIt/param_1:0/param_2:1024/param_3:1600/real_time/threads:2",
+                "run_type": "iteration",
+                "repetitions": 1,
+                "repetition_index": 0,
+                "threads": 2,
+                "iterations": 424,
+                "real_time": 1.3930781780654453e06,
+                "cpu_time": 2.2883681108490578e06,
+                "time_unit": "ns",
+            }
+        ]
+        * 3,
+        *[
+            {
+                "name": "DoThingAndThenUndoItDifferently/param_1:0/param_2:1024/real_time/threads:1",
+                "family_index": 1,
+                "per_family_instance_index": 0,
+                "run_name": "DoThingAndThenUndoItDifferently/param_1:0/param_2:1024/real_time/threads:1",
+                "run_type": "iteration",
+                "repetitions": 1,
+                "repetition_index": 0,
+                "threads": 1,
+                "iterations": 5374,
+                "real_time": 1.2566177409746450e05,
+                "cpu_time": 1.2565883178265738e05,
+                "time_unit": "ns",
+            }
+        ]
+        * 3,
+        *[
+            {
+                "name": "DoThingAndThenUndoItDifferently/param_1:0/param_2:1024/real_time/threads:2",
+                "family_index": 1,
+                "per_family_instance_index": 1,
+                "run_name": "DoThingAndThenUndoItDifferently/param_1:0/param_2:1024/real_time/threads:2",
+                "run_type": "iteration",
+                "repetitions": 1,
+                "repetition_index": 0,
+                "threads": 2,
+                "iterations": 2596,
+                "real_time": 2.5244852041621989e05,
+                "cpu_time": 4.2161582781201869e05,
+                "time_unit": "ns",
+            }
+        ]
+        * 3,
+    ],
+}
+
 
 class TestGbenchAdapter:
     @pytest.fixture
@@ -232,3 +321,46 @@ class TestGbenchAdapter:
     def test_run(self, gbench_adapter) -> None:
         results = gbench_adapter.run()
         assert len(results) == 2
+
+
+class TestBigGbenchAdapter:
+    @pytest.fixture
+    def gbench_adapter(self, monkeypatch):
+        monkeypatch.setenv(
+            "CONBENCH_PROJECT_REPOSITORY", "git@github.com:conchair/conchair"
+        )
+        monkeypatch.setenv("CONBENCH_PROJECT_PR_NUMBER", "47")
+        monkeypatch.setenv(
+            "CONBENCH_PROJECT_COMMIT", "2z8c9c49a5dc4a179243268e4bb6daa5"
+        )
+
+        result_file = tempfile.mktemp(suffix=".json")
+        gbench_adapter = GoogleBenchmarkAdapter(
+            command=["echo", "'Hello, world!'"], result_file=Path(result_file)
+        )
+
+        with open(gbench_adapter.result_file, "w") as f:
+            json.dump(big_gbench_json, f)
+
+        return gbench_adapter
+
+    def test_transform_results(self, gbench_adapter) -> None:
+        results = gbench_adapter.transform_results()
+
+        assert len(results) == 4
+        # each benchmark name should have a different batch_id regardless of the number of results
+        assert len(set(res.tags["name"] for res in results)) == 2
+        assert len(set(res.batch_id for res in results)) == 2
+        for result in results:
+            assert isinstance(result, BenchmarkResult)
+            assert isinstance(result.run_name, str)
+            assert result.tags["name"].startswith("DoThingAndThenUndoIt")
+            assert result.context == {"benchmark_language": "C++"}
+            assert "params" in result.tags
+            assert result.machine_info is not None
+            assert result.stats["iterations"] == 3
+            assert "gbench_context" in result.optional_benchmark_info
+
+    def test_run(self, gbench_adapter) -> None:
+        results = gbench_adapter.run()
+        assert len(results) == 4


### PR DESCRIPTION
Closes #702 by adding a level of grouping, so grouping at the case level collapses iterations (repetitions in microbenchmark-speak), and grouping at the name level collapses cases into a batch.

Adds some new test data that exercises all the levels of grouping better; left the old because it has some other mess like aggregates that we still want to test. Duplicated and tweaked the test instead of parameterizing everything because I find it easier to debug this way when something breaks.