### PR TITLE
UI: fix user list / management, and hardware listing

### DIFF
--- a/conbench/app/users.py
+++ b/conbench/app/users.py
@@ -69,13 +69,13 @@ class User(AppEndpoint):
             if delete_form.validate_on_submit():
                 delete_response = self.api_delete("api.user", user_id=user_id)
                 if delete_response.status_code == 204:
-                    self.flash("User deleted.")
+                    self.flash("User deleted", "info")
                     return self.redirect("app.users")
         elif form.validate_on_submit():
             # submit button pressed
             response = self.api_put("api.user", form, user_id=user_id)
             if response.status_code == 200:
-                self.flash("User updated.")
+                self.flash("User updated", "info")
                 return self.redirect("app.user", user_id=user_id)
 
         if response and not form.errors:
@@ -159,7 +159,7 @@ class UserCreate(AppEndpoint):
         if form.validate_on_submit():
             response = self.api_post("api.users", form)
             if response.status_code == 201:
-                self.flash("User created.")
+                self.flash("User created", "info")
                 return self.redirect("app.users")
 
         if response and not form.errors:

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -107,7 +107,15 @@
 {% block scripts %}
 <script src="https://code.jquery.com/jquery-3.6.4.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4" crossorigin="anonymous"></script>
-<script src="https://cdn.datatables.net/v/bs5/dt-1.13.3/r-2.4.0/datatables.min.js"></script>
+<!--
+    Note(JP): I think the datatables responsive plugin (included as version
+    2.4.0 via the special link below) is in conflict with Boostrap 5's
+    responsiveness of tables. Testing this for a bit without r-2.4.0. To
+    see what we really need and why.
+    <script src="https://cdn.datatables.net/v/bs5/dt-1.13.3/r-2.4.0/datatables.min.js"></script>
+-->
+<script src="https://cdn.datatables.net/v/bs5/dt-1.13.4/datatables.min.js"></script>
+<script src="https://cdn.datatables.net/plug-ins/1.13.3/features/conditionalPaging/dataTables.conditionalPaging.min.js"></script>
 
 <script>
 $(document).ready(function() {

--- a/conbench/templates/hardware-list.html
+++ b/conbench/templates/hardware-list.html
@@ -2,37 +2,47 @@
 {% import 'bootstrap/wtf.html' as wtf %}
 
 {% block app_content %}
-    <div class="row">
-        <div class="col-md-12">
-            <table id="hardwares" class="table table-striped table-bordered table-hover">
-                <thead>
-                    <tr>
-                        <th scope="col">#</th>
-                        <th scope="col">Name</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for hardware in hardwares %}
-                    <tr>
-                         <td>{{ hardware.id }}</td>
-                         <td>
-                           <a href="{{ url_for('app.hardware', hardware_id=hardware.id) }}">
-                             <div>{{ hardware.name }}</div>
-                           </a>
-                         </td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
+<!-- recipe taken from https://getbootstrap.com/docs/5.0/utilities/flex/#auto-margins -->
+<div class="d-flex">
+    <div class="p-2"><h3>Hardware list</h3></div>
+    <div class="ms-auto p-2">
+        <!-- reserved for `create` button -->
     </div>
+</div>
+
+<hr class="border border-danger border-2 opacity-50">
+<table id="hardwares" class="table table-hover">
+    <thead>
+        <tr>
+            <th scope="col" style="width: 25%">Hardware ID</th>
+            <th scope="col">Name</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for hardware in hardwares %}
+        <tr>
+                <td>{{ hardware.id }}</td>
+                <td>
+                <a href="{{ url_for('app.hardware', hardware_id=hardware.id) }}">
+                    <div>{{ hardware.name }}</div>
+                </a>
+                </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+
 {% endblock %}
 
 {% block scripts %}
 {{super()}}
 <script type="text/javascript">
 var table = $('#hardwares').dataTable( {
-    "responsive": true,
+    "conditionalPaging": true,
+    "pageLenth": 50,
+    "lengthChange": false, // not needed in this case (number of rows per page)
+    "info": false,
+    "searching": false,
     "order": [[1, 'desc']],
 } );
 

--- a/conbench/templates/user-create.html
+++ b/conbench/templates/user-create.html
@@ -10,7 +10,7 @@
     </nav>
     <div class="row">
         <div class="col-md-4">
-            {{ wtf.quick_form(form) }}
+            {{ wtf.quick_form(form, button_map={'submit': 'primary'}) }}
         </div>
     </div>
 {% endblock %}

