### PR TITLE
UI: update Transcription (and update local dev app name)

### DIFF
--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -3,7 +3,7 @@
 {% block app_content %}
 
 
-<h1 class="display-3 text-center" style="margin-bottom: 40px">/kənˈben(t)SH/</h1>
+<h1 class="display-3 text-center" style="margin-bottom: 40px">/ˈkɒnbɛnʧ/</h1>
 
 <div class="p-0"><h3>Recent runs</h3></div>
 <hr class="border border-danger border-1 opacity-50">

--- a/conbench/templates/register.html
+++ b/conbench/templates/register.html
@@ -18,7 +18,7 @@
 
   <div class="media-body">
     <h4 class="media-heading">Con·bench</h4>
-     <h4>/kənˈben(t)SH/</h4>
+     <h4>/ˈkɒnbɛnʧ/</h4>
      <h5><i>noun</i></h5>
      <h3>Language-independent Continuous Benchmarking (CB) Framework</h3>
   </div>

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -1329,7 +1329,7 @@
             },
         },
     },
-    "info": {"title": "conbench-for-pytest", "version": "1.0.0"},
+    "info": {"title": "local-dev-conbench", "version": "1.0.0"},
     "openapi": "3.0.2",
     "paths": {
         "/api/": {

--- a/conbench/tests/app/_asserts.py
+++ b/conbench/tests/app/_asserts.py
@@ -66,16 +66,16 @@ class AppEndpointTest:
 
     def assert_index_page(self, r):
         self.assert_200_ok(r)
-        assert b"conbench-for-pytest" in r.data
+        assert b"local-dev-conbench" in r.data
         assert b'<html lang="en">' in r.data
         # assert b"Login" in r.data
 
     def assert_page(self, r, title):
         self.assert_200_ok(r)
         # The HTML <title> tag starts with the conbench deployment name, in
-        # this case `conbench-for-pytest` and then contains a " - " seperator,
+        # this case `local-dev-conbench` and then contains a " - " seperator,
         # followed by the more specific page name
-        assert b"conbench-for-pytest - " in r.data
+        assert b"local-dev-conbench - " in r.data
 
     def create_benchmark(self, client):
         self.authenticate(client)
@@ -199,16 +199,16 @@ class GetEnforcer(Enforcer):
         # be reworked.
         # assert new_id.encode() not in r2.data
 
-        assert b"conbench-for-pytest - Sign In" in r2.data, r2.data
+        assert b"local-dev-conbench - Sign In" in r2.data, r2.data
 
     def test_unknown(self, client):
         self.authenticate(client)
         unknown_url = self.url.format("unknown")
         response = client.get(unknown_url, follow_redirects=True)
         if getattr(self, "redirect_on_unknown", True):
-            assert b"conbench-for-pytest - Home" in response.data, response.data
+            assert b"local-dev-conbench - Home" in response.data, response.data
         else:
-            title = f"conbench-for-pytest - {self.title}".encode()
+            title = f"local-dev-conbench - {self.title}".encode()
             assert title in response.data, response.data
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,23 +6,17 @@ services:
       # Note that currently this Dockerfile defines the image that' used for
       # Conbench production environments.
       dockerfile: Dockerfile
-    command:
-      [
-        "gunicorn",
-        "-c",
-        "conbench/gunicorn-conf.py",
-        "-b",
-        "0.0.0.0:5000",
-        "-w",
-        "5",
-        "-t",
-        "120",
-        "conbench:application",
-        "--access-logfile=-",
-        "--access-logformat",
-        '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" (%(L)s s)',
-        "--error-logfile=-"
-      ]
+    command: [
+          "gunicorn",
+          "-c", "conbench/gunicorn-conf.py",
+          "-b", "0.0.0.0:5000",
+          "-w", "5",
+          "-t", "120",
+          "conbench:application",
+          "--access-logfile=-",
+          "--access-logformat", '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" (%(L)s s)',
+          "--error-logfile=-"
+          ]
     ports:
       # When using the default value `127.0.0.1::5000` (two colons) then the
       # container-internal port 5000 will be dynamically mapped to a free port

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,17 +6,23 @@ services:
       # Note that currently this Dockerfile defines the image that' used for
       # Conbench production environments.
       dockerfile: Dockerfile
-    command: [
-          "gunicorn",
-          "-c", "conbench/gunicorn-conf.py",
-          "-b", "0.0.0.0:5000",
-          "-w", "5",
-          "-t", "120",
-          "conbench:application",
-          "--access-logfile=-",
-          "--access-logformat", '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" (%(L)s s)',
-          "--error-logfile=-"
-          ]
+    command:
+      [
+        "gunicorn",
+        "-c",
+        "conbench/gunicorn-conf.py",
+        "-b",
+        "0.0.0.0:5000",
+        "-w",
+        "5",
+        "-t",
+        "120",
+        "conbench:application",
+        "--access-logfile=-",
+        "--access-logformat",
+        '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" (%(L)s s)',
+        "--error-logfile=-"
+      ]
     ports:
       # When using the default value `127.0.0.1::5000` (two colons) then the
       # container-internal port 5000 will be dynamically mapped to a free port
@@ -35,7 +41,7 @@ services:
       - dex
       - db
     environment:
-      APPLICATION_NAME: "conbench-for-pytest"
+      APPLICATION_NAME: "local-dev-conbench"
       DB_USERNAME: "postgres"
       # From the docker-compose docs: "By default Compose sets up a single
       # network for your app. Each container for a service joins the default


### PR DESCRIPTION
Resolves #897

IPA transcriptions are broadly preferred to the English-based orthographic versions like we had (and we get to use fun characters like `ʧ` 😛 )

Also changes the name for local deployments to something slightly more obvious that that is what it is.