### PR TITLE
ci: minikube: expose conbench http api via k8s ingress

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ build-conbench-container-image: set-build-info
 deploy-on-minikube:
 	minikube status || minikube status --profile mk-conbench
 	mkdir -p _build
-	cp ci/minikube/deploy-conbench.template.yml _build/deploy-conbench.yml
+	/bin/cp ci/minikube/deploy-conbench.template.yml _build/deploy-conbench.yml
 	sed -i.bak "s|<CONBENCH_CONTAINER_IMAGE_SPEC>|${CONTAINER_IMAGE_SPEC}|g" _build/deploy-conbench.yml
 	time minikube --profile mk-conbench image load ${CONTAINER_IMAGE_SPEC}
 	minikube --profile mk-conbench kubectl -- apply -f _build/deploy-conbench.yml

--- a/Makefile
+++ b/Makefile
@@ -281,6 +281,7 @@ jsonnet-kube-prom-manifests:
 		wget https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.12.0/build.sh -O build.sh
 	cp k8s/kube-prometheus/conbench-flavor.jsonnet _kpbuild/cb-kube-prometheus
 	cp k8s/kube-prometheus/conbench-grafana-dashboard.json _kpbuild/cb-kube-prometheus
+	cp k8s/kube-prometheus/kube-prom-no-req-no-lim.jsonnet _kpbuild/cb-kube-prometheus
 	@if [ -z "$${PROM_REMOTE_WRITE_ENDPOINT_URL:=}" ]; then \
 			echo "PROM_REMOTE_WRITE_ENDPOINT_URL not set"; \
 		else \

--- a/ci/minikube/deploy-conbench.template.yml
+++ b/ci/minikube/deploy-conbench.template.yml
@@ -81,8 +81,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    alb.ingress.kubernetes.io/target-type: ip
   name: "conbench-service"
   labels:
     app: conbench
@@ -90,8 +88,32 @@ spec:
   ports:
   - name: conbench-service-port
     port: 80
+    # The port number above: the port that will be exposed by this service.
+    # `targetPort` is documented with "Number or name of the port to access on
+    # the pods targeted by the service."
     targetPort: gunicorn-port
     protocol: TCP
   type: NodePort
   selector:
     app: "conbench"
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-conbenchservice
+spec:
+  rules:
+  - host: conbench.local
+    http:
+      # A list of paths (for example, /testpath), each of which has an
+      # associated backend defined with a service.name and a service.port.name
+      # or service.port.number
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: conbench-service
+            port:
+              number: 80
+  ingressClassName: nginx

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -24,6 +24,9 @@ minikube status --profile mk-conbench || true
 # Unclear if actually required.
 minikube addons disable metrics-server --profile mk-conbench
 
+# For testing the ingress controller spec
+minikube addons enable ingress --profile mk-conbench
+
 # postgres-operator vastly simplifies setting up PostgreSQL in minikube for us:
 # https://postgres-operator.readthedocs.io
 # Great docs: https://postgres-operator.readthedocs.io/en/latest/user/

--- a/k8s/kube-prometheus/conbench-flavor.jsonnet
+++ b/k8s/kube-prometheus/conbench-flavor.jsonnet
@@ -14,6 +14,7 @@ local kp =
   // (import 'kube-prometheus/addons/custom-metrics.libsonnet') +
   // (import 'kube-prometheus/addons/external-metrics.libsonnet') +
   // (import 'kube-prometheus/addons/pyrra.libsonnet') +
+  (import 'kube-prom-no-req-no-lim.jsonnet') +
   {
     values+:: {
       prometheus+: {

--- a/k8s/kube-prometheus/kube-prom-no-req-no-lim.jsonnet
+++ b/k8s/kube-prometheus/kube-prom-no-req-no-lim.jsonnet
@@ -1,0 +1,57 @@
+// Takes inspiration from
+// https://github.com/prometheus-operator/kube-prometheus/blob/c5360561fa3cb52297b652c263794ca474a0ab73/jsonnet/kube-prometheus/components/prometheus-operator.libsonnet
+{
+  values+:: {
+    alertmanager+: {
+      resources+: {
+        limits: {},
+        requests: { cpu: '1m', memory: '10Mi' },
+      },
+    },
+
+    blackboxExporter+: {
+      resources+: {
+        limits: {},
+        requests: { cpu: '1m', memory: '10Mi' },
+      },
+    },
+
+    grafana+: {
+      resources+: {
+        limits: {},
+        requests: { cpu: '1m', memory: '10Mi' },
+      },
+    },
+
+    kubeStateMetrics+: {
+      resources+: {
+        limits: {},
+      },
+    },
+
+    nodeExporter+: {
+      resources+: {
+        limits: {},
+      },
+    },
+
+    prometheusAdapter+: {
+      resources+: {
+        limits: {},
+      },
+    },
+
+    prometheusOperator+: {
+      resources+: {
+        limits: {},
+      },
+    },
+
+    prometheus+: {
+      resources+: {
+        limits: {},
+        requests: { cpu: '1m', memory: '10Mi' },
+      },
+    },
+  },
+}


### PR DESCRIPTION
This is towards https://github.com/conbench/conbench/issues/726.

On my system, I ran
```
$ minikube ip --profile mk-conbench
192.168.49.2
```
and then I added `192.168.49.2 conbench.local` to my `/etc/hosts`.

Then I opened `http://conbench.local` in the browser and got served the Conbench UI.

Playing with ingress controller in minikube kind of requires setting up a local DNS infrastructure, and the pragmatic version of that is to modify /etc/hosts -- this is also documented here: https://kubernetes.io/docs/tasks/access-application-cluster/ingress-minikube/.

Why? nginx (as any HTTP server) relies on the HOST HTTP header in requests to  make a fundamental routing decision. Ingress rules use that concept, too. In local dev one can use a DNS name to talk to the minikube cluster by modifying /etc/hosts -- however, that requires superuser privileges.

I tried a more dynamic option which requires looking up the IP address that exposes the ingress on the host:
```
$ kubectl get ingress
NAME                      CLASS   HOSTS       ADDRESS        PORTS   AGE
ingress-conbenchservice   nginx   localhost   192.168.49.2   80      104s
```

That IP address can be obtained via `minikube ip --profile mk-conbench`. I tried a Makefile target to execute this command, and to then dynamically inject this IP address as "expected host name" in the ingress rule (k8s spec). However, then I got this error:
```
The Ingress "ingress-conbenchservice" is invalid: spec.rules[0].host: Invalid value: "192.168.49.2": must be a DNS name, not an IP address
```


