### PR TITLE
ci: modify JSONNET before deploy to minikube

### DIFF
--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -93,7 +93,11 @@ EOF
 
 export PROM_REMOTE_WRITE_CLUSTER_LABEL_VALUE="ci-conbench-on-$(hostname -s)"
 
-# Build custom version of kube-prometheus stack.
+
+# JSONNET-build our custom version of kube-prometheus. Before JSONNET
+# compilation mutate the main document to make adjustments for the minikube
+# environment (smaller resource footprint, anonymous access to Grafana UI).
+export MUTATE_JSONNET_FILE_FOR_MINIKUBE=true
 ( cd "${CONBENCH_REPO_ROOT_DIR}" && make jsonnet-kube-prom-manifests )
 
 # Set up the kube-prometheus stack. This follows the customization instructions

--- a/k8s/kube-prometheus/conbench-flavor.jsonnet
+++ b/k8s/kube-prometheus/conbench-flavor.jsonnet
@@ -14,7 +14,7 @@ local kp =
   // (import 'kube-prometheus/addons/custom-metrics.libsonnet') +
   // (import 'kube-prometheus/addons/external-metrics.libsonnet') +
   // (import 'kube-prometheus/addons/pyrra.libsonnet') +
-  (import 'kube-prom-no-req-no-lim.jsonnet') +
+  // (import "kube-prom-no-req-no-lim.jsonnet") +  // auto-uncommented-by-ci
   {
     values+:: {
       prometheus+: {
@@ -35,7 +35,7 @@ local kp =
         config: {
           // http://docs.grafana.org/installation/configuration/
           sections: {
-            'auth.anonymous': { enabled: true },
+            // "auth.anonymous": { enabled: true },  // auto-uncommented-by-ci
             // Configure Grafana to be available under sub path instead of
             // root.
             server: {
@@ -59,7 +59,7 @@ local kp =
             // If left as-is then Prometheus starts and periodically shows
             // a log line saying that this is an invalid URL. That's fine!
             // That is: replace this, if you want the k8s cluster to send
-            // metrics ot an external system. Leave this as-is when this
+            // metrics to an external system. Leave this as-is when this
             // capabily is not needed.
             url: 'PROM_REMOTE_WRITE_ENDPOINT_URL',
             basicAuth: {


### PR DESCRIPTION
This makes it so that `make jsonnet-kube-prom-manifests` does _not_ by default entail stack modifications that are in fact only of value / use when deploying on minikube. For example, do not by default use `"auth.anonymous": { enabled: true }`. This is related to #922. 