### PR TITLE
bugfix: rename apache:master to apache:main

### DIFF
--- a/benchadapt/python/benchadapt/adapters/gbench.py
+++ b/benchadapt/python/benchadapt/adapters/gbench.py
@@ -9,7 +9,7 @@ from ..result import BenchmarkResult
 from ._adapter import BenchmarkAdapter
 
 
-# adapted from https://github.com/apache/arrow/blob/master/dev/archery/archery/benchmark/google.py
+# adapted from https://github.com/apache/arrow/blob/main/dev/archery/archery/benchmark/google.py
 class GoogleBenchmarkObservation:
     """Represents one run of a single (google c++) benchmark.
     Aggregates are reported by Google Benchmark executables alongside

--- a/conbench/tests/entities/test_commit.py
+++ b/conbench/tests/entities/test_commit.py
@@ -161,7 +161,7 @@ def test_get_github_commit_none():
         None,
         # as if github info were provided the advanced, github_info() way: that function
         # returns a branch string like this
-        "apache:master",
+        "apache:main",
     ],
 )
 def test_get_github_commit_and_fork_point_sha(branch):
@@ -179,8 +179,8 @@ def test_get_github_commit_and_fork_point_sha(branch):
         "author_name": "Diana Clarke",
         "author_login": "dianaclarke",
         "author_avatar": "https://avatars.githubusercontent.com/u/878798?v=4",
-        "branch": "apache:master",
-        # this is the master branch, so the fork point sha == the commit sha
+        "branch": "apache:main",
+        # this is the default branch, so the fork point sha == the commit sha
         "fork_point_sha": sha,
     }
     try:

--- a/conbench/tests/populate_local_conbench.py
+++ b/conbench/tests/populate_local_conbench.py
@@ -300,7 +300,7 @@ def create_benchmarks_data():
         "2462492389a8f2ca286c481852c84ba1f0d0eff9",
     ]
 
-    branches = ["apache:master", None] * 3
+    branches = ["apache:main", None] * 3
 
     means = [16.670462, 16.4, 16.5, 16.67, 16.7, 16.7]
 


### PR DESCRIPTION
`apache/arrow` just renamed their default branch from `master` to `main`!

This PR updates any references to arrow's default branch with the new name. This was breaking an integration test that hit the GitHub API. Closes #758.