### PR TITLE
benchadapt: Remove excess GitHub data warning

### DIFF
--- a/benchadapt/python/benchadapt/_machine_info.py
+++ b/benchadapt/python/benchadapt/_machine_info.py
@@ -91,16 +91,6 @@ def github_info():
         "pr_number": pr_number,
     }
 
-    if not (repo and commit):
-        warnings.warn(
-            (
-                "Both CONBENCH_PROJECT_REPOSITORY and CONBENCH_PROJECT_COMMIT must be "
-                "set if `github` is not specified. CONBENCH_PROJECT_PR_NUMBER should be "
-                "not be set for builds on the default branch."
-                f"\nValues: `{gh_info}`"
-            ),
-        )
-
     return gh_info
 
 

--- a/benchadapt/python/tests/test_result.py
+++ b/benchadapt/python/tests/test_result.py
@@ -94,26 +94,16 @@ class TestBenchmarkResult:
 
         with pytest.warns(
             UserWarning,
-            match="Both CONBENCH_PROJECT_REPOSITORY and CONBENCH_PROJECT_COMMIT must be set if `github` is not specified",
+            match="Result not publishable! `github.repository` and `github.commit` must be populated",
         ):
-            BenchmarkResult()
-
-            with pytest.warns(
-                UserWarning,
-                match="Result not publishable! `github.repository` and `github.commit` must be populated",
-            ):
-                BenchmarkResult().to_publishable_dict()
+            BenchmarkResult().to_publishable_dict()
 
     def test_run_name_defaulting(self, monkeypatch):
         monkeypatch.delenv("CONBENCH_PROJECT_REPOSITORY", raising=False)
         monkeypatch.delenv("CONBENCH_PROJECT_PR_NUMBER", raising=False)
         monkeypatch.delenv("CONBENCH_PROJECT_COMMIT", raising=False)
 
-        with pytest.warns(
-            UserWarning,
-            match="Both CONBENCH_PROJECT_REPOSITORY and CONBENCH_PROJECT_COMMIT must be set if `github` is not specified",
-        ):
-            res = BenchmarkResult(run_reason=res_json["run_reason"])
+        res = BenchmarkResult(run_reason=res_json["run_reason"])
 
         assert res.github == {"commit": None, "repository": None, "pr_number": None}
         assert res.run_name is None

--- a/benchadapt/python/tests/test_run.py
+++ b/benchadapt/python/tests/test_run.py
@@ -66,17 +66,11 @@ class TestBenchmarkRun:
         monkeypatch.delenv("CONBENCH_PROJECT_PR_NUMBER")
         monkeypatch.delenv("CONBENCH_PROJECT_COMMIT")
 
-        with pytest.warns(
-            UserWarning,
-            match="Both CONBENCH_PROJECT_REPOSITORY and CONBENCH_PROJECT_COMMIT must be set if `github` is not specified",
+        with pytest.raises(
+            ValueError,
+            match="Run not publishable! `github.repository` and `github.commit` must be populated",
         ):
-            BenchmarkRun()
-
-            with pytest.raises(
-                ValueError,
-                match="Run not publishable! `github.repository` and `github.commit` must be populated",
-            ):
-                BenchmarkRun().to_publishable_dict()
+            BenchmarkRun().to_publishable_dict()
 
     def test_host_detection(self, monkeypatch):
         machine_info_name = "fake-computer-name"
@@ -92,11 +86,7 @@ class TestBenchmarkRun:
         monkeypatch.delenv("CONBENCH_PROJECT_PR_NUMBER", raising=False)
         monkeypatch.delenv("CONBENCH_PROJECT_COMMIT", raising=False)
 
-        with pytest.warns(
-            UserWarning,
-            match="Both CONBENCH_PROJECT_REPOSITORY and CONBENCH_PROJECT_COMMIT must be set if `github` is not specified",
-        ):
-            run = BenchmarkRun(reason=run_json["reason"])
+        run = BenchmarkRun(reason=run_json["reason"])
 
         assert run.github == {"commit": None, "repository": None, "pr_number": None}
         assert run.name is None


### PR DESCRIPTION
Closes #808 by removing the warning in `github_info()`. The situation it was to address is already covered by conditions in the `.to_pusblishable_dict()` methods of `BenchmarkRun` and `BenchmarkResult`, so this should just quiet logs when GitHub metadata is specified after dataclass instantiation without any loss of functionality.