### PR TITLE
benchalerts: reformat comments

### DIFF
--- a/benchalerts/benchalerts/message_formatting.py
+++ b/benchalerts/benchalerts/message_formatting.py
@@ -112,12 +112,18 @@ def github_check_details(full_comparison: FullComparisonInfo) -> Optional[str]:
 
 def pr_comment_link_to_check(summary: str, check_link: str) -> str:
     """Generate a GitHub PR comment that summarizes and links to a GitHub Check."""
-    return _clean(
-        f"""
-        ## ⚡️ Benchmark results ⚡️
+    summary_lines = summary.split("\n")
 
-        {summary}.
+    # Strip off the "note" and afterwards (would be noisy in a comment)
+    note_index = [ix for ix, line in enumerate(summary_lines) if line == "### Note"]
+    if note_index:
+        summary_lines = summary_lines[: note_index[0]]
 
-        See the full report [here]({check_link}).
-        """
+    summary_preview = "\n".join(summary_lines[:20])
+    if len(summary_lines) > 20:
+        summary_preview += "\n..."
+
+    return (
+        f"A [full benchmark report]({check_link}) is ready. Here is a preview:\n\n"
+        + summary_preview
     )

--- a/benchalerts/benchalerts/pipeline_steps/github.py
+++ b/benchalerts/benchalerts/pipeline_steps/github.py
@@ -298,7 +298,7 @@ class GitHubPRCommentAboutCheckStep(AlertPipelineStep):
         check_details: dict = previous_outputs[self.check_step_name]
         res = self.github_client.create_pull_request_comment(
             comment=self._default_comment(
-                summary=check_details["output"]["title"],
+                summary=check_details["output"]["summary"],
                 check_link=check_details["html_url"],
             ),
             pull_number=self.pr_number,

--- a/benchalerts/tests/integration_tests/test_alert_pipeline.py
+++ b/benchalerts/tests/integration_tests/test_alert_pipeline.py
@@ -107,11 +107,11 @@ def test_alert_pipeline(monkeypatch: pytest.MonkeyPatch, github_auth: str):
         assert outputs["GitHubCheckStep"]["conclusion"] == "failure"
         if not os.getenv("CI"):
             assert outputs["GitHubPRCommentAboutCheckStep"]["body"].startswith(
-                """## ⚡️ Benchmark results ⚡️
-
-Found 1 regression(s).
-
-See the full report [here]("""
+                "A [full benchmark report](https://github.com/conbench/benchalerts/runs/"
+            )
+            assert (
+                "Contender commit `c76715c9` had 1 performance regression(s) compared to its baseline runs."
+                in outputs["GitHubPRCommentAboutCheckStep"]["body"]
             )
 
     # sleep to see the updated statuses on the PR


### PR DESCRIPTION
This is a small PR to reformat the PR comments that `benchalerts` posts. Closes #900.

It posts the first 20 lines of the benchmark report to the comment, instead of just linking to the comment.