### PR TITLE
benchalerts: add step to post a PR comment about a GitHub Check

### DIFF
--- a/benchalerts/benchalerts/message_formatting.py
+++ b/benchalerts/benchalerts/message_formatting.py
@@ -108,3 +108,16 @@ def github_check_details(full_comparison: FullComparisonInfo) -> Optional[str]:
         """
     )
     return details
+
+
+def pr_comment_link_to_check(summary: str, check_link: str) -> str:
+    """Generate a GitHub PR comment that summarizes and links to a GitHub Check."""
+    return _clean(
+        f"""
+        ## ⚡️ Benchmark results ⚡️
+
+        {summary}.
+
+        See the full report [here]({check_link}).
+        """
+    )

--- a/benchalerts/benchalerts/pipeline_steps/__init__.py
+++ b/benchalerts/benchalerts/pipeline_steps/__init__.py
@@ -2,6 +2,7 @@ from .conbench import GetConbenchZComparisonStep
 from .github import (
     GitHubCheckErrorHandler,
     GitHubCheckStep,
+    GitHubPRCommentAboutCheckStep,
     GitHubStatusErrorHandler,
     GitHubStatusStep,
 )
@@ -10,6 +11,7 @@ __all__ = [
     "GetConbenchZComparisonStep",
     "GitHubCheckErrorHandler",
     "GitHubCheckStep",
+    "GitHubPRCommentAboutCheckStep",
     "GitHubStatusErrorHandler",
     "GitHubStatusStep",
 ]

--- a/benchalerts/tests/unit_tests/mocked_responses/POST_github_issues_1_comments.json
+++ b/benchalerts/tests/unit_tests/mocked_responses/POST_github_issues_1_comments.json
@@ -1,0 +1,34 @@
+{
+    "status_code": 201,
+    "data": {
+        "id": 1,
+        "node_id": "MDEyOklzc3VlQ29tbWVudDE=",
+        "url": "https://api.github.com/repos/octocat/Hello-World/issues/comments/1",
+        "html_url": "https://github.com/octocat/Hello-World/issues/1347#issuecomment-1",
+        "body": "Me too",
+        "user": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+        },
+        "created_at": "2011-04-14T16:00:49Z",
+        "updated_at": "2011-04-14T16:00:49Z",
+        "issue_url": "https://api.github.com/repos/octocat/Hello-World/issues/1347",
+        "author_association": "COLLABORATOR"
+    }
+}

--- a/benchalerts/tests/unit_tests/test_alert_pipeline.py
+++ b/benchalerts/tests/unit_tests/test_alert_pipeline.py
@@ -37,6 +37,9 @@ def test_reasonable_pipeline(conbench_env, github_auth):
             steps.GitHubStatusStep(
                 github_client=github_client, comparison_step_name="z_500"
             ),
+            steps.GitHubPRCommentAboutCheckStep(
+                pr_number=1, github_client=github_client
+            ),
         ],
         error_handlers=[
             steps.GitHubCheckErrorHandler(
@@ -53,7 +56,13 @@ def test_reasonable_pipeline(conbench_env, github_auth):
     )
 
     res = pipeline.run_pipeline()
-    for step_name in ["z_none", "z_500", "GitHubCheckStep", "GitHubStatusStep"]:
+    for step_name in [
+        "z_none",
+        "z_500",
+        "GitHubCheckStep",
+        "GitHubStatusStep",
+        "GitHubPRCommentAboutCheckStep",
+    ]:
         assert res[step_name]
 
     # now force an error to test error handling

--- a/benchalerts/tests/unit_tests/test_pipeline_steps/test_github.py
+++ b/benchalerts/tests/unit_tests/test_pipeline_steps/test_github.py
@@ -7,11 +7,12 @@ from benchalerts.integrations.github import GitHubRepoClient
 from benchalerts.pipeline_steps.github import (
     GitHubCheckErrorHandler,
     GitHubCheckStep,
+    GitHubPRCommentAboutCheckStep,
     GitHubStatusErrorHandler,
     GitHubStatusStep,
 )
 
-from ..mocks import MockAdapter, check_posted_markdown
+from ..mocks import MockAdapter, MockResponse, check_posted_markdown, response_dir
 
 
 @pytest.mark.parametrize(
@@ -70,6 +71,21 @@ def test_GitHubStatusStep(mock_comparison_info: FullComparisonInfo, github_auth:
         comparison_step_name="comparison_step",
     )
     res = step.run_step({"comparison_step": mock_comparison_info})
+    assert res
+
+
+@pytest.mark.parametrize("github_auth", ["pat", "app"], indirect=True)
+def test_GitHubPRCommentAboutCheckStep(github_auth: str):
+    mock_check_response = MockResponse.from_file(
+        response_dir / "POST_github_check-runs.json"
+    ).json()
+
+    step = GitHubPRCommentAboutCheckStep(
+        pr_number=1,
+        github_client=GitHubRepoClient(repo="some/repo", adapter=MockAdapter()),
+        check_step_name="check_step",
+    )
+    res = step.run_step(previous_outputs={"check_step": mock_check_response})
     assert res
 
 


### PR DESCRIPTION
This PR adds a `benchalerts` alert pipeline step to comment on a PR that a GitHub Check has been posted. This is useful when we run benchmarks on the default branch, if the relevant parties (e.g. the author of the most-recently-merged PR) are not necessarily monitoring the Checks that are posted to the default branch commits.

Closes #769.

[Here](https://github.com/conbench/benchalerts/pull/5#issuecomment-1470761104) is an example of the type of comment this step might post.