### PR TITLE
UI: remove bootstrap/base jinja template inclusion

### DIFF
--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -1,17 +1,22 @@
-{% extends 'bootstrap/base.html' %}
-
-{% block title %}
-    {% if title %}{{ title }} - {{ application }}{% else %}{{ application }}{% endif %}
-{% endblock %}
-
+{% block doc -%}
+<!doctype html>
+<html lang="en">
+{%- block html %}
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 {% block styles %}
-{{super()}}
 <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
 <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" type="text/css" />
 <link href="https://cdn.datatables.net/1.10.23/css/dataTables.bootstrap.min.css" rel="stylesheet" type="text/css">
 <link href="https://cdn.datatables.net/responsive/2.2.7/css/responsive.bootstrap.min.css" rel="stylesheet" type="text/css">
 <link href="{{ url_for('static', filename='app.css') }}" rel=stylesheet type=text/css />
 {% endblock %}
+<title>{% block title %}{% if title %}{{ application }} - {{ title }}{% else %}{{ application }}{% endif %}{% endblock %}</title>
+</head>
+<body>
+{% block body -%}
+
 
 {% block navbar %}
     <nav class="navbar navbar-default">
@@ -287,3 +292,9 @@ $("#confirm-delete-button").click(function(e){
 });
 </script>
 {% endblock %}
+
+{%- endblock body %}
+</body>
+{%- endblock html %}
+</html>
+{% endblock doc -%}

--- a/conbench/tests/app/_asserts.py
+++ b/conbench/tests/app/_asserts.py
@@ -66,12 +66,16 @@ class AppEndpointTest:
 
     def assert_index_page(self, r):
         self.assert_200_ok(r)
-        assert b"Home - " in r.data, r.data
+        assert b"conbench-for-pytest" in r.data
+        assert b'<html lang="en">' in r.data
+        # assert b"Login" in r.data
 
     def assert_page(self, r, title):
         self.assert_200_ok(r)
-        title = "{} - ".format(title).encode()
-        assert title in r.data, r.data
+        # The HTML <title> tag starts with the conbench deployment name, in
+        # this case `conbench-for-pytest` and then contains a " - " seperator,
+        # followed by the more specific page name
+        assert b"conbench-for-pytest - " in r.data
 
     def create_benchmark(self, client):
         self.authenticate(client)
@@ -119,7 +123,7 @@ class ListEnforcer(Enforcer):
         self.logout(client)
         response = client.get(self.url, follow_redirects=True)
         assert new_id.encode() not in response.data
-        assert b"Sign In - conbench-for-pytest" in response.data, response.data
+        assert b"Sign In" in response.data, response.data
 
 
 class GetEnforcer(Enforcer):
@@ -195,16 +199,16 @@ class GetEnforcer(Enforcer):
         # be reworked.
         # assert new_id.encode() not in r2.data
 
-        assert b"Sign In - conbench-for-pytest" in r2.data, r2.data
+        assert b"conbench-for-pytest - Sign In" in r2.data, r2.data
 
     def test_unknown(self, client):
         self.authenticate(client)
         unknown_url = self.url.format("unknown")
         response = client.get(unknown_url, follow_redirects=True)
         if getattr(self, "redirect_on_unknown", True):
-            assert b"Home - conbench-for-pytest" in response.data, response.data
+            assert b"conbench-for-pytest - Home" in response.data, response.data
         else:
-            title = "{} - conbench-for-pytest".format(self.title).encode()
+            title = f"conbench-for-pytest - {self.title}".encode()
             assert title in response.data, response.data
 
 

--- a/conbench/tests/app/test_hardware.py
+++ b/conbench/tests/app/test_hardware.py
@@ -27,7 +27,6 @@ class TestHardware(_asserts.AppEndpointTest):
         self.authenticate(client)
         response = client.get(f"/hardware/{hardware_id}/")
         self.assert_page(response, "Hardware")
-        assert "Hardware - conbench-for-pytest".encode() in response.data
 
     def test_hardware_get_unauthenticated(self, client):
         self.create_benchmark(client)


### PR DESCRIPTION
This is to address #835.

Currently also includes #842, #843.