### PR TITLE
db: define connect timeout

### DIFF
--- a/conbench/db.py
+++ b/conbench/db.py
@@ -38,7 +38,11 @@ def configure_engine(url):
         # tickets and discussions:
         # https://github.com/conbench/conbench/issues/599
         # https://github.com/conbench/conbench/pull/690
-        connect_args={"options": "-c timezone=utc -c statement_timeout=60s"},
+        # https://docs.sqlalchemy.org/en/20/core/engines.html#use-the-connect-args-dictionary-parameter
+        connect_args={
+            "options": "-c timezone=utc -c statement_timeout=60s",
+            "connect_timeout": 3,
+        },
     )
     log.info("bind engine to session")
     session_maker.configure(bind=engine)
@@ -132,6 +136,7 @@ def create_all():
         else:
             raise
 
+    log.info("create_all(engine) returned. dispose()")
     engine.dispose()
 
 

--- a/conbench/db.py
+++ b/conbench/db.py
@@ -41,7 +41,9 @@ def configure_engine(url):
         # https://docs.sqlalchemy.org/en/20/core/engines.html#use-the-connect-args-dictionary-parameter
         connect_args={
             "options": "-c timezone=utc -c statement_timeout=60s",
-            "connect_timeout": 3,
+            # The `connect_timeout` parameter is documented in
+            # https://www.postgresql.org/docs/12/libpq-connect.html
+            "connect_timeout": 3,  # unit: seconds
         },
     )
     log.info("bind engine to session")


### PR DESCRIPTION
Related to #801.

For example, allows for quicker retrying upon networking hiccup in the context of docker-compose.