### PR TITLE
ui: link github project in footer, landing page: remove jumbotron

### DIFF
--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -93,6 +93,7 @@
 
     {% endwith %}
     {# application content needs to be provided in the app_content block #}
+    <div style="margin-top: 30px"></div>
     {% block app_content %}
     {% endblock %}
     <br>

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -98,7 +98,7 @@
     <br>
     <hr>
     <div style="display:inline-block; float: right; color: #918d8c;">
-        Conbench {{ version_string_footer }} | <a href="/api/docs" target="_blank">api docs</a>
+        Conbench {{ version_string_footer }} | <a href="https://github.com/conbench/conbench" target="_blank">github</a> | <a href="/api/docs" target="_blank">api docs</a>
     </div>
 
 </div>

--- a/conbench/templates/benchmark-list.html
+++ b/conbench/templates/benchmark-list.html
@@ -2,20 +2,28 @@
 {% import 'bootstrap/wtf.html' as wtf %}
 
 {% block app_content %}
-    <div class="row">
-        <div class="hidden">{{ wtf.quick_form(delete_benchmark_form, id="delete-benchmark-form") }}</div>
-        <div class="col-md-12">
+<!-- recipe taken from https://getbootstrap.com/docs/5.0/utilities/flex/#auto-margins -->
+<div class="d-flex">
+  <div class="p-2"><h3>Recent benchmark results</h3></div>
+</div>
+
+<hr class="border border-danger border-2 opacity-50">
+
+<!-- note(jp): this form is not displayed, but must be there for the individual
+  trash icons in the table to work
+-->
+<div style="display: none;">{{ wtf.quick_form(delete_benchmark_form, id="delete-benchmark-form") }}</div>
+<table id="users" class="table table-hover">
             <table id="benchmarks" class="table table-hover">
-            <caption>Benchmarks</caption>
                 <thead>
                     <tr>
-                        <th scope="col">Date</th>
+                        <th scope="col">Timestamp</th>
                         <th scope="col">Lang</th>
                         <th scope="col">Batch</th>
                         <th scope="col">Benchmark</th>
-                        <th scope="col">Mean</th>
+                        <th scope="col" style="width: 10%">Mean</th>
                         {% if not current_user.is_anonymous %}
-                          <th scope="col"></th>
+                        <th scope="col" style="width: 5%">Delete</th>
                         {% endif %}
                     </tr>
                 </thead>
@@ -34,20 +42,18 @@
                          </a></td>
                          <td>{{ benchmark.display_mean }}</td>
                          {% if not current_user.is_anonymous %}
-                         <td data-href="{{ url_for('app.benchmark', benchmark_id=benchmark.id) }}"
-                             data-toggle="modal"
-                             data-target="#confirm-delete"
-                             data-form-id="#delete-benchmark-form"
-                             data-message="<ul><li>Delete benchmark: <strong>{{ benchmark.id }}</strong></li></ul>">
-                             <span class="glyphicon glyphicon-trash submenu"></span>
+                         <td data-cbcustom-href="{{ url_for('app.benchmark', benchmark_id=benchmark.id) }}"
+                             data-bs-toggle="modal"
+                             data-bs-target="#confirm-delete"
+                             data-cbcustom-form-id="#delete-benchmark-form"
+                             data-cbcustom-message="<ul><li>Delete benchmark result: <strong>{{ benchmark.id }}</strong></li></ul>">
+                             <i class="bi bi-trash3"></i>
                          </td>
                          {% endif %}
                     </tr>
                     {% endfor %}
                 </tbody>
             </table>
-        </div>
-    </div>
 {% endblock %}
 
 {% block scripts %}

--- a/conbench/templates/hardware-list.html
+++ b/conbench/templates/hardware-list.html
@@ -4,13 +4,10 @@
 {% block app_content %}
 <!-- recipe taken from https://getbootstrap.com/docs/5.0/utilities/flex/#auto-margins -->
 <div class="d-flex">
-    <div class="p-2"><h3>Hardware list</h3></div>
-    <div class="ms-auto p-2">
-        <!-- reserved for `create` button -->
-    </div>
+    <div class="p-0"><h3>Hardware list</h3></div>
 </div>
 
-<hr class="border border-danger border-2 opacity-50">
+<hr class="border border-danger border-1 opacity-50">
 <table id="hardwares" class="table table-hover">
     <thead>
         <tr>

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -3,7 +3,7 @@
 {% block app_content %}
 
 <div class="p-0"><h3>Recent runs</h3></div>
-<hr class="border border-danger border-2 opacity-50">
+<hr class="border border-danger border-1 opacity-50">
 
 <!-- https://getbootstrap.com/docs/5.2/content/tables/#responsive-tables -->
 <div class="table-responsive">

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -2,24 +2,7 @@
 
 {% block app_content %}
 
-<div class="p-3 mb-4 bg-light rounded-3">
-  <div class="container-fluid py-2">
-    <div class="row mb-3">
-      <div class="col-md-5">
-        <h1 class="display-5 fw-bold">Con·bench</h1>
-        <p class="col-md-8 fs-4">/kənˈben(t)SH/ <br /><i>noun</i></p>
-      </div>
-      <div class="col-md-7">
-        <div class="float-end">
-          <img class="media-object" style="padding: 5px" src="{{ url_for('static', filename='bar-graph.png') }}" height="180">
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-
-<div class="p-2"><h3>Recent runs</h3></div>
+<div class="p-0"><h3>Recent runs</h3></div>
 <hr class="border border-danger border-2 opacity-50">
 
 <!-- https://getbootstrap.com/docs/5.2/content/tables/#responsive-tables -->
@@ -113,7 +96,7 @@
       "order": [[0, 'desc']],
       // https://datatables.net/reference/option/dom
       // put `l` to the bottom
-      "dom": "frtipl",
+      "dom": "lfrtip",
       //"lengthMenu": [ 20, 25, 50, 75, 100 ],
       // Make "Commit" (commit hash) column (4) more narrow, hide 'sorting'
       // toggle. Sorting by commit hash is not needed, in particular because

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -2,6 +2,9 @@
 
 {% block app_content %}
 
+
+<h1 class="display-3 text-center" style="margin-bottom: 40px">/kənˈben(t)SH/</h1>
+
 <div class="p-0"><h3>Recent runs</h3></div>
 <hr class="border border-danger border-1 opacity-50">
 

--- a/conbench/templates/user-list.html
+++ b/conbench/templates/user-list.html
@@ -63,7 +63,7 @@ var table = $('#users').DataTable( {
     // published in https://cdn.datatables.net/plug-ins/1.13.3/features/.
     // kudos to https://stackoverflow.com/a/29639664/145400
     "conditionalPaging": true,
-    "pageLenth": 50,
+    "pageLength": 50,
     "lengthChange": false, // not needed in this case (number of rows per page)
     "info": false,
     "searching": false,

--- a/conbench/templates/user-list.html
+++ b/conbench/templates/user-list.html
@@ -6,15 +6,15 @@
 
 <!-- recipe taken from https://getbootstrap.com/docs/5.0/utilities/flex/#auto-margins -->
 <div class="d-flex">
-    <div class="p-2"><h3>Users</h3></div>
-    <div class="ms-auto p-2">
+    <div class="p-0"><h3>Users</h3></div>
+    <div class="ms-auto p-0">
         <a role="button" class="btn btn-outline-dark btn-lg" href="{{ url_for('app.user-create') }}">
             <i class="bi bi-person-plus-fill"></i>
         </a>
     </div>
 </div>
 
-<hr class="border border-danger border-2 opacity-50">
+<hr class="border border-danger border-1 opacity-50">
 
 <!-- note(jp): this form is not displayed, but must be there for the individual
     trash icons in the table to work


### PR DESCRIPTION
In UI design it's all about space, making good use of space and spacing. The jumbotron was nice. 

But with the link to the project in the footer I don't think we need this huge branding piece anymore I think.

This also cleans up the spacing/padding a bit via p-2 -> p-0.

And brings back the entry count selection menu to the top, it fits again I think, and is simply more accessible.

![Screenshot from 2023-03-15 14-51-29](https://user-images.githubusercontent.com/265630/225330514-dfafb824-9ccc-43fc-bb9e-c373762a3a09.png)

Side thought, this triggers thinking about multi-repo support vs single-repo support.
I think all rows in the `repository` column have the same value here in this case. 
We probably want to remove this column and then show the table once per repo (if there are multiple repos known).

