### PR TITLE
benchalerts: floor benchclients dependency

### DIFF
--- a/benchalerts/requirements.txt
+++ b/benchalerts/requirements.txt
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-benchclients
+benchclients>=2023.2.24
 pyjwt[crypto]


### PR DESCRIPTION
This is the main reason I like the PyPI wheel solution with sortable version strings. Now that `benchalerts` depends on a specific feature of `benchclients`, we can codify that dependency in its `requirements.txt` (but we don't have to prescribe where or how to get the correct `benchclients` code, so that it works for both CI on PR branches, and users)