### PR TITLE
UI: show per-run result count in runs table (db: load results immediately with run)

### DIFF
--- a/conbench/app/index.py
+++ b/conbench/app/index.py
@@ -44,6 +44,7 @@ class Index(AppEndpoint, RunMixin):
             rd = RunForDisplay(
                 ctime_for_table=r.timestamp.strftime("%Y-%m-%d %H:%M:%S UTC"),
                 commit_message_short=short_commit_msg(r.commit.message),
+                result_count=len(r.results),
                 run=r,
             )
 
@@ -80,6 +81,7 @@ def repo_url_to_display_name(url: str) -> str:
 class RunForDisplay:
     ctime_for_table: str
     commit_message_short: str
+    result_count: int
     # Expose the raw Run object (but this needs to be used with a lot of
     # care, in the template -- for VSCode supporting Python variable types and
     # auot-completion in a jinja2 template see

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from datetime import datetime, timezone
-from typing import Optional, List
+from typing import List, Optional
 
 import flask as f
 import marshmallow
@@ -21,8 +21,6 @@ from ..entities._entity import (
     NotNull,
     Nullable,
 )
-
-from ..entities._entity import Base, EntityMixin, EntitySerializer, NotNull, Nullable
 
 from ..entities.commit import (
     CantFindAncestorCommitsError,
@@ -79,7 +77,10 @@ class Run(Base, EntityMixin):
     # Follow ttps://docs.sqlalchemy.org/en/20/orm/basic_relationships.html#one-to-many.
     # There is a one-to-many relationship between Run (one) and BenchmarkResult
     # (0, 1, many).
-    results: Mapped[List["BenchmarkResult"]] = relationship(back_populates="run")
+    # Ignorantly importing BenchmarkResult results in circular import err.
+    results: Mapped[List["BenchmarkResult"]] = relationship(  # noqa
+        back_populates="run"
+    )
 
     @staticmethod
     def create(data) -> "Run":

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Optional, List
 
 import flask as f
 import marshmallow
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Mapped, relationship
 import conbench.util
 
 from ..db import Session
+
 from ..entities._entity import (
     Base,
     EntityExists,
@@ -20,6 +21,9 @@ from ..entities._entity import (
     NotNull,
     Nullable,
 )
+
+from ..entities._entity import Base, EntityMixin, EntitySerializer, NotNull, Nullable
+
 from ..entities.commit import (
     CantFindAncestorCommitsError,
     Commit,
@@ -71,6 +75,11 @@ class Run(Base, EntityMixin):
     has_errors: Mapped[bool] = NotNull(s.Boolean, default=False)
     hardware_id: Mapped[str] = NotNull(s.String(50), s.ForeignKey("hardware.id"))
     hardware: Mapped[Hardware] = relationship("Hardware", lazy="joined")
+
+    # Follow ttps://docs.sqlalchemy.org/en/20/orm/basic_relationships.html#one-to-many.
+    # There is a one-to-many relationship between Run (one) and BenchmarkResult
+    # (0, 1, many).
+    results: Mapped[List["BenchmarkResult"]] = relationship(back_populates="run")
 
     @staticmethod
     def create(data) -> "Run":

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -76,7 +76,7 @@ class Run(Base, EntityMixin):
     # There is a one-to-many relationship between Run (one) and BenchmarkResult
     # (0, 1, many).
     # Ignorantly importing BenchmarkResult results in circular import err.
-    results: Mapped[List["BenchmarkResult"]] = relationship(  # noqa
+    results: Mapped[List["BenchmarkResult"]] = relationship(  # type: ignore # noqa
         back_populates="run"
     )
 

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -12,7 +12,6 @@ from sqlalchemy.orm import Mapped, relationship
 import conbench.util
 
 from ..db import Session
-
 from ..entities._entity import (
     Base,
     EntityExists,
@@ -21,7 +20,6 @@ from ..entities._entity import (
     NotNull,
     Nullable,
 )
-
 from ..entities.commit import (
     CantFindAncestorCommitsError,
     Commit,

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -28,7 +28,7 @@
     </tr>
     <tr>
         <!-- add tooltip, saying that this is DB insertion time -->
-        <th scope="col" style="width: 180px">insertion time</th>
+        <th scope="col" style="width: 180px">insertion time (result count)</th>
         <th scope="col" class="reason-col">reason</th>
         <th scope="col" style="width: 150px">hardware</th>
         <th scope="col" style="width: 170px">author</th>
@@ -41,7 +41,7 @@
   {% for r in runobjs %}
   <tr>
     <td style="white-space: nowrap;">
-        <a href="{{ url_for('app.run', run_id=r.run.id) }}">{{ r.ctime_for_table }}</a>
+        <a href="{{ url_for('app.run', run_id=r.run.id) }}">{{ r.ctime_for_table }}</a>  ({{ r.result_count }})
         {% if r.run.has_errors or r.run.error_info %}
             <i class="bi bi-exclamation-circle text-danger"
               data-toggle="tooltip"

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -28,7 +28,8 @@
     </tr>
     <tr>
         <!-- add tooltip, saying that this is DB insertion time -->
-        <th scope="col" style="width: 180px">insertion time (result count)</th>
+        <th scope="col" style="width: 180px">insertion time</th>
+        <th scope="col">results</th>
         <th scope="col" class="reason-col">reason</th>
         <th scope="col" style="width: 150px">hardware</th>
         <th scope="col" style="width: 170px">author</th>
@@ -41,14 +42,16 @@
   {% for r in runobjs %}
   <tr>
     <td style="white-space: nowrap;">
-        <a href="{{ url_for('app.run', run_id=r.run.id) }}">{{ r.ctime_for_table }}</a>  ({{ r.result_count }})
+        <a href="{{ url_for('app.run', run_id=r.run.id) }}">{{ r.ctime_for_table }}</a>
         {% if r.run.has_errors or r.run.error_info %}
             <i class="bi bi-exclamation-circle text-danger"
               data-toggle="tooltip"
               data-placement="top"
-              title="This Run contains at least one benchmark result with an error"></i>
+              title="This Run contains a benchmark result with an error, or is otherwise labeled as errored"></i>
         {% endif %}
     </td>
+
+    <td>{{ r.result_count }}</td>
 
     <td>
       {% if r.run.reason %}


### PR DESCRIPTION
This is for #911, maybe a provocative proposal. It's a small code change, so I thought I bring up a specific proposal for review feedback:

![Screenshot from 2023-03-20 17-09-34](https://user-images.githubusercontent.com/265630/226401439-cf74d85e-d0ab-4316-8438-4d0c028b7b6c.png)

Would love to hear opinions @jonkeane @austin3dickey @alistaire47. 