### PR TITLE
ci/local dev: bump PostgreSQL from 12.4 to 15.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       - "127.0.0.1::5556"
 
   db:
-    image: library/postgres:12.4
+    image: library/postgres:15.2-alpine
     environment:
       POSTGRES_DB: "postgres"
       POSTGRES_USER: "postgres"


### PR DESCRIPTION
Let's see if we maybe can take advantage of DB performance improvements for local dev / developer productivity.

For feature parity with the corresponding cloud offering, see https://aws.amazon.com/about-aws/whats-new/2023/02/amazon-rds-postgresql-major-version-15/

> [Amazon Relational Database Service (Amazon RDS)](https://aws.amazon.com/rds/postgresql/) for PostgreSQL now supports the latest major version PostgreSQL 15.

