### PR TITLE
UI: further work after migration to bootstrap 5 (re-create jumbotron, ... )

### DIFF
--- a/conbench/templates/benchmark-list.html
+++ b/conbench/templates/benchmark-list.html
@@ -5,7 +5,7 @@
     <div class="row">
         <div class="hidden">{{ wtf.quick_form(delete_benchmark_form, id="delete-benchmark-form") }}</div>
         <div class="col-md-12">
-            <table id="benchmarks" class="table table-striped table-bordered table-hover">
+            <table id="benchmarks" class="table table-hover">
             <caption>Benchmarks</caption>
                 <thead>
                     <tr>

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -1,30 +1,28 @@
 {% extends "app.html" %}
 
 {% block app_content %}
-<div class="row">
-  <div class="col-md-12">
-    <div class="jumbotron">
-      <div class="media">
-        <div class="media-body">
-          <h4 class="media-heading">Con·bench</h4>
-          <h4>/kənˈben(t)SH/</h4>
-          <h5><i>noun</i></h5>
-          <h3>Language-independent Continuous Benchmarking (CB) Framework</h3>
-        </div>
-        <div class="media-right">
-          <img class="media-object" style="padding: 5px" src="{{ url_for('static', filename='bar-graph.png') }}" height="150">
+
+<div class="p-3 mb-4 bg-light rounded-3">
+  <div class="container-fluid py-2">
+    <div class="row mb-3">
+      <div class="col-md-5">
+        <h1 class="display-5 fw-bold">Con·bench</h1>
+        <p class="col-md-8 fs-4">/kənˈben(t)SH/ <br /><i>noun</i></p>
+      </div>
+      <div class="col-md-7">
+        <div class="float-end">
+          <img class="media-object" style="padding: 5px" src="{{ url_for('static', filename='bar-graph.png') }}" height="180">
         </div>
       </div>
     </div>
   </div>
 </div>
 
-
 <div class="row">
     <hr />
     <div class="col-md-12">
         <h4>Recent runs</h4>
-        <table id="runs" class="table table-striped table-bordered table-hover">
+        <table id="runs" class="table table-hover">
             <thead>
                 <tr>
                     <th scope="col">Run creation time</th>

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -18,11 +18,13 @@
   </div>
 </div>
 
-<div class="row">
-    <hr />
-    <div class="col-md-12">
-        <h4>Recent runs</h4>
-        <table id="runs" class="table table-hover">
+
+<div class="p-2"><h3>Recent runs</h3></div>
+<hr class="border border-danger border-2 opacity-50">
+
+<!-- https://getbootstrap.com/docs/5.2/content/tables/#responsive-tables -->
+<div class="table-responsive">
+<table id="runs" class="table table-hover">
             <thead>
                 <tr>
                     <th scope="col">Run creation time</th>
@@ -94,10 +96,8 @@
                 </tr>
                 {% endfor %}
             </tbody>
-        </table>
-    </div>
+</table>
 </div>
-
 
 {% endblock %}
 

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -107,10 +107,13 @@
 <script>
   var table = $('#runs').DataTable({
       // the default default seems to be the first item in lengthMenu.
-      "lengthMenu": [ 5, 15, 50, 75, 100 ],
+      "lengthMenu": [ 5, 10, 50, 75, 100 ],
       // but when pageLength is also set, then _this_ is the default.
-      "pageLength": 15,
+      "pageLength": 10,
       "order": [[0, 'desc']],
+      // https://datatables.net/reference/option/dom
+      // put `l` to the bottom
+      "dom": "frtipl",
       //"lengthMenu": [ 20, 25, 50, 75, 100 ],
       // Make "Commit" (commit hash) column (4) more narrow, hide 'sorting'
       // toggle. Sorting by commit hash is not needed, in particular because

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -106,7 +106,12 @@
 {{super()}}
 <script>
   var table = $('#runs').DataTable({
+      // the default default seems to be the first item in lengthMenu.
+      "lengthMenu": [ 5, 15, 50, 75, 100 ],
+      // but when pageLength is also set, then _this_ is the default.
+      "pageLength": 15,
       "order": [[0, 'desc']],
+      //"lengthMenu": [ 20, 25, 50, 75, 100 ],
       // Make "Commit" (commit hash) column (4) more narrow, hide 'sorting'
       // toggle. Sorting by commit hash is not needed, in particular because
       // one can filter by commit hash via input field. Do the same for the
@@ -114,7 +119,7 @@
       // First column has index 0.
       "columnDefs": [{ "orderable": false, "targets": [1, 4, 5] }],
       "language": {
-          "searchPlaceholder": "commit hash works too",
+          "searchPlaceholder": "search across all columns",
       },
 });
 

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -61,7 +61,7 @@
 
     <div class="col-md-12">
         <h4>Benchmarks in run</h4>
-        <table id="benchmarks" class="table table-striped table-bordered table-hover">
+        <table id="benchmarks" class="table table-hover">
         <!-- does not display right: <caption>Benchmarks{% include 'units-tooltip.html' %}</caption>-->
             <thead>
                 <tr>


### PR DESCRIPTION
Currently this also includes #869.

This PR:

- re-creates the Jumbotron (that type of component does not exist anymore in Boostrap 5)
- introduces a simple table heading for the landing page `Recent runs` in level 3, followed by a ruler -- like I did before for the user list and hardware list. Just a tiny visual/design tweak that hopefully pleases some eyes for now.
- does visual cleanup work around tables, including landing page 'Recent runs' (see #861)
- tweaks the DataTables options for the 'Recent runs'

Screenshot from local dev:

![Screenshot from 2023-03-14 19-51-02](https://user-images.githubusercontent.com/265630/225108003-3bfb501b-2b9c-413c-89e4-715393ba6331.png)