### PR TITLE
benchconnect: Set log level to DEBUG

### DIFF
--- a/benchconnect/benchconnect/utils.py
+++ b/benchconnect/benchconnect/utils.py
@@ -1,9 +1,12 @@
+import logging
 from json import dumps, load, loads
 from pathlib import Path
 from typing import Any, Dict, List
 
 import click
 from benchclients.logging import fatal_and_log, log
+
+log.setLevel(logging.DEBUG)
 
 ENV_VAR_HELP = """
 


### PR DESCRIPTION
Closes #775. Just changes the logging level; does not add flags for now, since we don't have a use-case yet.