### PR TITLE
Migrate UI libs: bootstrap 3->5, DataTables 1.10->1.13, fix obvious breakages, address small issues along the way

### DIFF
--- a/conbench/app/_util.py
+++ b/conbench/app/_util.py
@@ -60,6 +60,7 @@ def set_display_error(benchmark):
 
 
 def display_message(message):
+    # Note(JP): why is that important, useful?
     # truncate git shas in commit message
     for m in re.findall(r"\b[0-9a-f]{40}\b", message):
         message = message.replace(m, m[:7])

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -95,6 +95,11 @@ class BenchmarkMixin:
 class RunMixin:
     def get_display_run(self, run_id):
         run, response = self._get_run(run_id)
+
+        if response.status_code == 404:
+            self.flash(f"Run ID unknown: {run_id}", "info")
+            return None
+
         if response.status_code != 200:
             self.flash("Error getting run.")
             return None

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -166,7 +166,7 @@ class Benchmark(AppEndpoint, BenchmarkMixin, RunMixin, TimeSeriesPlotMixin):
         if benchmark is None:
             return self.redirect("app.index")
 
-        update_button_color = "default"
+        update_button_color = "secondary"
         if flask_login.current_user.is_authenticated:
             if benchmark["change_annotations"].get("begins_distribution_change", False):
                 update_form.toggle_distribution_change.label.text = (

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -213,7 +213,7 @@ class Benchmark(AppEndpoint, BenchmarkMixin, RunMixin, TimeSeriesPlotMixin):
                     "api.benchmark", benchmark_id=benchmark_id
                 )
                 if delete_response.status_code == 204:
-                    self.flash("Benchmark deleted.")
+                    self.flash(f"Benchmark result {benchmark_id} deleted.", "info")
                     return self.redirect("app.benchmarks")
 
         elif update_form.validate_on_submit():

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -89,12 +89,8 @@
         {% if messages %}
             <!-- Categories: success (green), info (blue), warning (yellow), danger (red) -->
             {% for category, message in messages %}
-            <div align="center">
-                <span class="flash-message">
-                    <span class="glyphicon glyphicon-flash submenu"></span>
-                    {{ message }}
-                </span>
-                <br>
+            <div class="alert alert-{{ category }}" role="alert">
+                <i class="bi bi-lightning"></i> {{ message }}
             </div>
             {% endfor %}
         {% endif %}

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -7,9 +7,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 {% block styles %}
 <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
-<link href="https://cdn.datatables.net/1.10.23/css/dataTables.bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://cdn.datatables.net/responsive/2.2.7/css/responsive.bootstrap.min.css" rel="stylesheet" type="text/css">
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
+<link href="https://cdn.datatables.net/v/bs5/dt-1.13.3/r-2.4.0/datatables.min.css" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.3/font/bootstrap-icons.css">
 <link href="{{ url_for('static', filename='app.css') }}" rel=stylesheet type=text/css>
 {% endblock %}
 <title>{% block title %}{% if title %}{{ application }} - {{ title }}{% else %}{{ application }}{% endif %}{% endblock %}</title>

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -59,26 +59,26 @@
         </div>
     </nav>
 
-    <div class="modal fade" id="confirm-delete" tabindex="-1" role="dialog" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4 class="modal-title"><span class="glyphicon glyphicon-trash submenu"></span>&nbsp; &nbsp; Confirm Delete</h4>
-                </div>
-                <div class="modal-body">
-                    <p>Are you sure?</p>
-                    <p id="confirm-delete-message"></p>
-                    <input id="delete-form-id" type="hidden" value="">
-                    <input id="delete-form-action" type="hidden" value="">
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-                    <button id="confirm-delete-button" type="button" class="btn btn-primary" data-dismiss="modal">Delete</button>
-                </div>
+<!-- modal hidden by default, used for confirming deletion -->
+<div class="modal fade" id="confirm-delete" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title"><i class="bi bi-trash3-fill"></i></h4>
+            </div>
+            <div class="modal-body">
+                <p>Are you sure?</p>
+                <p id="confirm-delete-message"></p>
+                <input id="delete-form-id" type="hidden" value="">
+                <input id="delete-form-action" type="hidden" value="">
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                <button id="confirm-delete-button" type="button" class="btn btn-danger" data-dismiss="modal">Delete</button>
             </div>
         </div>
     </div>
