### PR TITLE
conbench webapp grafana dashboard: dynamic datasource

### DIFF
--- a/k8s/kube-prometheus/conbench-flavor.jsonnet
+++ b/k8s/kube-prometheus/conbench-flavor.jsonnet
@@ -63,10 +63,14 @@ local kp =
             // Reference docs for the mechanism used here:
             // https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
             // https://github.com/prometheus-operator/prometheus-operator/blob/c237d26b62ee5e29087e01f173e94886ada5b2ec/Documentation/api.md#relabelconfig
-            // The "keep" strategy is documented with
-            // "Drop targets for which regex does not match the concatenated source_labels."
+            // Note: maybe it's easiest to allowlist by specific label
+            // key/value pairs? For example, we know that kube-prometheus
+            // stack magic adds a `container=conbench` k/v pair to all
+            // metrics it scraped from conbench webapp containers.
             writeRelabelConfigs: [
               {
+                // The "keep" strategy is documented with
+                // "Drop targets for which regex does not match the concatenated source_labels."
                 action: 'keep',
                 regex: 'flask_.*|conbench_.*',
                 sourceLabels: [

--- a/k8s/kube-prometheus/conbench-grafana-dashboard.json
+++ b/k8s/kube-prometheus/conbench-grafana-dashboard.json
@@ -24,14 +24,14 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 29,
+  "id": 23,
   "links": [],
   "liveNow": false,
   "panels": [
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
+        "uid": "${datasource}"
       },
       "description": "\n",
       "fieldConfig": {
@@ -117,7 +117,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "rate(flask_http_request_exceptions_total[$timewindow])",
@@ -132,7 +132,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -210,7 +210,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(rate(flask_http_request_total{}[$timewindow]))",
@@ -225,7 +225,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
+        "uid": "${datasource}"
       },
       "description": "The rate of GitHub HTTP API responses received with status code 403",
       "fieldConfig": {
@@ -305,7 +305,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (instance)(rate(conbench_github_httpapi_403responses_total[$timewindow]))",
@@ -320,7 +320,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -400,7 +400,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (status) (rate(flask_http_request_total[$timewindow]))",
@@ -415,7 +415,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
+        "uid": "${datasource}"
       },
       "description": "These are attempted HTTP request, i.e. this rate includes failed requests.",
       "fieldConfig": {
@@ -494,7 +494,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (instance)(rate(conbench_github_httpapi_requests_total[$timewindow]))",
@@ -509,7 +509,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -581,7 +581,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (le) (rate(flask_http_request_duration_seconds_bucket{method!=\"GET\"}[$timewindow]))",
@@ -597,7 +597,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
+        "uid": "${datasource}"
       },
       "description": "This is a gauge. Last update wins. -1 means: not seen an HTTP response yet carrying the x-ratelimit-remaining header. Each process reports this. Processes might die.",
       "fieldConfig": {
@@ -679,7 +679,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "conbench_github_httpapi_quota_remaining",
@@ -694,7 +694,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -766,7 +766,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (le) (rate(flask_http_request_duration_seconds_bucket{method=\"GET\"}[$timewindow]))",
@@ -782,7 +782,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P1809F7CD0C75ACF3"
+        "uid": "${datasource}"
       },
       "description": "The rate of failed HTTP requests, either after retrying or upon first attempt.",
       "fieldConfig": {
@@ -861,7 +861,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by (instance)(rate(conbench_github_httpapi_requests_failed_total[$timewindow]))",
@@ -914,17 +914,36 @@
         "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "prometheus",
+          "value": "prometheus"
+        },
+        "description": "",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
       }
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-3h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Conbench / Web application overview",
   "uid": "b13a04d1c1424f4daa7b08c33d45ad51",
-  "version": 0,
+  "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
This adds a dashboard-local variable to the dashboard which is consumed in each panel. This makes it so that the same dashboard JSON model works as-is in different Grafana instances (which have different data sources attached), either by doing precisely nothing, or by just having to pick a data source from a drop down.

The following screenshot shows that in action:
![image](https://user-images.githubusercontent.com/265630/218774267-78d0f579-f4de-40d2-b42f-5172ebd64802.png)

On the right: this is the Grafana UI as served by grafana-on-minikube on my `http://localhost:3000/`. It shows the dashboard as defined by `k8s/kube-prometheus/conbench-grafana-dashboard.json` in this repo as of today.

On the left: this is Grafana UI as served by my personal Grafana Cloud tenant `https://jgehrckevdgrafana.grafana.net/`. It shows the same dashboard after me having only copy/pasted the JSON into a field. 

A notable difference between both screens around the top-left corner.
- Left it says `datasource: grafanacloud...-prom` (which is the _receiving end_ of where my local minikube cluster pushes metrics). 
- Right it says `datasource: prometheus` (which is the minikube-local Prometheus managed by kube-prometheus, actually running in a k8s StatefulSet).

In the background behind the two browser windows is a photo of the moon :full_moon: :woman_shrugging: 