### PR TITLE
landing page: prevent redraw/layout switch during datatables processing

### DIFF
--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -24,7 +24,7 @@
 
 <!-- https://getbootstrap.com/docs/5.2/content/tables/#responsive-tables -->
 <div class="table-responsive">
-<table id="runs" class="table table-hover">
+<table id="runs" class="table table-hover" style="display:none">
             <thead>
                 <tr>
                     <th scope="col">Run creation time</th>
@@ -124,6 +124,11 @@
       "language": {
           "searchPlaceholder": "search across all columns",
       },
+      initComplete: function () {
+        var api = this.api();
+        $('#runs').show();
+        api.columns.adjust();
+      }
 });
 
 


### PR DESCRIPTION
For #884.

This layout switch can be conceptually tamed by not showing the table until DataTables is done with its logic.

This is a strategy also discussed in https://datatables.net/forums/discussion/61332/eliminate-page-flashing-redrawing.

And in case someone wonders: yes, we want to require JavaScript for the Conbench UI :-) 