### PR TITLE
history: convert history stats calculations to pandas

### DIFF
--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -172,7 +172,7 @@ def set_z_scores(benchmark_results: List[BenchmarkResult]):
                 (benchmark_result.case_id, benchmark_result.context_id), (None, None)
             )
             benchmark_result.z_score = _calculate_z_score(
-                data_point=benchmark_result.mean,
+                data_point=float(benchmark_result.mean),
                 unit=benchmark_result.unit,
                 dist_mean=dist_mean,
                 dist_stddev=dist_stddev,

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -123,7 +123,7 @@ def get_history(case_id: str, context_id: str, hardware_hash: str, repo: str) ->
         .subquery()
     )
 
-    history_df = pd.read_sql(history.statement, Session.bind)
+    history_df = pd.read_sql(history.statement, Session.connection())
 
     history_df = _add_rolling_stats_columns_to_df(
         history_df, include_current_commit_in_rolling_stats=False
@@ -254,7 +254,7 @@ def _query_distribution_stats_by_run_id(
             ),
         )
 
-    history_df = pd.read_sql(history.statement, Session.bind)
+    history_df = pd.read_sql(history.statement, Session.connection())
 
     history_df = _add_rolling_stats_columns_to_df(
         history_df, include_current_commit_in_rolling_stats=True

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -321,7 +321,6 @@ class _CommitIndexer(pd.api.indexers.BaseIndexer):
         start_ixs = np.searchsorted(
             commit_ranks, commit_ranks - self.window_size, side=closed
         )
-        print([list(range(s, e)) for s, e in zip(start_ixs, end_ixs)])
         return start_ixs, end_ixs
 
 
@@ -388,7 +387,6 @@ def _add_rolling_stats_columns_to_df(
     ]
 
     # Add column with cumulative sum of distribution changes, to identify the segment
-    print("segment_id")
     df["segment_id"] = (
         df.groupby(["case_id", "context_id", "hash", "repository"])
         .rolling(
@@ -402,7 +400,6 @@ def _add_rolling_stats_columns_to_df(
     )
 
     # Add column with rolling mean of the means (only inside of the segment)
-    print("rolling_mean_excluding_this_commit")
     df["rolling_mean_excluding_this_commit"] = (
         df.groupby(["case_id", "context_id", "hash", "repository", "segment_id"])
         .rolling(
@@ -422,7 +419,6 @@ def _add_rolling_stats_columns_to_df(
 
     # ...but if requested, include the current commit
     if include_current_commit_in_rolling_stats:
-        print("rolling_mean")
         df["rolling_mean"] = (
             df.groupby(["case_id", "context_id", "hash", "repository", "segment_id"])
             .rolling(
@@ -443,7 +439,6 @@ def _add_rolling_stats_columns_to_df(
 
     # Add column with the rolling standard deviation of the residuals
     # (these can go outside the segment since we assume they don't change much)
-    print("rolling_stddev")
     df["rolling_stddev"] = (
         df.groupby(["case_id", "context_id", "hash", "repository"])  # not segment
         .rolling(

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -88,7 +88,7 @@ class _Serializer(EntitySerializer):
             "timestamp": history.timestamp.isoformat(),
             "run_name": history.name,
             "distribution_mean": _to_float(history.rolling_mean),
-            "distribution_stdev": _to_float(history.rolling_stddev or 0),
+            "distribution_stdev": _to_float(history.rolling_stddev) or 0.0,
         }
 
 
@@ -143,7 +143,7 @@ def get_history(case_id: str, context_id: str, hardware_hash: str, repo: str) ->
         history_df, include_current_commit_in_rolling_stats=False
     )
 
-    return history_df.itertuples()
+    return list(history_df.itertuples())
 
 
 def set_z_scores(benchmark_results: List[BenchmarkResult]):

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -120,7 +120,6 @@ def get_history(case_id: str, context_id: str, hardware_hash: str, repo: str) ->
             Commit.repository == repo,
             Hardware.hash == hardware_hash,
         )
-        .subquery()
     )
 
     history_df = pd.read_sql(history.statement, Session.connection())

--- a/conbench/tests/api/_fixtures.py
+++ b/conbench/tests/api/_fixtures.py
@@ -18,12 +18,6 @@ RESULTS_UP = [[1, 2, 3], [2, 3, 4], [10, 20, 30]]
 RESULTS_DOWN = [[10, 11, 12], [11, 12, 13], [1, 2, 3]]
 Z_SCORE_UP = 24.74873734152916  # Computed using statistics.stdev()
 Z_SCORE_DOWN = -13.435028842544401  # Computed using statistics.stdev()
-Z_SCORE_UP_COMPUTED_VIA_POSTGRES = (
-    Z_SCORE_UP + 0.000000000000004
-)  # Computed using sqlalchemy.func.stddev()
-Z_SCORE_DOWN_COMPUTED_VIA_POSTGRES = (
-    Z_SCORE_DOWN - 0.000000000000002
-)  # Computed using sqlalchemy.func.stddev()
 
 CLUSTER_INFO = {
     "name": f"cluster-{_uuid()}",

--- a/conbench/tests/api/test_benchmarks.py
+++ b/conbench/tests/api/test_benchmarks.py
@@ -85,7 +85,7 @@ class TestBenchmarkGet(_asserts.GetEnforcer):
                 "q3": 2.5,
                 "stdev": 1.0,
                 "times": [],
-                "z_score": -abs(_fixtures.Z_SCORE_DOWN_COMPUTED_VIA_POSTGRES),
+                "z_score": -abs(_fixtures.Z_SCORE_DOWN),
                 "z_regression": True,
                 "unit": "i/s",
             }
@@ -132,7 +132,7 @@ class TestBenchmarkGet(_asserts.GetEnforcer):
                 "q3": 25.0,
                 "stdev": 10.0,
                 "times": [],
-                "z_score": -abs(_fixtures.Z_SCORE_UP_COMPUTED_VIA_POSTGRES),
+                "z_score": -abs(_fixtures.Z_SCORE_UP),
                 "z_regression": True,
             }
         )
@@ -178,7 +178,7 @@ class TestBenchmarkGet(_asserts.GetEnforcer):
                 "q3": 25.0,
                 "stdev": 10.0,
                 "times": [],
-                "z_score": abs(_fixtures.Z_SCORE_UP_COMPUTED_VIA_POSTGRES),
+                "z_score": abs(_fixtures.Z_SCORE_UP),
                 "z_improvement": True,
                 "unit": "i/s",
             }
@@ -225,7 +225,7 @@ class TestBenchmarkGet(_asserts.GetEnforcer):
                 "q3": 2.5,
                 "stdev": 1.0,
                 "times": [],
-                "z_score": abs(_fixtures.Z_SCORE_DOWN_COMPUTED_VIA_POSTGRES),
+                "z_score": abs(_fixtures.Z_SCORE_DOWN),
                 "z_improvement": True,
             }
         )

--- a/conbench/tests/api/test_compare.py
+++ b/conbench/tests/api/test_compare.py
@@ -252,7 +252,7 @@ class TestCompareBenchmarksGet(_asserts.GetEnforcer):
                 "change": "-566.667%",
                 "regression": True,
                 "baseline_z_score": None,
-                "contender_z_score": -_fixtures.Z_SCORE_UP_COMPUTED_VIA_POSTGRES,
+                "contender_z_score": -_fixtures.Z_SCORE_UP,
                 "contender_z_regression": True,
             }
         )

