### PR TITLE
Remove code coverage remainders everywhere for now (ci, badges, ...)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,8 @@ db-populate:
 tests: require-env-ghtoken set-build-info
 	docker compose down --remove-orphans && \
 	docker compose build app && \
-	docker compose run \
-		-e COVERAGE_FILE=/etc/conbench-coverage-dir/.coverage \
-		app \
-		coverage run --source conbench \
-			-m pytest -vv -s --durations=20 conbench/tests/
+	docker compose run app \
+		pytest -vv -s --durations=20 conbench/tests/
 
 
 # Similar to `make run-app`, but with the `docker-compose.dev.yml` extension

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Conbench
 
-Check out the docs at https://conbench.github.io/conbench !
+Check out the docs at https://conbench.github.io/conbench.
 
 <img src="https://raw.githubusercontent.com/conbench/conbench/main/conbench.png" alt="Language-independent Continuous Benchmarking (CB) Framework">
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 <p align="right">
 <a href="https://github.com/conbench/conbench/blob/main/.github/workflows/actions.yml"><img alt="Build Status" src="https://github.com/conbench/conbench/actions/workflows/actions.yml/badge.svg?branch=main"></a>
-<a href="https://coveralls.io/github/conbench/conbench?branch=main"><img src="https://coveralls.io/repos/github/conbench/conbench/badge.svg?branch=main&kill_cache=06b9891a46827df564072ae831b13897599f7f3d" alt="Coverage Status" /></a>
-<a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 </p>
 
 # Conbench
@@ -26,7 +24,6 @@ compare results across varying benchmark machines, languages, and cases.
 
 There is also a Conbench command line interface, useful for Continuous
 Benchmarking (CB) orchestration alongside your development pipeline.
-
 
 <p align="center">
     <img src="https://arrow.apache.org/img/arrow.png" alt="Apache Arrow" height="100">

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 black
 bs4
-coverage
 coveralls
 flake8
 isort


### PR DESCRIPTION
This is for #852. Also see commit messages.

Side note: I think this might speed up `make tests`.