### PR TITLE
api: bmresult POST: document and test that name is required

### DIFF
--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -191,12 +191,16 @@ class BenchmarkResult(Base, EntityMixin):
                 "status": "Partial result: not all iterations completed"
             }
 
+        # Note(JP): this implicitly introduces a requirement for `name` to be
+        # set: https://github.com/conbench/conbench/issues/935
+        # Also note: this pulls the `name=xx` key/value pair out of tags.
         name = tags.pop("name")
 
         # create if not exists
         c = {"name": name, "tags": tags}
         case = Case.first(**c)
         if not case:
+            # Note(JP): there is a race condition here, expect this to collide
             case = Case.create(c)
 
         # create if not exists
@@ -576,7 +580,31 @@ class _BenchmarkFacadeSchemaCreate(marshmallow.Schema):
     tags = marshmallow.fields.Dict(
         required=True,
         metadata={
-            "description": "Details that define the individual benchmark case that is being run (e.g. name, query type, data source, parameters). These are details about a benchmark that define different cases, for example: for a file reading benchmark, some tags might be: the data source being read, the compression that file is written in, the output format, etc."
+            "description": conbench.util.dedent_rejoin(
+                """
+                The set of key/value pairs that defines a benchmark case
+                permutation. Top-level keys must be strings. Allowed value
+                types are ... (to be specified).
+
+                The special key "name" must be provided with a string value: it
+                indicates the name of the conceptual benchmark that was
+                performed for obtaining the result at hand. All case
+                permutations of a conceptual benchmark by definition have this
+                name in common.
+
+                We advise that each unique case (as defined by the complete set
+                of key/value pairs) indeed corresponds to unique benchmarking
+                behavior. That is, typically, these key/value pairs directly
+                correspond to input parameters to your benchmarking method.
+
+                Example: a conceptual benchmark with name "foo-write-file"
+                might have meaningful case permutations involving tag names
+                such as `compression_method` (values: `gzip`, `lzma`, ...),
+                `file_format` (values: `csv`, `hdf5`, ...), `dataset_name`
+                (values: `foo`, `bar`, ...). For each conceptual benchmark, it
+                is OK to have no or many case permutations.
+                """
+            )
         },
     )
     optional_benchmark_info = marshmallow.fields.Dict(

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -1027,7 +1027,7 @@
                     },
                     "stats": {"$ref": "#/components/schemas/BenchmarkResultCreate"},
                     "tags": {
-                        "description": "Details that define the individual benchmark case that is being run (e.g. name, query type, data source, parameters). These are details about a benchmark that define different cases, for example: for a file reading benchmark, some tags might be: the data source being read, the compression that file is written in, the output format, etc.",
+                        "description": 'The set of key/value pairs that defines a benchmark case permutation. Top-level keys must be strings. Allowed value types are ... (to be specified).  The special key "name" must be provided with a string value: it indicates the name of the conceptual benchmark that was performed for obtaining the result at hand. All case permutations of a conceptual benchmark by definition have this name in common.  We advise that each unique case (as defined by the complete set of key/value pairs) indeed corresponds to unique benchmarking behavior. That is, typically, these key/value pairs directly correspond to input parameters to your benchmarking method.  Example: a conceptual benchmark with name "foo-write-file" might have meaningful case permutations involving tag names such as `compression_method` (values: `gzip`, `lzma`, ...), `file_format` (values: `csv`, `hdf5`, ...), `dataset_name` (values: `foo`, `bar`, ...). For each conceptual benchmark, it is OK to have no or many case permutations.',
                         "type": "object",
                     },
                     "timestamp": {

--- a/conbench/tests/api/test_benchmarks.py
+++ b/conbench/tests/api/test_benchmarks.py
@@ -936,6 +936,16 @@ class TestBenchmarkPost(_asserts.PostEnforcer):
         assert resp.status_code == 400, f"unexpected response: {resp.text}"
         assert '"context": ["Missing data for required field."]' in resp.text
 
+    def test_create_benchmark_name_missing(self, client):
+        self.authenticate(client)
+        payload = _fixtures.VALID_PAYLOAD.copy()
+        del payload["tags"]["name"]
+        resp = client.post(self.url, json=payload)
+        # TODO: https://github.com/conbench/conbench/issues/935
+        # This here just quickly checks that there is a failure at all,
+        # that 'name' is required.
+        assert resp.status_code == 500
+
     def test_create_benchmark_context_empty(self, client):
         """
         It is an error to provide no context object (see test above). Whether

--- a/conbench/tests/api/test_benchmarks.py
+++ b/conbench/tests/api/test_benchmarks.py
@@ -938,13 +938,13 @@ class TestBenchmarkPost(_asserts.PostEnforcer):
 
     def test_create_benchmark_name_missing(self, client):
         self.authenticate(client)
-        payload = _fixtures.VALID_PAYLOAD.copy()
+        payload = copy.deepcopy(_fixtures.VALID_PAYLOAD)
         del payload["tags"]["name"]
-        resp = client.post(self.url, json=payload)
-        # TODO: https://github.com/conbench/conbench/issues/935
-        # This here just quickly checks that there is a failure at all,
-        # that 'name' is required.
-        assert resp.status_code == 500
+        with pytest.raises(KeyError):
+            client.post(self.url, json=payload)
+            # TODO: https://github.com/conbench/conbench/issues/935
+            # This here just quickly checks that there is a failure at all,
+            # that 'name' is required.
 
     def test_create_benchmark_context_empty(self, client):
         """


### PR DESCRIPTION
This is a quick follow-up for https://github.com/conbench/conbench/issues/935.