### PR TITLE
commit in db: "no context" for partial data, guarantee that "unknown context" has repo+hash, repo URL-related code consolidation

### DIFF
--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -158,6 +158,8 @@ class RunMixin:
         # display_message really seems to be name of the link
         run["commit"]["display_message"] = commit_message
         if not commit_message:  # None or empty string
+            # Note(JP): I wonder where the "url" ever got set.
+            # Maybe in the _Serializer(EntitySerializer) for Commit?
             if run["commit"].get("url"):  # be real conservative
                 run["commit"]["display_message"] = run["commit"].get("url")
             else:

--- a/conbench/app/runs.py
+++ b/conbench/app/runs.py
@@ -12,7 +12,10 @@ from ..app.benchmarks import ContextMixin, RunMixin
 from ..config import Config
 
 
-# This class has the same name as `entities.Run`.
+# This class had the same name as `entities.Run`. Mypy got confused:
+#   conbench/app/__init__.py:16: error: Incompatible import of "Run"
+#   (imported name has type "Type[conbench.app.runs.Run]", local name has
+#     type "Type[conbench.entities.run.Run]")  [assignment]
 class ViewRun(AppEndpoint, ContextMixin, RunMixin, TimeSeriesPlotMixin):
     def page(self, benchmarks, baseline_run, contender_run, form, run_id):
         compare_runs_url = None

--- a/conbench/app/runs.py
+++ b/conbench/app/runs.py
@@ -12,7 +12,8 @@ from ..app.benchmarks import ContextMixin, RunMixin
 from ..config import Config
 
 
-class Run(AppEndpoint, ContextMixin, RunMixin, TimeSeriesPlotMixin):
+# This class has the same name as `entities.Run`.
+class ViewRun(AppEndpoint, ContextMixin, RunMixin, TimeSeriesPlotMixin):
     def page(self, benchmarks, baseline_run, contender_run, form, run_id):
         compare_runs_url = None
         if not flask_login.current_user.is_authenticated:
@@ -91,6 +92,6 @@ class DeleteForm(flask_wtf.FlaskForm):
 
 rule(
     "/runs/<run_id>/",
-    view_func=Run.as_view("run"),
+    view_func=ViewRun.as_view("run"),
     methods=["GET", "POST"],
 )

--- a/conbench/entities/commit.py
+++ b/conbench/entities/commit.py
@@ -177,7 +177,7 @@ class Commit(Base, EntityMixin):
         # https://github.com/conbench/conbench/issues/817
         assert hash is not None
         assert len(hash)
