### PR TITLE
docs: add developer target for building docs

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -52,10 +52,7 @@ jobs:
             -e ./benchrun/python \
             -e .
       - name: Build docs
-        run: |
-          cd docs
-          # Exit non-zero if there are warnings. Those can be very bad.
-          make html SPHINXOPTS='-W --keep-going'
+        run: make build-docs
 
   # This is to confirm that commonly used developer commands still work.
   dev-cmds:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -51,8 +51,8 @@ jobs:
             -e ./benchconnect \
             -e ./benchrun/python \
             -e .
-      - name: Build docs
-        run: make build-docs
+      - name: Build docs, exiting non-zero on warnings (which can be very bad)
+        run: make build-docs SPHINXOPTS='-W --keep-going'
 
   # This is to confirm that commonly used developer commands still work.
   dev-cmds:

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -25,10 +25,7 @@ jobs:
             -e ./benchrun/python \
             -e .
       - name: Build docs
-        run: |
-          cd docs
-          # Exit non-zero if there are warnings. Those can be very bad.
-          make html SPHINXOPTS='-W --keep-going'
+        run: make build-docs
       - name: Upload docs as an artifact
         uses: actions/upload-pages-artifact@v1
         with:

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -24,8 +24,8 @@ jobs:
             -e ./benchconnect \
             -e ./benchrun/python \
             -e .
-      - name: Build docs
-        run: make build-docs
+      - name: Build docs, exiting non-zero on warnings (which can be very bad)
+        run: make build-docs SPHINXOPTS='-W --keep-going'
       - name: Upload docs as an artifact
         uses: actions/upload-pages-artifact@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,13 @@ rebuild-expected-api-docs: run-app-bg
 	rm _new_api_docs.json
 	git diff ./conbench/tests/api/_expected_docs.py
 
+
+# Build HTML docs, exiting non-zero if there are warnings. Those can be very bad.
+.PHONY: build-docs
+build-docs:
+	$(MAKE) -C docs html SPHINXOPTS='-W --keep-going'
+	echo 'To see the generated docs, open docs/_build/html/index.html'
+
 # The targets above this comment have been in use by humans. Change
 # conservatively.
 

--- a/Makefile
+++ b/Makefile
@@ -76,10 +76,10 @@ rebuild-expected-api-docs: run-app-bg
 	git diff ./conbench/tests/api/_expected_docs.py
 
 
-# Build HTML docs, exiting non-zero if there are warnings. Those can be very bad.
+# Build HTML docs locally
 .PHONY: build-docs
 build-docs:
-	$(MAKE) -C docs html SPHINXOPTS='-W --keep-going'
+	$(MAKE) -C docs html
 	echo 'To see the generated docs, open docs/_build/html/index.html'
 
 # The targets above this comment have been in use by humans. Change

--- a/README.md
+++ b/README.md
@@ -116,17 +116,14 @@ This also deploys a kube-prometheus-based observability stack.
 Use this target for local development in this area.
 
 * `make docs-build`: Builds HTML docs locally so you may check that they render
-  correctly with no linting problems. You may install dependencies with
-  ```
-  pip install \
-      -r requirements-dev.txt \
-      -e ./benchclients/python \
-      -e ./benchalerts \
-      -e ./benchadapt/python \
-      -e ./benchconnect \
-      -e ./benchrun/python \
-      -e .
-  ```
+  correctly with no linting problems. Dependencies can be installed with
+  `pip install -r requirements-dev.txt`. Also, if you're working on the docstrings of
+  any of this repo's python packages, ensure the package is installed locally before
+  using this command.
+
+  In CI, we use `make build-docs SPHINXOPTS='-W --keep-going'` to fail the build if
+  there are Sphinx warnings. When using this command locally, you can just do
+  `make build-docs`, but keep an eye on the warnings.
 
 ### View API documentation
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,18 @@ Deploys the Conbench API server to a local minikube-powered Kubernetes cluster.
 This also deploys a kube-prometheus-based observability stack.
 Use this target for local development in this area.
 
+* `make docs-build`: Builds HTML docs locally so you may check that they render
+  correctly with no linting problems. You may install dependencies with
+  ```
+  pip install \
+      -r requirements-dev.txt \
+      -e ./benchclients/python \
+      -e ./benchalerts \
+      -e ./benchadapt/python \
+      -e ./benchconnect \
+      -e ./benchrun/python \
+      -e .
+  ```
 
 ### View API documentation
 
@@ -202,6 +214,9 @@ To add a new page to our GitHub Pages-hosted documentation:
 1. Add a Markdown file to `docs/pages/`.
 2. In the toctree in the `docs/index.rst` file, add `pages/your_new_page`, where
    `your_new_page` is your new filename without the `.md` file suffix.
+
+To test that your new pages pass our documentation linter, run the `make docs-build`
+command, as described above.
 
 ## Configuring the web application
 


### PR DESCRIPTION
To address @jonkeane 's thoughts in https://github.com/conbench/conbench/pull/761#issue-1592417932, this PR adds a Makefile target and instructions for iterating locally with docs. Closes #762 .