### PR TITLE
ci: don't post PR comments from CI

### DIFF
--- a/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
+++ b/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
@@ -51,7 +51,7 @@ from benchclients import ConbenchClient
         ),
     ],
 )
-def test_get_comparison_to_baseline(
+def test_GetConbenchZComparisonStep(
     monkeypatch: pytest.MonkeyPatch, conbench_url, commit, expected_len, expected_bip
 ):
     if "ursa" in conbench_url:


### PR DESCRIPTION
This PR suppresses the `benchalerts` integration test that posts comments to a GitHub PR if it's running in CI. That was causing too much noise and getting us closer to our CI GitHub rate limit.