### PR TITLE
test-conbench-on-mk: pin run_operator_locally.sh

### DIFF
--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -34,7 +34,7 @@ pushd postgres-operator
     # git checkout v1.9.0  # release from 2023-01-30
     # Use this patch for better robustness for now, also see
     # https://github.com/conbench/conbench/issues/693
-    git checkout jp/run-local-robustness
+    git checkout 43e2d18d900d342a4f7fbc919edd64c24ea57eac # on jp/run-local-robustness
 
     # Set number of Postgres instances to 1. Need to be conservative with k8s
     # cluster resources, because GHA offers limited resources.


### PR DESCRIPTION
This makes explicit use of the current state of https://github.com/zalando/postgres-operator/pull/2218. To address https://github.com/conbench/conbench/issues/693.