### PR TITLE
ci: minikube flow: wait for secret to be created

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # conbench-specific things
-.buildinfo.json
+buildinfo.json
 _build
 _new_api_docs_json
 _kpbuild

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -65,6 +65,13 @@ kubectl get pods -A
 # In the PostgreSQL cluster the user 'zalando' has superuser privileges. We can
 # rename that user if we'd like to by modifying minimal-postgres-manifest.yaml.
 # Get password for this user (was dynamically generated during bootstrap):
+# Wait until this secret is available.
+until kubectl get secret zalando.acid-minimal-cluster.credentials.postgresql.acid.zalan.do
+do
+    echo "postgres-operator does not seem to have created the secret yet. wait."
+    sleep 3
+done
+
 export POSTGRES_CONBENCH_USER_PASSWORD="$(kubectl get secret zalando.acid-minimal-cluster.credentials.postgresql.acid.zalan.do -o 'jsonpath={.data.password}' | base64 -d)"
 echo "db password: ${POSTGRES_CONBENCH_USER_PASSWORD}"
 


### PR DESCRIPTION
Log excerpt provided by @austin3dickey, showing that things went pear-shaped :pear: because a k8s secret wasn't created yet at the time when we tried to read its value:
```
++ kubectl get secret zalando.acid-minimal-cluster.credentials.postgresql.acid.zalan.do -o 'jsonpath={.data.password}'
++ base64 -d
Error from server (NotFound): secrets "zalando.acid-minimal-cluster.credentials.postgresql.acid.zalan.do" not found
+ export POSTGRES_CONBENCH_USER_PASSWORD=
+ POSTGRES_CONBENCH_USER_PASSWORD=
```

Why did the script not error out at this point? It's either because of https://github.com/kubernetes/kubectl/issues/821 or because of the subshell not inheriting errexit, or not inheriting pipefail. I did not debug precisely.

Why was the secret not there yet? Race condition. That's plausible, because:
```
+ kubectl get pods -A
NAMESPACE     NAME                                  READY   STATUS    RESTARTS     AGE
default       postgres-operator-74bcb97f87-mtvb5    1/1     Running   1 (6s ago)   22s
```

The postgres-operator container restarted 6 seconds ago, and therefore it's likely that it didn't have enough time to create the secret yet.

This PR adds an explicit wait step. Infinite wait, for now. I have tested this locally, should work.
