### PR TITLE
hotfix: bug in nullable column

### DIFF
--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -372,7 +372,7 @@ def _add_rolling_stats_columns_to_df(
 
     # Clean up begins_distribution_change so it's a non-null boolean column
     df["begins_distribution_change"] = [
-        bool(x.get("begins_distribution_change", False))
+        bool(x.get("begins_distribution_change", False)) if x else False
         for x in df["change_annotations"]
     ]
 


### PR DESCRIPTION
This line was previously sometimes throwing `AttributeError: 'NoneType' object has no attribute 'get'`.

I'm not going to add a test in this PR, but we should eventually test for the case that `change_annotations` is null rather than `{}`.