--- a/conbench/tests/entities/test_history.py
+++ b/conbench/tests/entities/test_history.py
@@ -1,29 +1,28 @@
-import decimal
 from datetime import datetime
 
 from ...entities.commit import Commit
-from ...entities.history import get_history, set_z_scores
+from ...entities.history import get_history, set_z_scores, _to_float
 from ...tests.api import _fixtures
 
 # These correspond to the benchmark_results of _fixtures.gen_fake_data() without modification
 EXPECTED_Z_SCORES = [
     None,
     None,
-    decimal.Decimal("28.47704269814897756213593267"),
-    decimal.Decimal("0.7071067811865475244008443621"),
-    decimal.Decimal("2.121320343559642573202533086"),
-    decimal.Decimal("13.43502884254440296361604288"),
-    decimal.Decimal("1.092874886231796430755831194"),
-    decimal.Decimal("-2.185749772463593034070854952"),
-    decimal.Decimal("-4.486538431438487624231781225"),
-    decimal.Decimal("-4.946696853470236793924906443"),
+    28.477042698148946,
+    0.7071067811865444,
+    2.1213203435596393,
+    13.435028842544385,
+    1.0928748862317967,
+    -2.1857497724635935,
+    -4.486538431438488,
+    -4.946696853470237,
     None,
     None,
     None,
     None,
     None,
     None,
-    decimal.Decimal("-5.982052008847728203870175752"),
+    -5.98205200884773,
 ]
 
 