+</div>
 {% endblock %}
 
 {% block content %}

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -117,7 +117,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script type="text/javascript" src="https://code.jquery.com/jquery-3.5.1.js"></script>
+<script src="https://code.jquery.com/jquery-3.6.4.js"></script>
 <script type="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://cdn.datatables.net/1.10.23/js/jquery.dataTables.min.js"></script>
 <script type="text/javascript" src="https://cdn.datatables.net/1.10.23/js/dataTables.bootstrap.min.js"></script>

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -7,10 +7,10 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 {% block styles %}
 <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
-<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" type="text/css" />
 <link href="https://cdn.datatables.net/1.10.23/css/dataTables.bootstrap.min.css" rel="stylesheet" type="text/css">
 <link href="https://cdn.datatables.net/responsive/2.2.7/css/responsive.bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="{{ url_for('static', filename='app.css') }}" rel=stylesheet type=text/css />
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
+<link href="{{ url_for('static', filename='app.css') }}" rel=stylesheet type=text/css>
 {% endblock %}
 <title>{% block title %}{% if title %}{{ application }} - {{ title }}{% else %}{{ application }}{% endif %}{% endblock %}</title>
 </head>

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -18,46 +18,42 @@
 {% block body -%}
 
 
+
 {% block navbar %}
-    <nav class="navbar navbar-default">
-        <div class="container">
-            <div class="navbar-header">
-                <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
-                    <span class="sr-only">Toggle navigation</span>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                </button>
-                <a class="navbar-brand" href="{{ url_for('app.index') }}">{{ application }}</a>
-            </div>
-            <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-                {% if current_user.is_anonymous %}
-                    <ul class="nav navbar-nav navbar-right">
-                        <li><a href="{{ url_for('app.login') }}">Login</a></li>
-                    </ul>
-                {% else %}
-                    <ul class="nav navbar-nav navbar-right">
-                    <li class="dropdown">
-                        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                            <span class="glyphicon glyphicon-cog"></span>
-                            <span class="caret"></span>
-                        </a>
-                        <ul class="dropdown-menu">
-                            <li><a href="#">{{ current_user.name }}</a></li>
-                            <li role="separator" class="divider"></li>
-                            <li><a href="{{ url_for('app.users') }}""><span class="glyphicon glyphicon-user submenu"></span> &nbsp; Users</a></li>
-                            <li role="separator" class="divider"></li>
-                            <li><a href="{{ url_for('app.hardwares') }}""><span class="glyphicon glyphicon-blackboard submenu"></span> &nbsp; Hardware</a></li>
-                            <li role="separator" class="divider"></li>
-                            <li><a href="/api/docs"><span class="glyphicon glyphicon-book submenu"></span> &nbsp; API Docs</a></li>
-                        </ul>
+<!-- Note(JP): based on navbarTogglerDemo02 bootstrap 5.2 docs demo -->
+<nav class="navbar navbar-expand-lg bg-light">
+    <div class="container">
+        <a class="navbar-brand" href="{{ url_for('app.index') }}">{{ application }}</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarToggler" aria-controls="navbarToggler" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarToggler">
+            {% if current_user.is_anonymous %}
+                <!-- ms-auto for right alignment -->
+                <ul class="nav navbar-nav ms-auto">
+                    <li class="nav-item">
+                        <a class="btn btn-outline-dark" href="{{ url_for('app.login') }}">Login</a>
                     </li>
-                         <li><a href="{{ url_for('app.logout') }}">Logout</a></li>
-                    </ul>
-                {% endif %}
-            </div>
+                </ul>
+            {% else %}
+            <!-- ms-auto for right alignment -->
+            <ul class="nav navbar-nav ms-auto">
+                <li class="nav-item">
+                    <a class="nav-link" href="{{ url_for('app.users') }}">Users</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="{{ url_for('app.hardwares') }}">Hardware</a>
+                </li>
+
+                <li class="nav-item">
+                    <a class="nav-link" href="{{ url_for('app.logout') }}">Logout ({{ current_user.email }})</a>
+                </li>
+
+            </ul>
+            {% endif %}
         </div>
-    </nav>
+    </div>
+</nav>
 
 <!-- modal hidden by default, used for confirming deletion -->
 <div class="modal fade" id="confirm-delete" tabindex="-1" role="dialog" aria-hidden="true">

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -121,7 +121,7 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4" crossorigin="anonymous"></script>
 <script src="https://cdn.datatables.net/v/bs5/dt-1.13.3/r-2.4.0/datatables.min.js"></script>
 
