### PR TITLE
make conbench-on-minikube: cleanup, more human-oriented output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,12 +154,24 @@ deploy-on-minikube:
 # (../ci/minikube/test-conbench-on-mk.sh) is covered.
 .PHONY: conbench-on-minikube
 conbench-on-minikube: build-conbench-container-image start-minikube
-	rm -rf _build && mkdir -p _build && cd _build && bash ../ci/minikube/test-conbench-on-mk.sh
+#	rm -rf _build && mkdir -p _build && cd _build && bash ../ci/minikube/test-conbench-on-mk.sh
+	@echo
 	@echo "run: kubectl --namespace monitoring port-forward svc/grafana 3000"
-	@echo "then open the Grafana UI at: http://localhost:3000 "
-	@echo "log in with admin/admin"
+	@echo "     then open the Grafana UI at: http://localhost:3000 "
+	@echo "     log in with admin/admin"
+	@echo
 	@echo "run: kubectl port-forward svc/conbench-service 8000:conbench-service-port"
-	@echo "then open the Conbench UI at: http://localhost:8000 "
+	@echo "     then open the Conbench UI at: http://localhost:8000 "
+
+
+.PHONY: minikube-conbench-url
+minikube-conbench-url:
+	@CONBENCH_BASE_URL=$$(minikube --profile mk-conbench service conbench-service --url) && \
+		echo "" && \
+		echo "Depending on what you'd like to do next:" && \
+		echo "    open the Conbench UI at $${CONBENCH_BASE_URL}" && \
+		echo "    export CONBENCH_BASE_URL=$${CONBENCH_BASE_URL} && make db-populate" && \
+		echo ""
 
 
 # Currently not covered by CI. This is for now only meant for local dev

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ conbench-on-minikube: build-conbench-container-image start-minikube
 	@echo "Conbench UI port-forward:"
 	@echo "     kubectl port-forward svc/conbench-service 8000:conbench-service-port"
 	@echo "     then open the Conbench UI at: http://localhost:8000 "
-	@echo
+	@make -s minikube-conbench-url
 
 
 .PHONY: minikube-conbench-url

--- a/Makefile
+++ b/Makefile
@@ -154,14 +154,17 @@ deploy-on-minikube:
 # (../ci/minikube/test-conbench-on-mk.sh) is covered.
 .PHONY: conbench-on-minikube
 conbench-on-minikube: build-conbench-container-image start-minikube
-#	rm -rf _build && mkdir -p _build && cd _build && bash ../ci/minikube/test-conbench-on-mk.sh
+	rm -rf _build && mkdir -p _build && cd _build && bash ../ci/minikube/test-conbench-on-mk.sh
 	@echo
-	@echo "run: kubectl --namespace monitoring port-forward svc/grafana 3000"
+	@echo "Grafana UI port-forward:"
+	@echo "     run: kubectl --namespace monitoring port-forward svc/grafana 3000"
 	@echo "     then open the Grafana UI at: http://localhost:3000 "
 	@echo "     log in with admin/admin"
 	@echo
-	@echo "run: kubectl port-forward svc/conbench-service 8000:conbench-service-port"
+	@echo "Conbench UI port-forward:"
+	@echo "     kubectl port-forward svc/conbench-service 8000:conbench-service-port"
 	@echo "     then open the Conbench UI at: http://localhost:8000 "
+	@echo
 
 
 .PHONY: minikube-conbench-url


### PR DESCRIPTION
There is ~valuable code cleanup in this PR.

But there's also a user-facing change: towards the end of the Makefile it now shows this:
```
$ make conbench-on-minikube
...

Grafana UI port-forward:
     run: kubectl --namespace monitoring port-forward svc/grafana 3000
     then open the Grafana UI at: http://localhost:3000 
     log in with admin/admin

Conbench UI port-forward:
     kubectl port-forward svc/conbench-service 8000:conbench-service-port
     then open the Conbench UI at: http://localhost:8000 

Depending on what you'd like to do next:
    open the Conbench UI at http://192.168.49.2:30120
    export CONBENCH_BASE_URL=http://192.168.49.2:30120 && make db-populate

```