@@ -73,13 +72,13 @@ def test_get_history():
         if benchmark_result.id in actual_benchmark_result_ids:
             # we're on the default branch so the distribution stats should be available
             dist_mean, dist_stddev = [
-                (row.rolling_mean, row.rolling_stddev)
+                (_to_float(row.rolling_mean), _to_float(row.rolling_stddev))
                 for row in actual_history
                 if row.id == benchmark_result.id
             ][0]
             if dist_stddev:
                 assert (
-                    dist_mean - benchmark_result.mean
+                    dist_mean - _to_float(benchmark_result.mean)
                 ) / dist_stddev == expected_z_score
             else:
                 assert expected_z_score is None
@@ -115,9 +114,7 @@ def test_append_z_scores():
             name=benchmark_results[0].case.name,
         )
     )
-    expected_z_scores = EXPECTED_Z_SCORES + [
-        decimal.Decimal("-52.99938107760084621169252236")
-    ]
+    expected_z_scores = EXPECTED_Z_SCORES + [-52.99938107760085]
 
     set_z_scores(benchmark_results)
     for benchmark_result, expected_z_score in zip(benchmark_results, expected_z_scores):
@@ -126,11 +123,11 @@ def test_append_z_scores():
 
 def test_append_z_scores_with_distribution_change():
     expected_z_scores = EXPECTED_Z_SCORES.copy()
-    expected_z_scores[6] = decimal.Decimal("0")
-    expected_z_scores[7] = decimal.Decimal("-32.90896534380866857702148049")
-    expected_z_scores[8] = decimal.Decimal("-56.00297033789100726112978662")
-    expected_z_scores[9] = decimal.Decimal("-60.62177826491070527346062195")
-    expected_z_scores[16] = decimal.Decimal("-71.01408311032396903462530000")
+    expected_z_scores[6] = 0.0
+    expected_z_scores[7] = -32.90896534380864
+    expected_z_scores[8] = -56.00297033789095
+    expected_z_scores[9] = -60.62177826491064
+    expected_z_scores[16] = -71.0140831103239
 
     _, benchmark_results = _fixtures.gen_fake_data()
 

--- a/conbench/tests/entities/test_history.py
+++ b/conbench/tests/entities/test_history.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from ...entities.commit import Commit
-from ...entities.history import get_history, set_z_scores, _to_float
+from ...entities.history import _to_float, get_history, set_z_scores
 from ...tests.api import _fixtures
 
 # These correspond to the benchmark_results of _fixtures.gen_fake_data() without modification

--- a/requirements-webapp.txt
+++ b/requirements-webapp.txt
@@ -16,6 +16,7 @@ marshmallow
 numpy
 oauthlib
 openapi-spec-validator
+pandas
 prometheus-client
 prometheus-flask-exporter
 psutil


### PR DESCRIPTION
May address #744 and #745.

This PR replaces the SQL query logic for calculating history stats (rolling mean, rolling standard deviation, etc) with pandas logic. The SQL query was incredibly complex and often timing out. Since we're operating on a relatively small number of rows, it's much faster to grab the raw data and do these calculations in pandas. I think this will reduce the number of timeouts on Conbench instances with large data.

In previous PRs, we consolidated all this logic into `conbench.entities.history` so I'm happy that we only have to change it in one place!