### PR TITLE
typing: add type hints for DB columns

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install linting dependencies
-        run: pip install -r requirements-dev.txt
+        run: pip install -r requirements-dev.txt -r requirements-webapp.txt
       - name: lint
         run: make lint-ci
 

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -2,7 +2,7 @@ import collections
 import copy
 import json
 import logging
-from typing import List, Optional, no_type_check
+from typing import List, Optional, Tuple, no_type_check
 
 import bokeh.events
 import bokeh.models
@@ -152,7 +152,7 @@ def simple_bar_plot(benchmarks, height=400, width=400, vbar_width=0.7):
 
 # Using `Optional[float]` here only because of BenchmarkResult.mean being
 # nullable as of today.
-def _should_format(floats: list[Optional[float]], unit):
+def _should_format(floats: List[Optional[float]], unit):
     unit_fmt = formatter_for_unit(unit)
 
     units_formatted = set()
@@ -182,7 +182,7 @@ def _insert_nans(some_list: list, indexes: List[int]):
 
 @no_type_check
 def _source(
-    samples: list[HistorySample],
+    samples: List[HistorySample],
     unit,
     formatted=False,
     distribution_mean=False,
@@ -299,7 +299,7 @@ def _source(
     return bokeh.models.ColumnDataSource(data=dsdict)
 
 
-def _inspect_for_multisample(items: list[HistorySample]) -> tuple[bool, Optional[int]]:
+def _inspect_for_multisample(items: List[HistorySample]) -> Tuple[bool, Optional[int]]:
     """
     `items`: list of benchmark results as encoded by the history variant of the
     `_Serializer(EntitySerializer)`.
@@ -584,7 +584,7 @@ def time_series_plot(
         toolbar_location="right",
         x_range=(t_start, t_end),
     )
-    p.toolbar.logo = None
+    p.toolbar.logo = None  # type: ignore[attr-defined]
 
     # TapTool is not responding to each click event, but but only triggers when
     # clicking a glyph:
@@ -688,7 +688,7 @@ def time_series_plot(
     dist_change_in_legend = False
     for ix in dist_change_indexes:
         p.add_layout(
-            bokeh.models.Span(
+            bokeh.models.Span(  # type: ignore[attr-defined]
                 location=util.tznaive_iso8601_to_tzaware_dt(
                     # transforming from datetime to string back to datetime is
                     # weird; done as part of refactoring to not change too much

--- a/conbench/entities/_entity.py
+++ b/conbench/entities/_entity.py
@@ -3,16 +3,16 @@ import uuid
 from typing import List
 
 import flask as f
-from sqlalchemy import Column, distinct
+from sqlalchemy import distinct
 from sqlalchemy.dialects.postgresql import insert as postgresql_insert
-from sqlalchemy.orm import declarative_base
+from sqlalchemy.orm import declarative_base, mapped_column
 from sqlalchemy.orm.exc import NoResultFound
 
 from ..db import Session
 
 Base = declarative_base()
-NotNull = functools.partial(Column, nullable=False)
-Nullable = functools.partial(Column, nullable=True)
+NotNull = functools.partial(mapped_column, nullable=False)
+Nullable = functools.partial(mapped_column, nullable=True)
 
 
 class NotFound(NoResultFound):

--- a/conbench/entities/case.py
+++ b/conbench/entities/case.py
@@ -1,14 +1,15 @@
 import sqlalchemy as s
 from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm import Mapped
 
 from ..entities._entity import Base, EntityMixin, NotNull, generate_uuid
 
 
 class Case(Base, EntityMixin):
     __tablename__ = "case"
-    id = NotNull(s.String(50), primary_key=True, default=generate_uuid)
-    name = NotNull(s.Text)
-    tags = NotNull(postgresql.JSONB)
+    id: Mapped[str] = NotNull(s.String(50), primary_key=True, default=generate_uuid)
+    name: Mapped[str] = NotNull(s.Text)
+    tags: Mapped[dict] = NotNull(postgresql.JSONB)
 
 
 s.Index("case_index", Case.name, Case.tags, unique=True)

--- a/conbench/entities/context.py
+++ b/conbench/entities/context.py
@@ -1,6 +1,7 @@
 import flask as f
 import sqlalchemy as s
 from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm import Mapped
 
 from ..entities._entity import (
     Base,
@@ -13,8 +14,8 @@ from ..entities._entity import (
 
 class Context(Base, EntityMixin):
     __tablename__ = "context"
-    id = NotNull(s.String(50), primary_key=True, default=generate_uuid)
-    tags = NotNull(postgresql.JSONB)
+    id: Mapped[str] = NotNull(s.String(50), primary_key=True, default=generate_uuid)
+    tags: Mapped[dict] = NotNull(postgresql.JSONB)
 
 
 s.Index("context_index", Context.tags, unique=True)

--- a/conbench/entities/hardware.py
+++ b/conbench/entities/hardware.py
@@ -6,6 +6,7 @@ import marshmallow
 import sqlalchemy as s
 from sqlalchemy import CheckConstraint as check
 from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm import Mapped
 
 from ..entities._entity import (
     Base,
@@ -19,10 +20,10 @@ from ..entities._entity import (
 
 class Hardware(Base, EntityMixin):
     __tablename__ = "hardware"
-    id = NotNull(s.String(50), primary_key=True, default=generate_uuid)
-    name = NotNull(s.Text)
-    type = NotNull(s.String(50))
-    hash = NotNull(s.String(1000))
+    id: Mapped[str] = NotNull(s.String(50), primary_key=True, default=generate_uuid)
+    name: Mapped[str] = NotNull(s.Text)
+    type: Mapped[str] = NotNull(s.String(50))
+    hash: Mapped[str] = NotNull(s.String(1000))
 
     __mapper_args__ = {"polymorphic_on": type, "polymorphic_identity": "hardware"}
 

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -4,7 +4,7 @@ import decimal
 import logging
 import math
 from collections import defaultdict
-from typing import Dict, List, Optional, Tuple, Union
+from typing import DefaultDict, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -109,8 +109,8 @@ class HistorySample:
     # also there is a lack of spec
     mean: Optional[float]
     # math.nan is allowed for representing a failed iteration.
-    data: list[float]
-    times: list[float]
+    data: List[float]
+    times: List[float]
     unit: str
     hardware_hash: str
     repository: str
@@ -147,7 +147,7 @@ def get_history_for_benchmark(benchmark_result_id: str):
 
 def get_history_for_cchr(
     case_id: str, context_id: str, hardware_hash: str, repo: str
-) -> list[HistorySample]:
+) -> List[HistorySample]:
     """
     Given a case/context/hardware/repo, return all non-errored BenchmarkResults
     (past, present, and future) on the default branch that match those
@@ -196,7 +196,7 @@ def get_history_for_cchr(
 
     # return list(history_df.itertuples())
 
-    samples: list[HistorySample] = []
+    samples: List[HistorySample] = []
     # Iterate over rows of pandas dataframe; get each row as namedtuple.
     for sample in history_df.itertuples():
         # Note(JP): the Commit.timestamp is nullable, i.e. not all Commit
@@ -269,7 +269,7 @@ def set_z_scores(benchmark_results: List[BenchmarkResult]):
     """
     # For most invocations of this function, there are very few unique run_ids among the
     # benchmark_results. Sort them by run_id and run aoptimized query for each group.
-    sorted_by_run_id = defaultdict(list)
+    sorted_by_run_id: DefaultDict[str, List[BenchmarkResult]] = defaultdict(list)
     for benchmark_result in benchmark_results:
         sorted_by_run_id[benchmark_result.run_id].append(benchmark_result)
 
@@ -551,7 +551,7 @@ def _add_rolling_stats_columns_to_df(
 
 def _calculate_z_score(
     data_point: Optional[float],
-    unit: str,
+    unit: Optional[str],
     dist_mean: Optional[float],
     dist_stddev: Optional[float],
 ) -> Optional[float]:

--- a/conbench/entities/info.py
+++ b/conbench/entities/info.py
@@ -1,6 +1,7 @@
 import flask as f
 import sqlalchemy as s
 from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm import Mapped
 
 from ..entities._entity import (
     Base,
@@ -13,8 +14,8 @@ from ..entities._entity import (
 
 class Info(Base, EntityMixin):
     __tablename__ = "info"
-    id = NotNull(s.String(50), primary_key=True, default=generate_uuid)
-    tags = NotNull(postgresql.JSONB)
+    id: Mapped[str] = NotNull(s.String(50), primary_key=True, default=generate_uuid)
+    tags: Mapped[dict] = NotNull(postgresql.JSONB)
 
 
 s.Index("info_index", Info.tags, unique=True)

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -1,13 +1,13 @@
 import logging
 import time
-from datetime import timezone
+from datetime import datetime, timezone
 from typing import Optional
 
 import flask as f
 import marshmallow
 import sqlalchemy as s
 from sqlalchemy.dialects import postgresql
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import Mapped, relationship
 
 import conbench.util
 
@@ -35,9 +35,9 @@ log = logging.getLogger(__name__)
 
 class Run(Base, EntityMixin):
     __tablename__ = "run"
-    id = NotNull(s.String(50), primary_key=True)
-    name = Nullable(s.String(250))
-    reason = Nullable(s.String(250))
+    id: Mapped[str] = NotNull(s.String(50), primary_key=True)
+    name: Mapped[Optional[str]] = Nullable(s.String(250))
+    reason: Mapped[Optional[str]] = Nullable(s.String(250))
     # `timestamp`  is never set by API clients, i.e. the
     # `server_default=s.sql.func.now()` is always taking effect. That also
     # means that this property reflects the point in time of DB insertion (that
@@ -48,17 +48,21 @@ class Run(Base, EntityMixin):
     # timestamp on a DB server that does not have its system time in UTC? That
     # should not happen, as is hopefully confirmed by the test
     # `test_auto_generated_run_timestamp_value()`.
-    timestamp = NotNull(s.DateTime(timezone=False), server_default=s.sql.func.now())
+    timestamp: Mapped[datetime] = NotNull(
+        s.DateTime(timezone=False), server_default=s.sql.func.now()
+    )
     # tz-naive timestamp expected to refer to UTC time.
-    finished_timestamp = Nullable(s.DateTime(timezone=False))
-    info = Nullable(postgresql.JSONB)
-    error_info = Nullable(postgresql.JSONB)
-    error_type = Nullable(s.String(250))
-    commit_id = NotNull(s.String(50), s.ForeignKey("commit.id"))
-    commit = relationship("Commit", lazy="joined")
-    has_errors = NotNull(s.Boolean, default=False)
-    hardware_id = NotNull(s.String(50), s.ForeignKey("hardware.id"))
-    hardware = relationship("Hardware", lazy="joined")
+    finished_timestamp: Mapped[Optional[datetime]] = Nullable(
+        s.DateTime(timezone=False)
+    )
+    info: Mapped[Optional[dict]] = Nullable(postgresql.JSONB)
+    error_info: Mapped[Optional[dict]] = Nullable(postgresql.JSONB)
+    error_type: Mapped[Optional[str]] = Nullable(s.String(250))
+    commit_id: Mapped[str] = NotNull(s.String(50), s.ForeignKey("commit.id"))
+    commit: Mapped[Commit] = relationship("Commit", lazy="joined")
+    has_errors: Mapped[bool] = NotNull(s.Boolean, default=False)
+    hardware_id: Mapped[str] = NotNull(s.String(50), s.ForeignKey("hardware.id"))
+    hardware: Mapped[Hardware] = relationship("Hardware", lazy="joined")
 
     @staticmethod
     def create(data):

--- a/conbench/entities/user.py
+++ b/conbench/entities/user.py
@@ -3,6 +3,7 @@ import flask_login
 import marshmallow
 import sqlalchemy as s
 import werkzeug.security
+from sqlalchemy.orm import Mapped
 
 from ..entities._entity import (
     Base,
@@ -21,10 +22,10 @@ def load_user(user_id):
 
 class User(flask_login.UserMixin, Base, EntityMixin):
     __tablename__ = "user"
-    id = NotNull(s.String(50), primary_key=True, default=generate_uuid)
-    email = NotNull(s.String(120), index=True, unique=True)
-    name = NotNull(s.String(120))
-    password = NotNull(s.String(128))
+    id: Mapped[str] = NotNull(s.String(50), primary_key=True, default=generate_uuid)
+    email: Mapped[str] = NotNull(s.String(120), index=True, unique=True)
+    name: Mapped[str] = NotNull(s.String(120))
+    password: Mapped[str] = NotNull(s.String(128))
 
     def __repr__(self):
         return f"<User {self.email}>"


### PR DESCRIPTION
Now that we have SQLAlchemy 2.0, there is more support for rich nested typing of SQLAlchemy objects. This PR adds type hints for all our DB columns based on the [recommended way](https://docs.sqlalchemy.org/en/20/orm/declarative_tables.html) to type-hint declarative tables.

I think this PR is extremely exciting! I was able to fix some additional typing-related errors that `mypy` found, since it's now possible to statically check the types of not only the raw column objects, but also the query result columns themselves.

VS Code is also showing me a lot more detail about each object. As just one example, it now knows the types of the `commit_ancestry_query` columns:

<img width="674" alt="image" src="https://user-images.githubusercontent.com/16600275/224798885-9d20d232-bd31-4499-aeec-857eaf785267.png">
