### PR TITLE
UI: show "unknown ID: ..." instead of "error getting benchmark" (fix #906)

### DIFF
--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -14,7 +14,6 @@ from ..app._plots import TimeSeriesPlotMixin
 from ..app._util import augment, display_message, display_time
 from ..config import Config
 
-
 log = logging.getLogger(__name__)
 
 

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -63,7 +63,7 @@ class BenchmarkMixin:
         benchmark, response = self._get_benchmark(benchmark_id)
 
         if response.status_code == 404:
-            self.flash("unknown benchmark ID: {benchmark_id}", "info")
+            self.flash(f"unknown benchmark ID: {benchmark_id}", "info")
 
         if response.status_code != 200:
             # Note(JP): quick band-aid to at least not swallow err detail, need

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -86,7 +86,7 @@
             <!-- Categories: success (green), info (blue), warning (yellow), danger (red) -->
             {% for category, message in messages %}
             <div class="alert alert-{{ category }}" role="alert">
-                <i class="bi bi-lightning"></i> {{ message }}
+                <p class="fs-5"><i class="bi bi-exclamation-diamond-fill"></i> {{ message }}</p>
             </div>
             {% endfor %}
         {% endif %}

--- a/conbench/tests/app/test_benchmarks.py
+++ b/conbench/tests/app/test_benchmarks.py
@@ -22,7 +22,7 @@ class TestBenchmarkGet(_asserts.GetEnforcer):
         self.authenticate(client)
         response = client.get("/benchmarks/unknown/", follow_redirects=True)
         self.assert_index_page(response)
-        assert b"Error getting benchmark." in response.data
+        assert re.search(r"unknown benchmark ID: \w+", response.text, flags=re.ASCII)
 
 
 class TestBenchmarkDelete(_asserts.DeleteEnforcer):
@@ -48,7 +48,7 @@ class TestBenchmarkDelete(_asserts.DeleteEnforcer):
         # cannot get benchmark after
         response = client.get(f"/benchmarks/{benchmark_id}/", follow_redirects=True)
         self.assert_index_page(response)
-        assert b"Error getting benchmark." in response.data
+        assert re.search(r"unknown benchmark ID: \w+", response.text, flags=re.ASCII)
 
     def test_unauthenticated(self, client):
         benchmark_id = self.create_benchmark(client)


### PR DESCRIPTION
This is for addressing #906.