### PR TITLE
conbench-on-minikube: wait longer for postgres-operator, misc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,10 +132,11 @@ build-conbench-container-image: set-build-info
 	# docker push ${CONTAINER_IMAGE_SPEC}
 
 
-# On GHA, the default minikube profile name is used, cannot be overridden yet
-# (see https://github.com/medyagh/setup-minikube/issues/59). Locally, we use a
-# specific profile name though. Note that this target here is invoked in the
-# context of ci/minikube/test-conbench-on-mk.sh. That wrapper is expected to set  The `minikube image load`
+# On GHA, the default minikube profile name is used (see
+# https://github.com/medyagh/setup-minikube/issues/59). Locally, we use a
+# Conbench-specific profile name reduce the risk of touching a user's minikube
+# that is unrelated to Conbench. Note that this target here is invoked in the
+# context of ci/minikube/test-conbench-on-mk.sh. The `minikube image load`
 # technique allows for using local Docker images in k8s deployments (as long as
 # they specify `imagePullPolicy: Never`). That command however takes a while
 # for bigger images (about 1 min per GB, on my machine).

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -48,6 +48,10 @@ pushd postgres-operator
     sed -i.bak 's|numberOfInstances: 2|numberOfInstances: 1|g' manifests/minimal-postgres-manifest.yaml
     cat manifests/minimal-postgres-manifest.yaml | grep numberOfInstances
 
+    # Timeout after four minutes instead of one minute. On some platforms this
+    # takes longish. See https://github.com/conbench/conbench/issues/693.
+    sed -i.bak 's|{1..20}|{1..80}|g' ./run_operator_locally.sh
+
     # alchemy: Remove 'clean_up' and 'start_minikube' from
     # `run_operator_locally.sh` (the minikube cluster is already up and running
     # at this point). Do this via line number deletion. In the original file,

--- a/conbench/metrics.py
+++ b/conbench/metrics.py
@@ -83,8 +83,8 @@ def decorate_flask_app_with_metrics(app) -> None:
     This mutates `app` in-place.
     """
     # Use `GunicornPrometheusMetrics` when spawning a separate HTTP server for
-    # the metrics scrape endpoing. Note that this sets the global singleton.
-    # This needs PROMETHEUS_MULTIPROC_DIR to be set to a path to a directory.
+    # the metrics scrape endpoing. This needs PROMETHEUS_MULTIPROC_DIR to be
+    # set to a path to a directory.
     _inspect_prom_multiproc_dir()
     GunicornInternalPrometheusMetrics(
         app=app,


### PR DESCRIPTION
Mainly for https://github.com/conbench/conbench/issues/693.

I don't know if that's going to help. Need @austin3dickey to try this out on his machine after all. In CI and also for me locally, this wait period is short. Example here:
```
Fri, 10 Feb 2023 08:08:39 GMT ==== FORWARD OPERATOR PORT 8080 TO LOCAL PORT 8080  ====
Fri, 10 Feb 2023 08:08:39 GMT ==== RUN HEALTH CHECK ==== 
Fri, 10 Feb 2023 08:08:39 GMT Command for checking: curl --location --silent --output /dev/null http://127.0.0.1:8080/clusters
Fri, 10 Feb 2023 08:08:39 GMT Wait for port forwarding to take effect
Fri, 10 Feb 2023 08:08:42 GMT ==== SUCCESS: OPERATOR IS RUNNING ==== 
```

That is, if dependencies are not met within ~1 minute, I am not sure how much it is going to help for another three minutes. We will find out via this patch.

Comment changes for:
https://github.com/conbench/conbench/pull/692#discussion_r1099093981
https://github.com/conbench/conbench/pull/717#discussion_r1101810145