### PR TITLE
benchclients: bump general http req timeout to 75 s

### DIFF
--- a/benchclients/python/benchclients/base.py
+++ b/benchclients/python/benchclients/base.py
@@ -22,7 +22,7 @@ class BaseClient(abc.ABC):
     base_url: str
     # Note(JP): I have bumped this from 10 to 75 seconds to err on side of
     # caution (remove stress from DB, at the cost of potentially longer-running
-    # jobs, and at the cost of time-between-useful-logmsgs, this needs more
+    # jobs, and at the cost of time-between-useful-logmsgs). This needs more
     # context-specific timeout constants, also see
     # https://github.com/conbench/conbench/issues/801 and
     # https://github.com/conbench/conbench/issues/806

--- a/benchclients/python/benchclients/base.py
+++ b/benchclients/python/benchclients/base.py
@@ -20,7 +20,13 @@ class BaseClient(abc.ABC):
     """
 
     base_url: str
-    timeout_s = 10
+    # Note(JP): I have bumped this from 10 to 75 seconds to err on side of
+    # caution (remove stress from DB, at the cost of potentially longer-running
+    # jobs, and at the cost of time-between-useful-logmsgs, this needs more
+    # context-specific timeout constants, also see
+    # https://github.com/conbench/conbench/issues/801 and
+    # https://github.com/conbench/conbench/issues/806
+    timeout_s = 75
 
     def __init__(self, adapter: Optional[HTTPAdapter]):
         if not adapter:


### PR DESCRIPTION
This is for issue #806 and related to #801.