--- a/conbench/templates/user-entity.html
+++ b/conbench/templates/user-entity.html
@@ -2,17 +2,17 @@
 {% import 'bootstrap/wtf.html' as wtf %}
 
 {% block app_content %}
-    <nav aria-label="breadcrumb">
-      <ol class="breadcrumb">
-        <li class="breadcrumb-item active"><a href="{{ url_for('app.users') }}">Users</a></li>
-        <li class="breadcrumb-item active" aria-current="page">{{ user.name }}</li>
-      </ol>
-    </nav>
-    <div class="row">
-        <div class="col-md-4">
-            {{ wtf.quick_form(form, id="user-form", button_map={'submit': 'primary'}) }}
-        </div>
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item active"><a href="{{ url_for('app.users') }}">Users</a></li>
+    <li class="breadcrumb-item active" aria-current="page">{{ user.name }}</li>
+  </ol>
+</nav>
+<div class="row">
+    <div class="col-md-4">
+        {{ wtf.quick_form(form, id="user-form", button_map={'submit': 'primary', 'delete': 'danger'}) }}
     </div>
+</div>
 {% endblock %}
 
 {% block scripts %}
@@ -20,11 +20,11 @@
 <script type="text/javascript">
 $(document).ready(function($) {
     $("#user-form").find("#delete").attr("type", "button");
-    $("#user-form").find("#delete").attr("data-toggle", "modal");
-    $("#user-form").find("#delete").attr("data-target", "#confirm-delete");
-    $("#user-form").find("#delete").attr("data-form-id", "#user-form");
-    $("#user-form").find("#delete").attr("data-href", "{{ url_for('app.user', user_id=user.id) }}");
-    $("#user-form").find("#delete").attr("data-message", "<ul><li>Delete user: <strong>{{ user.email }}</strong></li></ul>");
+    $("#user-form").find("#delete").attr("data-bs-toggle", "modal");
+    $("#user-form").find("#delete").attr("data-bs-target", "#confirm-delete");
+    $("#user-form").find("#delete").attr("data-cbcustom-form-id", "#user-form");
+    $("#user-form").find("#delete").attr("data-cbcustom-href", "{{ url_for('app.user', user_id=user.id) }}");
+    $("#user-form").find("#delete").attr("data-cbcustom-message", "<ul><li>Delete user: <strong>{{ user.email }}</strong></li></ul>");
 });
 </script>
 {% endblock %}

--- a/conbench/templates/user-list.html
+++ b/conbench/templates/user-list.html
@@ -49,7 +49,7 @@ var table = $('#users').dataTable( {
     "columnDefs": [{ "orderable": false, "targets": [0, 3, 4] }]
 } );
 
-enable_search_query_string('#users');
+//enable_search_query_string('#users');
 
 </script>
 {% endblock %}

--- a/conbench/templates/user-list.html
+++ b/conbench/templates/user-list.html
@@ -43,8 +43,16 @@
 {% block scripts %}
 {{super()}}
 <script type="text/javascript">
