### PR TITLE
ui: per-batch view: clarifications (#873)

### DIFF
--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -269,7 +269,12 @@ class BenchmarkResult(Base, EntityMixin):
 
 s.Index("benchmark_result_run_id_index", BenchmarkResult.run_id)
 s.Index("benchmark_result_case_id_index", BenchmarkResult.case_id)
+
+# Note(JP): we provde an API endpoint that allows for querying all benchmark
+# results that have a certain batch name set. Therefore, this index is
+# valuable.
 s.Index("benchmark_result_batch_id_index", BenchmarkResult.batch_id)
+
 s.Index("benchmark_result_info_id_index", BenchmarkResult.info_id)
 s.Index("benchmark_result_context_id_index", BenchmarkResult.context_id)
 

--- a/conbench/templates/batch.html
+++ b/conbench/templates/batch.html
@@ -5,13 +5,14 @@
       <ol class="breadcrumb">
         {% if benchmarks %}
         <li class="breadcrumb-item active">
+          <!-- Note(jp): the benchmark results don't necessarily have the same
+               run in common, so this hierarchy might be misleading.
+               see https://github.com/conbench/conbench/issues/873
+          -->
           <a href="{{ url_for('app.run', run_id=benchmarks[0].run_id) }}">Run</a>
         </li>
         {% endif %}
-        <li class="breadcrumb-item active">Batch</li>
-        {% if benchmarks %}
-        <li class="breadcrumb-item active" aria-current="page">{{ benchmarks[0].batch_id }}</li>
-        {% endif %}
+        <li class="breadcrumb-item active">Batch {{requested_batch_id}}</li>
       </ol>
     </nav>
 
@@ -47,15 +48,17 @@
 <div class="col-md-2"></div>
 {% endif %}
 
-    <div class="col-md-12">
-        <table id="benchmarks" class="table table-striped table-bordered table-hover">
-        <caption>Benchmarks{% include 'units-tooltip.html' %}</caption>
+
+<h3>Benchmark results with given batch ID</h3>
+
+        <table id="benchmarks" class="table table-hover">
+
             <thead>
                 <tr>
                     <th scope="col">Date</th>
                     <th scope="col">Lang</th>
-                    <th scope="col">Batch</th>
-                    <th scope="col">Benchmark</th>
+                    <th scope="col">Benchmark (suite) name</th>
+                    <th scope="col" style="width: 35%">Benchmark result (case permutation is shown)</th>
                     <th scope="col">Mean</th>
                     <th scope="col" style="white-space: nowrap;">Z-Score</th>
                 </tr>
@@ -87,7 +90,7 @@
                 {% endfor %}
             </tbody>
         </table>
-    </div>
+
 
 {% endblock %}
 


### PR DESCRIPTION
This is for https://github.com/conbench/conbench/issues/877, i.e. a follow-up after inspection documented here: https://github.com/conbench/conbench/issues/873#issuecomment-1469751855

This is not really meant to look great, and is not tackling _all_ challenges, but is supposed to provide really important conceptual clarifications UI-wise.

The Run -> Batch hierarchy is still misleadingly represented, but I didn't yet want to change too much in this PR. For the 'common' case, this breadcrumb hierarchy allows for navigating back to the Run.

![Screenshot from 2023-03-15 11-53-12](https://user-images.githubusercontent.com/265630/225288570-4c486b43-f3dd-4ced-b27b-201c74341ce4.png)
