### PR TITLE
kube-prometheus: prepare config to remote_write to external system

### DIFF
--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -86,7 +86,6 @@ stringData:
   SECRET_KEY: "not-actually-secret"
 EOF
 
-
 # Build custom version of kube-prometheus stack.
 ( cd "${CONBENCH_REPO_ROOT_DIR}" && make jsonnet-kube-prom-manifests )
 
@@ -100,6 +99,15 @@ pushd "${CONBENCH_REPO_ROOT_DIR}"/_kpbuild/cb-kube-prometheus/
         --namespace=monitoring
     kubectl apply -f manifests/
 popd
+
+
+# Set up invalid username/password for the Prometheus remote_write config.
+# remote_write will fail, and that is OK.
+echo "invalid-password" > _prom_remote_write_password
+kubectl create secret generic kubepromsecret \
+    --from-literal=username="inval-user" \
+    --from-file=password='_prom_remote_write_password' \
+    -n monitoring
 
 
 # On minikube with cpus=2 and memory=2000 (which is the github actions resource

--- a/k8s/kube-prometheus/conbench-flavor.jsonnet
+++ b/k8s/kube-prometheus/conbench-flavor.jsonnet
@@ -9,7 +9,7 @@ local kp =
   // Uncomment the following imports to enable its patches
   // (import 'kube-prometheus/addons/anti-affinity.libsonnet') +
   // (import 'kube-prometheus/addons/managed-cluster.libsonnet') +
-  // (import 'kube-prometheus/addons/node-ports.libsonnet') +
+  (import 'kube-prometheus/addons/node-ports.libsonnet') +
   // (import 'kube-prometheus/addons/static-etcd.libsonnet') +
   // (import 'kube-prometheus/addons/custom-metrics.libsonnet') +
   // (import 'kube-prometheus/addons/external-metrics.libsonnet') +
@@ -25,6 +25,25 @@ local kp =
           // present in the current working directory when running
           // `bash build.sh conbench-flavor.jsonnet`
           'conbench-grafana-dashboard.json': (importstr 'conbench-grafana-dashboard.json'),
+        },
+      },
+    },
+    prometheus+: {
+      prometheus+: {
+        spec+: {
+          remoteWrite: [{
+            url: '<put_a_remote_write_endpoint_url_here>',
+            basicAuth: {
+              username: {
+                name: 'kubepromsecret',
+                key: 'username',
+              },
+              password: {
+                name: 'kubepromsecret',
+                key: 'password',
+              },
+            },
+          }],
         },
       },
     },


### PR DESCRIPTION
This is a patch towards https://github.com/conbench/conbench/issues/737, relevant research/discussion and also references can be found in there. 

Aspects that matter:

* The goal is to get the `remoteWrite` key into the specification for the Prometheus k8s object, as defined here: https://github.com/prometheus-operator/prometheus-operator/blob/c237d26b62ee5e29087e01f173e94886ada5b2ec/Documentation/api.md#monitoring.coreos.com/v1.RemoteWriteSpec. One can do that before JSONNET compilation or thereafter. The choice between both approaches is not so easy to make as of today. I have picked _before_ for now.
* The invalid remote_write URL and credentials are as intended (indicating that by default this the pusher proms do _not_ write to an external system).