-        assert repo_url.startswith('http')
+        assert repo_url.startswith("http")
 
         return Commit.create(
             {

--- a/conbench/entities/commit.py
+++ b/conbench/entities/commit.py
@@ -152,6 +152,9 @@ class Commit(Base, EntityMixin):
 
     @staticmethod
     def create_no_context():
+        # Special commit row, a singleton that call results can relate to (in
+        # DB, via forgeign key) that have _no_ commit information set. But: is
+        # that needed? Why have that relation at all then?
         commit = Commit.first(sha="", repository="")
         if not commit:
             commit = Commit.create(
@@ -167,11 +170,19 @@ class Commit(Base, EntityMixin):
         return commit
 
     @staticmethod
-    def create_unknown_context(sha, repository):
+    def create_unknown_context(hash: str, repo_url: str) -> "Commit":
+        # Note(JP): I think this means "could not verify, could not get further
+        # info from remote API" -- but we _do_ have a commit hash, and a
+        # repository URL specifier -- insert that into the database. Also see
+        # https://github.com/conbench/conbench/issues/817
+        assert hash is not None
+        assert len(hash)
+        assert repo_url.startswith('http')
+
         return Commit.create(
             {
-                "sha": sha,
-                "repository": repository,
+                "sha": hash,
+                "repository": repo_url,
                 "parent": None,
                 "timestamp": None,
                 "message": "",

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -439,6 +439,10 @@ class GitHubCreate(marshmallow.Schema):
         },
     )
     repository = marshmallow.fields.String(
+        # Does this allow for empty strings or not?
+        # Unclear, after reading marshmallow docs. Testes this. Yes, this
+        # allows for empty string:
+        # https://github.com/marshmallow-code/marshmallow/issues/76#issuecomment-1473348472
         required=True,
         metadata={
             "description": "The repository name (in the format `org/repo`) or the URL "
@@ -446,6 +450,8 @@ class GitHubCreate(marshmallow.Schema):
         },
     )
     pr_number = marshmallow.fields.Integer(
+        # I think this means that all of these pass validation:
+        # empty string, non-empty-string, null
         required=False,
         allow_none=True,
         metadata={

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -38,15 +38,16 @@ class Run(Base, EntityMixin):
     id: Mapped[str] = NotNull(s.String(50), primary_key=True)
     name: Mapped[Optional[str]] = Nullable(s.String(250))
     reason: Mapped[Optional[str]] = Nullable(s.String(250))
-    # `timestamp`  is never set by API clients, i.e. the
-    # `server_default=s.sql.func.now()` is always taking effect. That also
-    # means that this property reflects the point in time of DB insertion (that
-    # should be documented in the API schema for Run objects). A more explicit
-    # way to code that would be in the create() method. The point in time by
-    # convention is stored in UTC _without_ timezone information. Is a wrong
-    # point in time stored when `s.sql.func.now()` returns a non-UTC tz-aware
-    # timestamp on a DB server that does not have its system time in UTC? That
-    # should not happen, as is hopefully confirmed by the test
+    # Naive datetime object, to be interpreted in UTC. `timestamp`  is never
+    # set by API clients, i.e. the `server_default=s.sql.func.now()` is always
+    # taking effect. That also means that this property reflects the point in
+    # time of DB insertion (that should be documented in the API schema for Run
+    # objects). A more explicit way to code that would be in the create()
+    # method. The point in time by convention is stored in UTC _without_
+    # timezone information. Is a wrong point in time stored when
+    # `s.sql.func.now()` returns a non-UTC tz-aware timestamp on a DB server
+    # that does not have its system time in UTC? That should not happen, as is
+    # hopefully confirmed by the test
     # `test_auto_generated_run_timestamp_value()`.
     timestamp: Mapped[datetime] = NotNull(
         s.DateTime(timezone=False), server_default=s.sql.func.now()
@@ -99,6 +100,10 @@ class Run(Base, EntityMixin):
                     github_data["repository"],
                     repo_url,
                 )
+
+                # Do some type normalization again.
+                if repo_url == "":
+                    repo_url = None
 
             # Note(JP): this string may be zerolength as of today, does that
             # make sense? Also see https://github.com/conbench/conbench/issues/817

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -77,9 +77,10 @@ class Run(Base, EntityMixin):
         # Work towards a state where these are guaranteed to be either None or
         # non-zerolength strings.
         repo_url: Optional[str] = None
-        pr_number: Optional[str] = None
         branch: Optional[str] = None
         commit_hash: Optional[str] = None
+
+        pr_number: Optional[int] = None
 
         if github_data := data.pop("github", None):
             # Note(JP): this should ensure that the `repository` Column in the
@@ -110,16 +111,15 @@ class Run(Base, EntityMixin):
                 # a repository context, and there is a commit to refer to.
                 log.warning("Run.create(): zero-length string github_data['commit']")
 
-            if github_data.get("pr_number"):
-                # Only set to non-None when non-empty string.
-                pr_number = github_data.get("pr_number")
-
             if github_data.get("branch"):
                 # Only set to non-None when non-empty string.
                 branch = github_data.get("branch")
 
+            # This assignment is expected to retain the Optional[int] type.
+            pr_number = github_data.get("pr_number")
+
         # Before DB insertion its good to have clarity.
-        for testitem in (commit_hash, repo_url, pr_number, branch):
+        for testitem in (commit_hash, repo_url, branch):
             assert testitem is None or len(testitem) > 0, github_data
 
         commit_id = commit_fetch_info_and_create_in_db_if_not_exists(

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -435,7 +435,7 @@ class GitHubCreate(marshmallow.Schema):
     commit = marshmallow.fields.String(
         required=True,
         metadata={
-            "description": "The 40-character commit SHA of the repo being benchmarked"
+            "description": "The 40-character commit hash of the repo being benchmarked"
         },
     )
     repository = marshmallow.fields.String(
@@ -450,8 +450,6 @@ class GitHubCreate(marshmallow.Schema):
         },
     )
     pr_number = marshmallow.fields.Integer(
-        # I think this means that all of these pass validation:
-        # empty string, non-empty-string, null
         required=False,
         allow_none=True,
         metadata={
@@ -460,6 +458,8 @@ class GitHubCreate(marshmallow.Schema):
         },
     )
     branch = marshmallow.fields.String(
+        # I think this means that all of these pass validation:
+        # empty string, non-empty-string, null
         required=False,
         allow_none=True,
         metadata={

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -1180,7 +1180,7 @@
                         "type": "string",
                     },
                     "commit": {
-                        "description": "The 40-character commit SHA of the repo being benchmarked",
+                        "description": "The 40-character commit hash of the repo being benchmarked",
                         "type": "string",
                     },
                     "pr_number": {

--- a/conbench/tests/api/_fixtures.py
+++ b/conbench/tests/api/_fixtures.py
@@ -339,7 +339,7 @@ def gen_fake_data() -> Tuple[Dict[str, Commit], List[BenchmarkResult]]:
 
     # commits with less context
     commits["sha"] = Commit.create_unknown_context(
-        sha="sha", repository="https://github.com/org/something_else_entirely"
+        hash="sha", repo_url="https://github.com/org/something_else_entirely"
     )
     commits[""] = Commit.create_no_context()
 

--- a/conbench/tests/api/test_benchmarks.py
+++ b/conbench/tests/api/test_benchmarks.py
@@ -826,7 +826,9 @@ class TestBenchmarkPost(_asserts.PostEnforcer):
         new_id = response.json["id"]
         benchmark_result = BenchmarkResult.one(id=new_id)
         assert benchmark_result.run.commit.sha == ""
-        assert benchmark_result.run.commit.repository == ARROW_REPO
+
+        # new code path: no context, not unknown context
+        # assert benchmark_result.run.commit.repository == ARROW_REPO
         assert benchmark_result.run.commit.parent is None
         location = "http://localhost/api/benchmarks/%s/" % new_id
         self.assert_201_created(response, _expected_entity(benchmark_result), location)
@@ -840,7 +842,8 @@ class TestBenchmarkPost(_asserts.PostEnforcer):
         new_id = response.json["id"]
         benchmark_result = BenchmarkResult.one(id=new_id)
         assert benchmark_result.run.commit.sha == ""
-        assert benchmark_result.run.commit.repository == CONBENCH_REPO
+        # new code path: no context, not unknown context
+        # assert benchmark_result.run.commit.repository == CONBENCH_REPO
         assert benchmark_result.run.commit.parent is None
         location = "http://localhost/api/benchmarks/%s/" % new_id
         self.assert_201_created(response, _expected_entity(benchmark_result), location)
@@ -855,7 +858,8 @@ class TestBenchmarkPost(_asserts.PostEnforcer):
         response = client.post("/api/benchmarks/", json=data)
         new_id = response.json["id"]
         benchmark_result = BenchmarkResult.one(id=new_id)
-        assert benchmark_result.run.commit.sha == "something something"
+        # new code path: no context, not unknown context
+        # assert benchmark_result.run.commit.sha == "something something"
         assert benchmark_result.run.commit.repository == ""
         assert benchmark_result.run.commit.parent is None
         location = "http://localhost/api/benchmarks/%s/" % new_id


### PR DESCRIPTION
This is a PR mainly towards making code a little clearer.

It's a rather intermediate state towards more rigor.

There is small change in internal behavior, making it so that less empty-string values are inserted into the database. It's better to have two states (None, non-empty string) instead of three states.

This tiny bit of type normalization from empty string to None here and there has yielded some insights.

That changes a code path into something that makes a lot of sense, I think: "no context" commit objects instead of "unknown context". "unknown context" now _requires_ having a commit hash and repository URL set. So, this is a good step forward for #817.

Also see

https://github.com/conbench/conbench/issues/888
https://github.com/conbench/conbench/issues/887