-var table = $('#users').dataTable( {
-    "responsive": true,
+var table = $('#users').DataTable( {
+    // Note(JP): this enables a special, simple plugin called
+    // `conditionalPaging` which must be included, e.g. via the dist URLs
+    // published in https://cdn.datatables.net/plug-ins/1.13.3/features/.
+    // kudos to https://stackoverflow.com/a/29639664/145400
+    "conditionalPaging": true,
+    "pageLenth": 50,
+    "lengthChange": false, // not needed in this case (number of rows per page)
+    "info": false,
+    "searching": false,
     "order": [[1, 'desc']],
     "columnDefs": [{ "orderable": false, "targets": [0, 3, 4] }]
 } );

--- a/conbench/templates/user-list.html
+++ b/conbench/templates/user-list.html
@@ -2,42 +2,56 @@
 {% import 'bootstrap/wtf.html' as wtf %}
 
 {% block app_content %}
-    <div class="row">
-        <div class="hidden">{{ wtf.quick_form(delete_user_form, id="delete-user-form") }}</div>
-        <div class="col-md-12">
-            <table id="users" class="table table-striped table-bordered table-hover">
-            <caption><a href="{{ url_for('app.user-create') }}"><span class="glyphicon glyphicon-plus"></span> Add User</a></caption>
-                <thead>
-                    <tr>
-                        <th scope="col">#</th>
-                        <th scope="col">Name</th>
-                        <th scope="col">Email</th>
-                        <th scope="col"></th>
-                        <th scope="col"></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for user in users %}
-                    <tr>
-                         <td>{{ user.id }}</td>
-                         <td>{{ user.name }}</td>
-                         <td>{{ user.email }}</td>
-                         <td><a href="{{ url_for('app.user', user_id=user.id) }}">
-                             <span class="glyphicon glyphicon-pencil submenu"></span>
-                         </a></td>
-                         <td data-href="{{ url_for('app.user', user_id=user.id) }}"
-                             data-toggle="modal"
-                             data-target="#confirm-delete"
-                             data-form-id="#delete-user-form"
-                             data-message="<ul><li>Delete user: <strong>{{ user.email }}</strong></li></ul>">
-                             <span class="glyphicon glyphicon-trash"></span>
-                         </td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
+
+
+<!-- recipe taken from https://getbootstrap.com/docs/5.0/utilities/flex/#auto-margins -->
+<div class="d-flex">
+    <div class="p-2"><h3>Users</h3></div>
+    <div class="ms-auto p-2">
+        <a role="button" class="btn btn-outline-dark btn-lg" href="{{ url_for('app.user-create') }}">
+            <i class="bi bi-person-plus-fill"></i>
+        </a>
     </div>
+</div>
+
+<hr class="border border-danger border-2 opacity-50">
+
+<!-- note(jp): this form is not displayed, but must be there for the individual
+    trash icons in the table to work
+ -->
+<div style="display: none;">{{ wtf.quick_form(delete_user_form, id="delete-user-form") }}</div>
+<table id="users" class="table table-hover">
+    <thead>
+        <tr>
+            <th scope="col" style="width: 25%">User ID</th>
+            <th scope="col">Name</th>
+            <th scope="col">Email</th>
+            <th scope="col" style="width: 5%">Edit</th>
+            <th scope="col" style="width: 5%">Delete</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for user in users %}
+        <tr>
+                <td>{{ user.id }}</td>
+                <td>{{ user.name }}</td>
+                <td>{{ user.email }}</td>
+                <td><a href="{{ url_for('app.user', user_id=user.id) }}">
+                    edit
+                </a></td>
+                <td data-cbcustom-href="{{ url_for('app.user', user_id=user.id) }}"
+                    data-bs-toggle="modal"
+                    data-bs-target="#confirm-delete"
+                    data-cbcustom-form-id="#delete-user-form"
+                    data-cbcustom-message="<ul><li>Delete user: <strong>{{ user.email }}</strong></li></ul>">
+                    <i class="bi bi-trash3"></i>
+                </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+
+
 {% endblock %}
 
 {% block scripts %}

--- a/conbench/tests/app/test_users.py
+++ b/conbench/tests/app/test_users.py
@@ -49,7 +49,7 @@ class TestUser(_asserts.AppEndpointTest):
         }
         response = client.post(f"/users/{other.id}/", data=data, follow_redirects=True)
         self.assert_page(response, "User")
-        assert b"User updated." in response.data
+        assert b"User updated" in response.data
         assert b'value="New Name"' in response.data
 
     def test_user_update_unauthenticated(self, client):
@@ -86,7 +86,7 @@ class TestUser(_asserts.AppEndpointTest):
         data = {"delete": ["Delete"], "csrf_token": self.get_csrf_token(response)}
         response = client.post(f"/users/{other.id}/", data=data, follow_redirects=True)
         self.assert_page(response, "Users")
-        assert b"User deleted." in response.data
+        assert b"User deleted" in response.data
 
         # cannot get user after
         response = client.get(f"/users/{other.id}/", follow_redirects=True)
@@ -135,7 +135,7 @@ class TestUserCreate(_asserts.AppEndpointTest):
         }
         response = client.post("/users/create/", data=data, follow_redirects=True)
         self.assert_page(response, "Users")
-        assert b"User created." in response.data
+        assert b"User created" in response.data
 
     def test_user_create_post_unauthenticated(self, client):
         response = client.post("/users/create/", data={}, follow_redirects=True)


### PR DESCRIPTION
Addresses the user management issues described in #868.

A number of changes along the way. Screenshots / vid follow.

------

Now with table heading, and right-aligned `add user` button:

![Screenshot from 2023-03-14 18-50-15](https://user-images.githubusercontent.com/265630/225099045-677511d4-1639-4710-a6da-8b5d444fabd8.png)

------

Hardware list analogue to user list:

![Screenshot from 2023-03-14 18-53-30](https://user-images.githubusercontent.com/265630/225099011-29236edb-43ad-4dc9-84a8-59752a39d081.png)

------

Some menus are still visually weird/bad, but management functionality is restored:

https://user-images.githubusercontent.com/265630/225098926-dec767d5-a4a9-46bb-8d5b-83c1a9086f1a.mov

