### PR TITLE
ci: minikube: expose grafana via k8s ingress controller

### DIFF
--- a/ci/minikube/deploy-conbench.template.yml
+++ b/ci/minikube/deploy-conbench.template.yml
@@ -97,6 +97,19 @@ spec:
   selector:
     app: "conbench"
 ---
+# Create a bridge service of type ExternalName, pointing to a service in
+# another k8s namespace via magic DNS name. This bridge service now is in the
+# same namespace as the ingress rules defined further below (for an ingress
+# rule to apply it must be set up in the same namespace as the service that it
+# is referring to).
+kind: Service
+apiVersion: v1
+metadata:
+  name: grafana-bridge
+spec:
+  type: ExternalName
+  externalName: grafana.monitoring.svc.cluster.local
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -116,4 +129,11 @@ spec:
             name: conbench-service
             port:
               number: 80
+      - path: /grafana
+        pathType: Prefix
+        backend:
+          service:
+            name: grafana-bridge
+            port:
+              number: 3000
   ingressClassName: nginx

--- a/deploy.yml
+++ b/deploy.yml
@@ -49,6 +49,8 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
+    # "ip mode is required for sticky sessions to work with Application Load
+    # Balancers"
     alb.ingress.kubernetes.io/target-type: ip
   name: "conbench-service"
 spec:

--- a/k8s/kube-prometheus/conbench-flavor.jsonnet
+++ b/k8s/kube-prometheus/conbench-flavor.jsonnet
@@ -32,6 +32,20 @@ local kp =
           // `bash build.sh conbench-flavor.jsonnet`
           'conbench-grafana-dashboard.json': (importstr 'conbench-grafana-dashboard.json'),
         },
+        config: {
+          // http://docs.grafana.org/installation/configuration/
+          sections: {
+            'auth.anonymous': { enabled: true },
+            // Configure Grafana to be available under sub path instead of
+            // root.
+            server: {
+              domain: 'conbench.local',
+              serve_from_sub_path: true,
+              // root_url: 'http://conbench.local/grafana/',
+              root_url: '%(protocol)s://%(domain)s:%(http_port)s/grafana/',
+            },
+          },
+        },
       },
     },
     prometheus+: {


### PR DESCRIPTION
This is towards https://github.com/conbench/conbench/issues/726.

This patch took a few hours to build; k8s is complex :).

The outcome is a combination of Service definition and Ingress rule and Grafana config that allows for using the Grafana UI through k8s ingress, under a sub path of a common DNS name. 

Note the location bar in this screenshot:

![image](https://user-images.githubusercontent.com/265630/221889312-a9d71f05-2445-467c-9b13-5f642763b767.png)