-<script type="text/javascript">
+<script>
 $(document).ready(function() {
     setTimeout(function() {
         $(".flash-message").fadeOut("slow");

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -265,9 +265,11 @@ function column_search_implementation(data_table_id) {
 }
 
 $("#confirm-delete").on("show.bs.modal", function(e) {
-    $(this).find("#confirm-delete-message").html($(e.relatedTarget).data("message"));
-    $(this).find("#delete-form-id").attr("value", $(e.relatedTarget).data("form-id"));
-    $(this).find("#delete-form-action").attr("value", $(e.relatedTarget).data("href"));
+    // using cbcustom- prefix to indicate that this is introduced and used by
+    // conbench. for example, bootstrap 5 uses the bs- prefix
+    $(this).find("#confirm-delete-message").html($(e.relatedTarget).data("cbcustom-message"));
+    $(this).find("#delete-form-id").attr("value", $(e.relatedTarget).data("cbcustom-form-id"));
+    $(this).find("#delete-form-action").attr("value", $(e.relatedTarget).data("cbcustom-href"));
 });
 
 $("#confirm-delete-button").click(function(e){

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -95,8 +95,10 @@
             {% endfor %}
         {% endif %}
 
-        {# application content needs to be provided in the app_content block #}
-        {% block app_content %}{% endblock %}
+    {% endwith %}
+    {# application content needs to be provided in the app_content block #}
+    {% block app_content %}
+    {% endblock %}
     <br>
     <hr>
     <div style="display:inline-block; float: right; color: #918d8c;">

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -97,13 +97,7 @@
                 <br>
             </div>
             {% endfor %}
-        {% else %}
-            <div align="center">
-                <span class="flash-message"></span>
-                <br>
-            </div>
         {% endif %}
-        {% endwith %}
 
         {# application content needs to be provided in the app_content block #}
         {% block app_content %}{% endblock %}

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -118,7 +118,7 @@
 
 {% block scripts %}
 <script src="https://code.jquery.com/jquery-3.6.4.js"></script>
-<script type="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4" crossorigin="anonymous"></script>
 <script src="https://cdn.datatables.net/v/bs5/dt-1.13.3/r-2.4.0/datatables.min.js"></script>
 
 <script type="text/javascript">

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -119,10 +119,7 @@
 {% block scripts %}
 <script src="https://code.jquery.com/jquery-3.6.4.js"></script>
 <script type="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-<script type="text/javascript" src="https://cdn.datatables.net/1.10.23/js/jquery.dataTables.min.js"></script>
-<script type="text/javascript" src="https://cdn.datatables.net/1.10.23/js/dataTables.bootstrap.min.js"></script>
-<script type="text/javascript" src="https://cdn.datatables.net/responsive/2.2.7/js/dataTables.responsive.min.js"></script>
-<script type="text/javascript" src="https://cdn.datatables.net/responsive/2.2.7/js/responsive.bootstrap.min.js"></script>
+<script src="https://cdn.datatables.net/v/bs5/dt-1.13.3/r-2.4.0/datatables.min.js"></script>
 
 <script type="text/javascript">
 $(document).ready(function() {

--- a/conbench/templates/benchmark-entity.html
+++ b/conbench/templates/benchmark-entity.html
@@ -10,7 +10,7 @@
     <li class="breadcrumb-item active">
       <a href="{{ url_for('app.batch', batch_id=benchmark.batch_id) }}">Batch</a>
     </li>
-    <li class="breadcrumb-item active aria-current="page">Benchmark {{ benchmark.id }}</li>
+    <li class="breadcrumb-item active aria-current="page">Benchmark result {{ benchmark.id }}</li>
   </ol>
 </nav>
 

--- a/conbench/templates/benchmark-entity.html
+++ b/conbench/templates/benchmark-entity.html
@@ -10,8 +10,7 @@
     <li class="breadcrumb-item active">
       <a href="{{ url_for('app.batch', batch_id=benchmark.batch_id) }}">Batch</a>
     </li>
-    <li class="breadcrumb-item active">Benchmark</li>
-    <li class="breadcrumb-item active" aria-current="page">{{ benchmark.id }}</li>
+    <li class="breadcrumb-item active aria-current="page">Benchmark {{ benchmark.id }}</li>
   </ol>
 </nav>
 

--- a/conbench/templates/benchmark-entity.html
+++ b/conbench/templates/benchmark-entity.html
@@ -47,7 +47,7 @@
 <div class="row">
   <div class="col-md-6">
     <ul class="list-group">
-      <li class="list-group-item active">Benchmark</li>
+      <li class="list-group-item list-group-item-primary">Benchmark</li>
       <li class="list-group-item" style="overflow-y: auto;">
         <b>benchmark</b>
         <div class="ellipsis-500" align="right" style="display:inline-block; float: right;">
@@ -84,7 +84,7 @@
       </li>
 
       {% if benchmark.error %}
-      <li class="list-group-item active">Error</li>
+      <li class="list-group-item list-group-item-primary">Error</li>
       <li class="list-group-item" style="overflow-y: auto;">
         <b>timestamp</b>
         <div align="right" style="display:inline-block; float: right;">
@@ -101,7 +101,7 @@
       {% endfor %}
       {% endif %}
       {% if benchmark.stats %}
-      <li class="list-group-item active">Result</li>
+      <li class="list-group-item list-group-item-primary">Result</li>
       <li class="list-group-item" style="overflow-y: auto;">
         <b>timestamp (start time)</b>
         <div align="right" style="display:inline-block; float: right;">
@@ -118,7 +118,7 @@
       {% endfor %}
       {% endif %}
 
-      <li class="list-group-item active">Tags</li>
+      <li class="list-group-item list-group-item-primary">Tags</li>
       {% for k,v in benchmark.tags.items() %}
       <li class="list-group-item" style="overflow-y: auto;">
         <b>{{ k }}</b>
@@ -128,7 +128,7 @@
       </li>
       {% endfor %}
       {% if benchmark.optional_benchmark_info %}
-      <li class="list-group-item active">Additional Benchmark Details</li>
+      <li class="list-group-item list-group-item-primary">Additional Benchmark Details</li>
       {% for k,v in benchmark.optional_benchmark_info.items() %}
       <li class="list-group-item" style="overflow-y: auto;">
         <b>{{ k }}</b>
@@ -139,7 +139,7 @@
       {% endfor %}
       {% endif %}
       {% if benchmark.validation %}
-      <li class="list-group-item active">Validation</li>
+      <li class="list-group-item list-group-item-primary">Validation</li>
       {% for k,v in benchmark.validation.items() %}
       <li class="list-group-item" style="overflow-y: auto;">
         <b>{{ k }}</b>
@@ -155,7 +155,7 @@
   <div class="col-md-6">
     <ul class="list-group">
       {% if run and run.commit.url %}
-      <li class="list-group-item active">Commit</li>
+      <li class="list-group-item list-group-item-primary">Commit</li>
       <li class="list-group-item" style="overflow-y: auto;">
         <b>commit</b>
         <div class="ellipsis-500" align="right" style="display:inline-block; float: right;">
@@ -205,14 +205,14 @@
       </li>
       {% endif %}
       {% endif %}
-      <li class="list-group-item active">Hardware</li>
+      <li class="list-group-item list-group-item-primary">Hardware</li>
       {% for k,v in run.hardware.items() %}
       <li class="list-group-item" style="overflow-y: auto;">
         <b>{{ k }}</b>
         <div align="right" style="display:inline-block; float: right;">{{ v }}</div>
       </li>
       {% endfor %}
-      <li class="list-group-item active">Context</li>
+      <li class="list-group-item list-group-item-primary">Context</li>
       {% for k,v in benchmark.context.items() %}
       <li class="list-group-item" style="overflow-y: auto;">
         <b>{{ k }}</b>
@@ -220,7 +220,7 @@
       </li>
       {% endfor %}
       {% if benchmark.info and benchmark.info|length > 1 %}
-      <li class="list-group-item active">Additional Context Details</li>
+      <li class="list-group-item list-group-item-primary">Additional Context Details</li>
       {% for k,v in benchmark.info.items() %}
       <li class="list-group-item" style="overflow-y: auto;">
         <b>{{ k }}</b>

--- a/conbench/templates/benchmark-entity.html
+++ b/conbench/templates/benchmark-entity.html
@@ -233,10 +233,12 @@
   </div>
 </div>
 
-<div class="row">
-  <div class="col-md-8">
-    {{ wtf.quick_form(delete_form, id="delete-form", button_map={'delete': 'danger'}) }}
-  </div>
+<div class="row mt-5">
+  <br />
+  <form method="post" id="delete-form">
+    {{ delete_form.hidden_tag() }}
+    <input class="btn btn-danger" id="delete" name="delete" type="button" value="Delete benchmark result"></input>
+  </form>
 </div>
 
 

--- a/conbench/templates/benchmark-entity.html
+++ b/conbench/templates/benchmark-entity.html
@@ -252,11 +252,11 @@
 <script type="text/javascript">
   $(document).ready(function ($) {
     $("#delete-form").find("#delete").attr("type", "button");
-    $("#delete-form").find("#delete").attr("data-toggle", "modal");
-    $("#delete-form").find("#delete").attr("data-target", "#confirm-delete");
-    $("#delete-form").find("#delete").attr("data-form-id", "#delete-form");
-    $("#delete-form").find("#delete").attr("data-href", "{{ url_for('app.benchmark', benchmark_id=benchmark.id) }}");
-    $("#delete-form").find("#delete").attr("data-message", "<ul><li>Delete benchmark: <strong>{{ benchmark.id }}</strong></li></ul>");
+    $("#delete-form").find("#delete").attr("data-bs-toggle", "modal");
+    $("#delete-form").find("#delete").attr("data-bs-target", "#confirm-delete");
+    $("#delete-form").find("#delete").attr("data-cbcustom-form-id", "#delete-form");
+    $("#delete-form").find("#delete").attr("data-cbcustom-href", "{{ url_for('app.benchmark', benchmark_id=benchmark.id) }}");
+    $("#delete-form").find("#delete").attr("data-cbcustom-message", "<ul><li>Delete benchmark result: <strong>{{ benchmark.id }}</strong></li></ul>");
   });
 
   {% if plot_history %}

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -3,21 +3,19 @@
 {% block app_content %}
 <div class="row">
   <div class="col-md-12">
-
-<div class="jumbotron">
-<div class="media">
-  <div class="media-body">
-    <h4 class="media-heading">Con·bench</h4>
-     <h4>/kənˈben(t)SH/</h4>
-     <h5><i>noun</i></h5>
-     <h3>Language-independent Continuous Benchmarking (CB) Framework</h3>
-  </div>
-  <div class="media-right">
-     <img class="media-object" style="padding: 5px" src="{{ url_for('static', filename='bar-graph.png') }}" height="150">
-  </div>
-</div>
-</div>
-
+    <div class="jumbotron">
+      <div class="media">
+        <div class="media-body">
+          <h4 class="media-heading">Con·bench</h4>
+          <h4>/kənˈben(t)SH/</h4>
+          <h5><i>noun</i></h5>
+          <h3>Language-independent Continuous Benchmarking (CB) Framework</h3>
+        </div>
+        <div class="media-right">
+          <img class="media-object" style="padding: 5px" src="{{ url_for('static', filename='bar-graph.png') }}" height="150">
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -21,10 +21,10 @@
 
 
 <div class="row">
+    <hr />
     <div class="col-md-12">
+        <h4>Recent runs</h4>
         <table id="runs" class="table table-striped table-bordered table-hover">
-          <caption>Runs
-          </caption>
             <thead>
                 <tr>
                     <th scope="col">Run creation time</th>

--- a/conbench/templates/login.html
+++ b/conbench/templates/login.html
@@ -1,7 +1,14 @@
 {% extends "app.html" %}
 {% block app_content %}
 
+<div class="row">
+<div class="col-md-4"></div>
 
+<!-- center column, also see
+     https://getbootstrap.com/docs/5.2/examples/grid/#containers
+-->
+<div class="col-md-4">
+<h4>Sign in</h4>
 <form method="post" novalidate>
   {{ form.hidden_tag() }}
   <div class="mb-3">
@@ -13,6 +20,7 @@
       {{ form.password(class_="form-control", size=80) }}
   </div>
   <div class="mb-3 form-check">
+
       {{ form.remember_me(class_="form-check-input") }} {{ form.remember_me.label }}
   </div>
   <button type="submit" class="btn btn-primary">Sign in</button>
@@ -32,7 +40,9 @@
   {% endif %}
 {% endif %}
 
-
+</div>
+<div class="col-md-4"></div>
+</div>
 
 
 {% endblock %}

--- a/conbench/templates/login.html
+++ b/conbench/templates/login.html
@@ -1,45 +1,38 @@
 {% extends "app.html" %}
-{% import 'bootstrap/wtf.html' as wtf %}
-
 {% block app_content %}
-<h1>{{ title }}</h1>
-<br/>
-<div class="row">
 
-<div class="col-md-4">
-  {{ wtf.quick_form(form) }}
-  <br>
-  <p>New user? <a href="{{ url_for('app.register') }}">Sign Up</a></p>
-  {% if sso %}
-  <hr>
-    {# Dynamically add `target` URL query parameter. `url_for()` is documented
-    with "unknown keys are appended as query string arguments". I think
-    that url_for() automatically performs URL-encoding. #}
-    {% if target_url_after_login %}
-    <a href="{{ url_for('api.google', target=target_url_after_login) }}">Google Login</a>
-    {% else %}
-    <a href="{{ url_for('api.google' ) }}">Google Login</a>
-    {% endif %}
+
+<form method="post" novalidate>
+  {{ form.hidden_tag() }}
+  <div class="mb-3">
+    {{ form.email.label }}
+    {{ form.email(class_="form-control", size=80) }}
+  </div>
+  <div class="mb-3">
+      {{ form.password.label }}
+      {{ form.password(class_="form-control", size=80) }}
+  </div>
+  <div class="mb-3 form-check">
+      {{ form.remember_me(class_="form-check-input") }} {{ form.remember_me.label }}
+  </div>
+  <button type="submit" class="btn btn-primary">Sign in</button>
+</form>
+
+<br>
+<p>New user? <a href="{{ url_for('app.register') }}">Sign Up</a></p>
+{% if sso %}
+<hr>
+  {# Dynamically add `target` URL query parameter. `url_for()` is documented
+  with "unknown keys are appended as query string arguments". I think
+  that url_for() automatically performs URL-encoding. #}
+  {% if target_url_after_login %}
+  <a href="{{ url_for('api.google', target=target_url_after_login) }}">Google Login</a>
+  {% else %}
+  <a href="{{ url_for('api.google' ) }}">Google Login</a>
   {% endif %}
-</div>
+{% endif %}
 
-<div class="col-md-8">
-  <div class="jumbotron">
-    <div class="media">
 
-  <div class="media-body">
-    <h4 class="media-heading">Con·bench</h4>
-     <h4>/kənˈben(t)SH/</h4>
-     <h5><i>noun</i></h5>
-     <h3>Language-independent Continuous Benchmarking (CB) Framework</h3>
-  </div>
-  <div class="media-right">
-     <img class="media-object" style="padding: 5px" src="{{ url_for('static', filename='bar-graph.png') }}" height="150">
-  </div>
 
-    </div>
-  </div>
-</div>
 
-</div>
 {% endblock %}

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -122,11 +122,15 @@
                 {% endfor %}
             </tbody>
         </table>
-        {% if run_id %}
-            {{ wtf.quick_form(form, id="run-form", button_map={'delete': 'primary'}) }}
-        {%  endif %}
     </div>
 
+    {% if run %}
+    <br />
+    <form method="post" id="run-form">
+      {{ form.hidden_tag() }}
+      <input class="btn btn-danger" id="delete" name="delete" type="button" value="Delete Run"></input>
+    </form>
+    <br />
     <div class="col-md-12">
         <ul class="list-group">
             <li class="list-group-item active">Run</li>

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -73,8 +73,9 @@
 {% endif %}
 
     <div class="col-md-12">
+        <h4>Benchmarks in run:</h4>
         <table id="benchmarks" class="table table-striped table-bordered table-hover">
-        <caption>Benchmarks{% include 'units-tooltip.html' %}</caption>
+        <!-- does not display right: <caption>Benchmarks{% include 'units-tooltip.html' %}</caption>-->
             <thead>
                 <tr>
                     <th scope="col">Date</th>

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -2,21 +2,21 @@
 {% import 'bootstrap/wtf.html' as wtf %}
 
 {% block app_content %}
-    <nav aria-label="breadcrumb">
-      <ol class="breadcrumb">
-        <li class="breadcrumb-item active">Run</li>
-        {% if run_id %}
-        <li class="breadcrumb-item active" aria-current="page">{{ run_id }}</li>
-        {% endif %}
-        {% if compare_runs_url %}
-        <span align="right" style="display:inline-block; float: right;">
-          <a href="{{ compare_runs_url }}">compare <span class="glyphicon glyphicon-arrow-right"></span></a>
-        </span>
-        {% endif %}
-      </ol>
-    </nav>
-
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item active">Run</li>
+    {% if run_id %}
+    <li class="breadcrumb-item active" aria-current="page">{{ run_id }}</li>
     {% endif %}
+  </ol>
+</nav>
+
+{% if compare_runs_url %}
+<p class="fs-5">
+  <i class="bi bi-file-diff"></i> <a href="{{ compare_runs_url }}">compare to baseline</a>
+</p>
+
+{% endif %}
 
 
 {% if plot_history %}

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -134,24 +134,18 @@
     <br />
     <div class="col-md-12">
         <ul class="list-group">
-            <li class="list-group-item active">Run</li>
+            <li class="list-group-item list-group-item-secondary">Run details:</li>
             <li class="list-group-item" style="overflow-y: auto;">
-                <b>Timestamp</b>
-                {% if run.timestamp is not none %}
-                    <div align="right" style="display:inline-block; float: right;">{{ run.timestamp }}</div>
-                {% endif %}
+                Timestamp:
+                <div align="right" style="display:inline-block; float: right;">{{ run.timestamp }}</div>
             </li>
             <li class="list-group-item" style="overflow-y: auto;">
-                <b>Finished Timestamp</b>
-                {% if run.finished_timestamp is not none %}
-                    <div align="right" style="display:inline-block; float: right;">{{ run.finished_timestamp }}</div>
-                {% endif %}
+                Finished Timestamp:
+                <div align="right" style="display:inline-block; float: right;">{{ run.finished_timestamp }}</div>
             </li>
             <li class="list-group-item" style="overflow-y: auto;">
-                <b>Error Type</b>
-                {% if run.error_type is not none %}
-                    <div align="right" style="display:inline-block; float: right;">{{ run.error_type }}</div>
-                {% endif %}
+                Error Type:
+                <div align="right" style="display:inline-block; float: right;">{{ run.error_type }}</div>
             </li>
             {% if run.error_info %}
                 <li class="list-group-item active">Error Info</li>

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -60,7 +60,7 @@
 {% endif %}
 
     <div class="col-md-12">
-        <h4>Benchmarks in run:</h4>
+        <h4>Benchmarks in run</h4>
         <table id="benchmarks" class="table table-striped table-bordered table-hover">
         <!-- does not display right: <caption>Benchmarks{% include 'units-tooltip.html' %}</caption>-->
             <thead>

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -16,19 +16,6 @@
       </ol>
     </nav>
 
-    {% if run %}
-      {% if run.commit.display_message %}
-    <div class="row">
-      <div class="col-md-12">
-        <ul class="list-group">
-          <li class="list-group-item" align="right" style="border-style:none">
-          Commit:
-          <a href="{{ run.commit.url }}">{{ run.commit.display_message }}</a>
-          </li>
-         </ul>
-      </div>
-    </div>
-      {% endif %}
     {% endif %}
 
 
@@ -135,6 +122,12 @@
     <div class="col-md-12">
         <ul class="list-group">
             <li class="list-group-item list-group-item-secondary">Run details:</li>
+
+            <li class="list-group-item">
+              Commit:
+              <div align="right" style="display:inline-block; float: right;"><a href="{{ run.commit.url }}">{{ run.commit.display_message }}</a></div>
+            </li>
+
             <li class="list-group-item" style="overflow-y: auto;">
                 Timestamp:
                 <div align="right" style="display:inline-block; float: right;">{{ run.timestamp }}</div>

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -195,11 +195,11 @@ $(document).ready(function() {
     $('#unit-tooltip').tooltip()
     {% if run_id %}
         $("#run-form").find("#delete").attr("type", "button");
-        $("#run-form").find("#delete").attr("data-toggle", "modal");
-        $("#run-form").find("#delete").attr("data-target", "#confirm-delete");
-        $("#run-form").find("#delete").attr("data-form-id", "#run-form");
-        $("#run-form").find("#delete").attr("data-href", "{{ url_for('app.run', run_id=run_id) }}");
-        $("#run-form").find("#delete").attr("data-message", "<ul><li>Delete run: <strong>{{ run_id }}</strong></li></ul>");
+        $("#run-form").find("#delete").attr("data-bs-toggle", "modal");
+        $("#run-form").find("#delete").attr("data-bs-target", "#confirm-delete");
+        $("#run-form").find("#delete").attr("data-cbcustom-form-id", "#run-form");
+        $("#run-form").find("#delete").attr("data-cbcustom-href", "{{ url_for('app.run', run_id=run_id) }}");
+        $("#run-form").find("#delete").attr("data-cbcustom-message", "<ul><li>Delete run: <strong>{{ run_id }}</strong></li></ul>");
     {% endif %}
 });
 

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -176,6 +176,7 @@
             {% endif %}
         </ul>
     </div>
+    {% endif %}
 
 
 {% endblock %}

--- a/conbench/tests/app/_asserts.py
+++ b/conbench/tests/app/_asserts.py
@@ -56,7 +56,7 @@ class AppEndpointTest:
 
     def assert_login_page(self, r):
         self.assert_200_ok(r)
-        assert b"<h1>Sign In</h1>" in r.data, r.data
+        assert b"Sign in" in r.data
         assert b"New user?" in r.data
 
     def assert_registration_page(self, r):

--- a/conbench/tests/app/test_benchmarks.py
+++ b/conbench/tests/app/test_benchmarks.py
@@ -1,3 +1,5 @@
+import re
+
 from ...tests.app import _asserts
 
 
@@ -39,7 +41,9 @@ class TestBenchmarkDelete(_asserts.DeleteEnforcer):
             f"/benchmarks/{benchmark_id}/", data=data, follow_redirects=True
         )
         self.assert_page(response, "Benchmarks")
-        assert b"Benchmark deleted." in response.data
+        assert re.search(
+            r"Benchmark result \w+ deleted\.", response.text, flags=re.ASCII
+        )
 
         # cannot get benchmark after
         response = client.get(f"/benchmarks/{benchmark_id}/", follow_redirects=True)

--- a/conbench/tests/app/test_runs.py
+++ b/conbench/tests/app/test_runs.py
@@ -1,3 +1,5 @@
+import re
+
 from ...tests.api import _fixtures
 from ...tests.app import _asserts
 
@@ -28,7 +30,7 @@ class TestRunDelete(_asserts.DeleteEnforcer):
 
         response = client.get(f"/runs/{run_id}/", follow_redirects=True)
         self.assert_page(response, "Run")
-        assert b"Error getting run." in response.data
+        assert re.search(r"Run ID unknown: \w+", response.text, flags=re.ASCII)
 
     def test_unauthenticated(self, client):
         self.create_benchmark(client)

--- a/conbench/tests/populate_local_conbench.py
+++ b/conbench/tests/populate_local_conbench.py
@@ -108,7 +108,7 @@ def generate_benchmarks_data(
         fields_set = {
             f"{benchmark_language}_specific_{key}_field_1": "value-1",
             f"{benchmark_language}_specific_{key}_field_2": f"{benchmark_language}-{key}-value-2",
-            f"{key}_field_3": f"{benchmark_language}-{key}-value-2",
+            f"{key}_field_3": f"{benchmark_language}-{key}-value-3",
             f"{key}_field_4": None if benchmark_language == "Python" else "value-4",
         }
         data[key].update(fields_set)
@@ -427,7 +427,7 @@ def generate_synthetic_benchmark_history():
         for c in reversed(ARROW_COMMIT_HASH_LINES_50.splitlines())
         if c.strip()
     ]
-    benchmark_name = "dummy-bench"
+    benchmark_name = "dummybenchname"
 
     distr_mean = 20.0
     # `lower_bound` is to simulate the real-world effect of there being a


### PR DESCRIPTION
This mainly addresses https://github.com/conbench/conbench/issues/845.

The jump from Bootstrap 3 to 5 rendered some of the HTML invalid. That resulted in hard breakages. Things that stopped working:
- navbar
- various CSS classes
- forms
- JavaScript-controlled modal content population
- icons/glyphicons
- (and more)

The focus in this PR was to fix the hard breakages, not to review and re-tweak all visual changes. For repairing the breakages, I studied and took some advice from
https://getbootstrap.com/docs/4.6/migration/
https://getbootstrap.com/docs/5.2/migration/

Also needed to rebuild certain parts pragmatically from scratch, like navbar and login form.

The [glyphicons from bootstrap 3](https://getbootstrap.com/docs/3.3/components/#glyphicons) have no direct replacement, I introduced from the new [bootstrap icons](https://icons.getbootstrap.com/) whatever made sense to me.

In the local dev env I tried to manually test all UI functionality. Did I miss some? I hope not. What I confirmed to be working again, locally, among others
- login
- run deletion (with confirmation modal)
- benchmark result deletion (with confirmation modal)
- 'responsiveness' properties
- benchmark result annotation toggle
- ...

I'd love for us to take the next step and test the changes (and identify potential further bugs introduced with this PR) in our staging environment.

Other things addressed in this PR:
- https://github.com/conbench/conbench/issues/865
- https://github.com/conbench/conbench/issues/850 (partially, at least)


Note: when I do work like this, I try to commit changes in chunks with super quick reflection of thoughts in commit messages. So, there's some thinking reflected in those that I will not try to re-summarize here in the PR description.

A few changes (I hope: improvements) landed in this PR that were not strictly necessary as part of the migration. For example, the usage of flash message category for having context-aware color, as shown in this screenshot ('info' category, 'danger' would be red -- and the :zap: lightning icon is an example for me quicking something quickly; maybe it should be a trash can :shrug:, this PR should not be about that):

![Screenshot from 2023-03-10 16-09-12](https://user-images.githubusercontent.com/265630/225013444-95906b2c-ccd7-4b23-83b4-d133aaaa5183.png)

