### PR TITLE
UI, internals: more of "benchmark name" and "benchmark case permutation", start cleaning up hacks.py

### DIFF
--- a/conbench/api/compare.py
+++ b/conbench/api/compare.py
@@ -10,7 +10,7 @@ from ..entities.benchmark_result import BenchmarkResult
 from ..entities.commit import Commit
 from ..entities.compare import CompareBenchmarkResultSerializer
 from ..entities.history import set_z_scores
-from ..hacks import set_display_batch, set_display_name
+from ..hacks import set_display_benchmark_name, set_display_case_permutation
 
 
 def _compare_entity(benchmark_result):
@@ -134,10 +134,10 @@ class CompareEntityEndpoint(ApiEndpoint, CompareMixin):
         baseline_benchmark_result = self._get(baseline_id)
         contender_benchmark_result = self._get(contender_id)
         set_z_scores([baseline_benchmark_result, contender_benchmark_result])
-        set_display_name(baseline_benchmark_result)
-        set_display_name(contender_benchmark_result)
-        set_display_batch(baseline_benchmark_result)
-        set_display_batch(contender_benchmark_result)
+        set_display_case_permutation(baseline_benchmark_result)
+        set_display_case_permutation(contender_benchmark_result)
+        set_display_benchmark_name(baseline_benchmark_result)
+        set_display_benchmark_name(contender_benchmark_result)
 
         baseline = _compare_entity(baseline_benchmark_result)
         contender = _compare_entity(contender_benchmark_result)
@@ -191,12 +191,12 @@ class CompareListEndpoint(ApiEndpoint, CompareMixin):
 
         baseline_items, contender_items = [], []
         for benchmark_result in baselines:
-            set_display_name(benchmark_result)
-            set_display_batch(benchmark_result)
+            set_display_benchmark_name(benchmark_result)
+            set_display_benchmark_name(benchmark_result)
             baseline_items.append(_compare_entity(benchmark_result))
         for benchmark_result in contenders:
-            set_display_name(benchmark_result)
-            set_display_batch(benchmark_result)
+            set_display_benchmark_name(benchmark_result)
+            set_display_benchmark_name(benchmark_result)
             contender_items.append(_compare_entity(benchmark_result))
 
         pairs = _get_pairs(baseline_items, contender_items)

--- a/conbench/api/compare.py
+++ b/conbench/api/compare.py
@@ -13,7 +13,7 @@ from ..entities.history import set_z_scores
 from ..hacks import set_display_benchmark_name, set_display_case_permutation
 
 
-def _compare_entity(benchmark_result):
+def _compare_entity(benchmark_result: BenchmarkResult):
     return {
         "id": benchmark_result.id,
         "batch_id": benchmark_result.batch_id,
@@ -23,8 +23,10 @@ def _compare_entity(benchmark_result):
         "value": benchmark_result.mean,
         "error": benchmark_result.error,
         "unit": benchmark_result.unit,
-        "benchmark": benchmark_result.display_name,
-        "batch": benchmark_result.display_batch,
+        # TODO: change this property name to reflect the idea of 'case permutation'
+        "benchmark": benchmark_result.display_case_perm,
+        # TODO: change this property name to reflect the idea of 'benchmark name'
+        "batch": benchmark_result.display_bmname,
         "language": benchmark_result.context.tags.get("benchmark_language", "unknown"),
         "tags": benchmark_result.case.tags,
         "z_score": benchmark_result.z_score,
@@ -191,12 +193,14 @@ class CompareListEndpoint(ApiEndpoint, CompareMixin):
 
         baseline_items, contender_items = [], []
         for benchmark_result in baselines:
+            # TODO: define dynamic properties on BenchmarkResult instead of
+            # mutating these objects here in-place.
             set_display_benchmark_name(benchmark_result)
-            set_display_benchmark_name(benchmark_result)
+            set_display_case_permutation(benchmark_result)
             baseline_items.append(_compare_entity(benchmark_result))
         for benchmark_result in contenders:
             set_display_benchmark_name(benchmark_result)
-            set_display_benchmark_name(benchmark_result)
+            set_display_case_permutation(benchmark_result)
             contender_items.append(_compare_entity(benchmark_result))
 
         pairs = _get_pairs(baseline_items, contender_items)

--- a/conbench/app/_util.py
+++ b/conbench/app/_util.py
@@ -1,13 +1,13 @@
 import re
 
-from ..hacks import set_display_batch, set_display_name
+from ..hacks import set_display_benchmark_name, set_display_case_permutation
 from ..units import formatter_for_unit
 
 
 def augment(benchmark, contexts=None):
-    set_display_name(benchmark)
+    set_display_benchmark_name(benchmark)
     set_display_time(benchmark)
-    set_display_batch(benchmark)
+    set_display_case_permutation(benchmark)
     set_display_mean(benchmark)
     set_display_language(benchmark, contexts)
     set_display_error(benchmark)

--- a/conbench/app/compare.py
+++ b/conbench/app/compare.py
@@ -121,11 +121,11 @@ class Compare(AppEndpoint, BenchmarkMixin, RunMixin, TimeSeriesPlotMixin):
         contender_copy = copy.deepcopy(contender)
         baseline_copy["tags"] = {
             "compare": "baseline",
-            "name": baseline["display_name"],
+            "name": baseline["display_case_perm"],
         }
         contender_copy["tags"] = {
             "compare": "contender",
-            "name": contender["display_name"],
+            "name": contender["display_case_perm"],
         }
         plot = json.dumps(
             bokeh.embed.json_item(

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -413,9 +413,9 @@ class _Serializer(EntitySerializer):
     def _dump(self, benchmark_result):
         z_score = float(benchmark_result.z_score) if benchmark_result.z_score else None
         case = benchmark_result.case
-        # This is interesting, here we put the `name` and `id` keys into tags.
-        # That is, the `tags` as returned may look different from the tags as
-        # injected.
+        # Note(JP): this is interesting, here we put the `name` and `id` keys
+        # into tags. That is, the `tags` as returned may look different from
+        # the tags as injected.
         tags = {"id": case.id, "name": case.name}
         tags.update(case.tags)
         return {

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -413,6 +413,9 @@ class _Serializer(EntitySerializer):
     def _dump(self, benchmark_result):
         z_score = float(benchmark_result.z_score) if benchmark_result.z_score else None
         case = benchmark_result.case
+        # This is interesting, here we put the `name` and `id` keys into tags.
+        # That is, the `tags` as returned may look different from the tags as
+        # injected.
         tags = {"id": case.id, "name": case.name}
         tags.update(case.tags)
         return {

--- a/conbench/hacks.py
+++ b/conbench/hacks.py
@@ -1,5 +1,4 @@
 import logging
-
 from typing import Dict, List
 
 from conbench.entities.benchmark_result import BenchmarkResult
@@ -67,7 +66,7 @@ def set_display_case_permutation(bmresult: Dict | BenchmarkResult):
     else:
         # This is the result of a needless re-serialization cycle
         # Test if we can work with that assumption
-        if not "name" in tags:
+        if "name" not in tags:
             log.warning("dict bm result w/o name in tags")
 
     caseperm_string_chunks = get_case_kvpair_strings(tags)

--- a/conbench/hacks.py
+++ b/conbench/hacks.py
@@ -1,13 +1,27 @@
+import logging
+
 from typing import Dict, List
 
-CASE_KEYS_DO_NOT_USE_FOR_NAME = ("id", "name", "suite", "source", "dataset")
+from conbench.entities.benchmark_result import BenchmarkResult
+
+# Note(JP): ideally this contains just a single key. I think that this here is
+# purely for display purposes, not for storing in the DB. Now that I think
+# about it: Let's keep things simple: this is part of the case permutation in
+# the database, so show it.
+#  CASE_KEYS_DO_NOT_USE_FOR_STRING = ("id", "name", "suite", "source", "dataset")
 
 
-def get_case_kvpair_strings(tags: Dict[str, str], include_dataset=False) -> List[str]:
+log = logging.getLogger(__name__)
+
+
+def get_case_kvpair_strings(tags: Dict[str, str]) -> List[str]:
     """
-    Build and and return a list of strings, each item reflecting a key/value
-    pair, all of which together define the "case permutation" of this
-    conceptual benchmark.
+    Build and and return a sorted list of strings, each item reflecting a
+    (label/tag) key/value pair, all of which together define the "case
+    permutation" of this conceptual benchmark.
+
+    The returned list might be of length 0 when `tags` has only one key called
+    "name".
 
     Each item takes the shape key=value.
 
@@ -15,64 +29,57 @@ def get_case_kvpair_strings(tags: Dict[str, str], include_dataset=False) -> List
 
     Keep those with None value.
     """
-    kvpairs = [
-        (k, v)
-        for k, v in sorted(tags.items())
-        if k not in CASE_KEYS_DO_NOT_USE_FOR_NAME
-    ]
-
-    # Rationale?
-    if include_dataset and "dataset" in tags:
-        kvpairs.append(("dataset", tags["dataset"]))
-
-    # # Rationale?
-    # if "language" in tags:
-    #     kvpairs.append(("language", tags["language"]))
-
-    # booleans = [True, False, "true", "false"]
-
-    # case = [(k, f"{k}={v}") if v in booleans else (k, v) for k, v in case]
-
-    # return [f"{k}={v}" if isinstance(v, (int, float)) else str(v) for k, v in case]
-
-    return [f"{k}={v}" for k, v in kvpairs]
+    return [f"{k}={v}" for k, v in sorted(tags.items()) if k not in ("name")]
 
 
-def set_display_case_permutation(bmresult):
+def set_display_case_permutation(bmresult: Dict | BenchmarkResult):
     """
-    Build and set a string reflecting the case permutation for this bmresult
-    result.
+    Build and set a string reflecting the case permutation (specific variation
+    of str/str key/value pairs, each pair reflecting a case parameter) for this
+    benchmark result object.
     """
-    is_api = isinstance(bmresult, dict)
-    tags = bmresult["tags"] if is_api else bmresult.case.tags
 
-    # Note(JP): this tries to pull in the benchmark name into the case
-    # permutation k/v pairs. Skip this for now. Unique combination must be
-    # name+case_perm, so adding the name into the case_perm again should not be
-    # conceptually needed.
+    # Extract `tags` object.
+    if isinstance(bmresult, BenchmarkResult):
+        tags: Dict[str, str] = bmresult.case.tags
+    else:
+        tags = bmresult["tags"]
 
-    # name = tags.get("name") if is_api else bmresult.case.name
-    # if "name" not in tags:
-    #     tags["name"] = name
+    # Note(JP): On the input side of things, we pulled the `name=<bmname>` pair
+    # out of tags, and stored it on case.name (and stored remaining case.tags
+    # separately). These next lines re-add the benchmark name into `tags`, to
+    # keep output and input symmetric, I suppose. However, in the future, we
+    # should emphasize better thant it is the combination of name+case_perm
+    # which must be unique, and it is OK to store both separately, and
+    # represent both separately in the output. I am in favor returning,
+    # conceptually, something like this:
+    #
+    #    {"benchmark_name": name, "benchmark_case": casetags}
+    #
+    # I think this is clearer than returning {"tags": tags} where `tags` then
+    # contains everything.
+    #
+    # If is_api is True then this is a dictionary and the name key is already
+    # in tags! See benchmark_result.py serializer... woof.
+    if isinstance(bmresult, BenchmarkResult):
+        benchmark_name = bmresult.case.name
+        tags["name"] = benchmark_name
+    else:
+        # This is the result of a needless re-serialization cycle
+        # Test if we can work with that assumption
+        if not "name" in tags:
+            log.warning("dict bm result w/o name in tags")
 
-    caseperm_string_chunks = get_case_kvpair_strings(tags, include_dataset=True)
-
-    # Again, this here is related to setting the bmresult name.
-    # Do not include this in the case perm string.
-
-    # if "suite" in tags:
-    #     case = [name] + case
-
-    # name = ", ".join(case) if case else name
+    caseperm_string_chunks = get_case_kvpair_strings(tags)
 
     result = ", ".join(caseperm_string_chunks)
     if len(caseperm_string_chunks) == 0:
         result = "no-permutations"
 
-    if is_api:
-        bmresult["display_case_perm"] = result
-    else:
+    if isinstance(bmresult, BenchmarkResult):
         bmresult.display_case_perm = result
+    else:
+        bmresult["display_case_perm"] = result
 
 
 def set_display_benchmark_name(bmresult):

--- a/conbench/templates/batch.html
+++ b/conbench/templates/batch.html
@@ -69,10 +69,10 @@
                      <td style="white-space: nowrap;">{{ benchmark.display_timestamp }}</td>
                      <td>{{ benchmark.display_language }}</td>
                      <td>
-                         <div>{{ benchmark.display_batch }}</div>
+                         <div>{{ benchmark.display_bmname }}</div>
                      </td>
                      <td><a href="{{ url_for('app.benchmark', benchmark_id=benchmark.id) }}">
-                         <div>{{ benchmark.display_name }}</div>
+                         <div>{{ benchmark.display_case_perm }}</div>
                      </a></td>
                      <td style="white-space: nowrap;">{{ benchmark.display_mean }}</td>
                      {% if benchmark.stats.z_score is not none %}

--- a/conbench/templates/benchmark-list.html
+++ b/conbench/templates/benchmark-list.html
@@ -34,11 +34,11 @@
                          <td style="white-space: nowrap;">{{ benchmark.display_language }}</td>
                          <td style="white-space: nowrap;">
                            <a href="{{ url_for('app.batch', batch_id=benchmark.batch_id) }}">
-                             <div>{{ benchmark.display_batch }}</div>
+                             <div>{{ benchmark.display_bmname }}</div>
                            </a>
                          </td>
                          <td><a href="{{ url_for('app.benchmark', benchmark_id=benchmark.id) }}">
-                              <div>{{ benchmark.display_name }}</div>
+                              <div>{{ benchmark.display_case_perm }}</div>
                          </a></td>
                          <td>{{ benchmark.display_mean }}</td>
                          {% if not current_user.is_anonymous %}

--- a/conbench/templates/benchmark-result.html
+++ b/conbench/templates/benchmark-result.html
@@ -17,7 +17,8 @@
 
 <br />
 {% if history_plot_info.jsondoc is not none %}
-<div align="center">{{ benchmark.display_batch }}, {{ benchmark.display_name }}</div>
+<div align="center"><p class="fs-4">{{ benchmark.display_bmname }}</p></div>
+<div align="center">{{ benchmark.display_case_perm }}</div>
 <div id="plot-history-0" align="center"></div>
 <div class="row">
   <div class="col-md-12" style="padding-top: 10px;">
@@ -51,27 +52,27 @@
 <div class="row">
   <div class="col-md-6">
     <ul class="list-group">
-      <li class="list-group-item list-group-item-primary">Benchmark</li>
+      <li class="list-group-item list-group-item-primary">Benchmark details</li>
       <li class="list-group-item" style="overflow-y: auto;">
-        <b>benchmark</b>
-        <div class="ellipsis-500" align="right" style="display:inline-block; float: right;">
-          {{ benchmark.display_name }}
-        </div>
-      </li>
-      <li class="list-group-item" style="overflow-y: auto;">
-        <b>batch</b>
+        <b>Benchmark name</b>
         <div align="right" style="display:inline-block; float: right;">
-          <a href="{{ url_for('app.batch', batch_id=benchmark.batch_id ) }}">{{ benchmark.display_batch }}</a>
+          <a href="{{ url_for('app.batch', batch_id=benchmark.batch_id ) }}">{{ benchmark.display_bmname }}</a>
         </div>
       </li>
       <li class="list-group-item" style="overflow-y: auto;">
-        <b>run</b>
+        <b>Benchmark case permutation</b>
+        <div align="right" style="display:inline-block; float: right;">
+          {{ benchmark.display_case_perm }}
+        </div>
+      </li>
+      <li class="list-group-item" style="overflow-y: auto;">
+        <b>Run ID</b>
         <div align="right" style="display:inline-block; float: right;">
           <a href="{{ url_for('app.run', run_id=benchmark.run_id) }}">{{ benchmark.run_id }}</a>
         </div>
       </li>
       <li class="list-group-item" style="overflow-y: auto;">
-        <b>run name</b>
+        <b>Run name</b>
         <div align="right" style="display:inline-block; float: right;">
           {% if run.name %}
           {{ run.name }}
@@ -79,7 +80,7 @@
         </div>
       </li>
       <li class="list-group-item" style="overflow-y: auto;">
-        <b>run reason</b>
+        <b>Run reason</b>
         <div align="right" style="display:inline-block; float: right;">
           {% if run.reason %}
           {{ run.reason }}
@@ -126,9 +127,7 @@
       {% for k,v in benchmark.tags.items() %}
       <li class="list-group-item" style="overflow-y: auto;">
         <b>{{ k }}</b>
-        {% if v is not none %}
         <div align="right" style="display:inline-block; float: right;">{{ v }}</div>
-        {% endif %}
       </li>
       {% endfor %}
       {% if benchmark.optional_benchmark_info %}

--- a/conbench/templates/compare-entity.html
+++ b/conbench/templates/compare-entity.html
@@ -108,7 +108,7 @@ matching fields between baseline and contender are aligned and mismatched fields
 
     </div>
 
-	<div align="center">{{ baseline.display_batch }}, {{ baseline.display_name }}</div>
+	<div align="center">{{ baseline.display_bmname }}, {{ baseline.display_case_perm }}</div>
     <div id="plot-history-0" align="center"></div>
     <br/>
 
@@ -126,13 +126,13 @@ matching fields between baseline and contender are aligned and mismatched fields
             <li class="list-group-item" style="overflow-y: auto;">
               <b>batch</b>
               <div align="right" style="display:inline-block; float: right;">
-                <a href="{{ url_for('app.batch', batch_id=baseline.batch_id ) }}">{{ baseline.display_batch }}</a>
+                <a href="{{ url_for('app.batch', batch_id=baseline.batch_id ) }}">{{ baseline.display_bmname }}</a>
               </div>
             </li>
             <li class="list-group-item" style="overflow-y: auto;">
               <b>benchmark</b>
               <div align="right" style="display:inline-block; float: right;">
-                <a href="{{ url_for('app.benchmark', benchmark_id=baseline.id) }}">{{ baseline.display_name }}</a>
+                <a href="{{ url_for('app.benchmark', benchmark_id=baseline.id) }}">{{ baseline.display_case_perm }}</a>
               </div>
             </li>
             {% if baseline_run %}
@@ -231,13 +231,13 @@ matching fields between baseline and contender are aligned and mismatched fields
             <li class="list-group-item" style="overflow-y: auto;">
               <b>batch</b>
               <div align="right" style="display:inline-block; float: right;">
-                <a href="{{ url_for('app.batch', batch_id=contender.batch_id ) }}">{{ contender.display_batch }}</a>
+                <a href="{{ url_for('app.batch', batch_id=contender.batch_id ) }}">{{ contender.display_bmname }}</a>
               </div>
             </li>
             <li class="list-group-item" style="overflow-y: auto;">
               <b>benchmark</b>
               <div align="right" style="display:inline-block; float: right;">
-                <a href="{{ url_for('app.benchmark', benchmark_id=contender.id) }}">{{ contender.display_name }}</a>
+                <a href="{{ url_for('app.benchmark', benchmark_id=contender.id) }}">{{ contender.display_case_perm }}</a>
               </div>
             </li>
             {% if contender_run %}

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -81,11 +81,11 @@
                      <td>{{ benchmark.display_language }}</td>
                      <td>
                        <a href="{{ url_for('app.batch', batch_id=benchmark.batch_id) }}">
-                         {{ benchmark.display_batch }}
+                         {{ benchmark.display_bmname }}
                        </a>
                      </td>
                      <td><a href="{{ url_for('app.benchmark', benchmark_id=benchmark.id) }}">
-                         {{ benchmark.display_name }}
+                         {{ benchmark.display_case_perm}}
                      </a></td>
                      <td style="white-space: nowrap;">{{ benchmark.display_mean }}</td>
                      {% if benchmark.stats.z_score is not none %}

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -67,8 +67,8 @@
                 <tr>
                     <th scope="col">Date</th>
                     <th scope="col" style="width: 80px">Lang</th>
-                    <th scope="col" style="width: 80px">Batch</th>
-                    <th scope="col">Benchmark</th>
+                    <th scope="col" style="width: 80px">Benchmark name</th>
+                    <th scope="col">Case permutation</th>
                     <th scope="col" style="width: 55px">Mean</th>
                     <th scope="col" style="width: 55px">Z-Score</th>
                     <th scope="col" style="width: 55px">Error</th>

--- a/conbench/tests/api/test_compare.py
+++ b/conbench/tests/api/test_compare.py
@@ -9,7 +9,7 @@ from ...api.compare import _get_pairs
 from ...tests.api import _asserts, _fixtures
 from ...tests.helpers import _uuid
 
-CASE = "snappy, cpu_count=2, parquet, arrow, nyctaxi_sample"
+CASE = "compression=snappy, cpu_count=2, file_type=parquet, input_type=arrow, dataset=nyctaxi_sample"
 
 
 class FakeEntity:
@@ -248,7 +248,8 @@ class TestCompareBenchmarksGet(_asserts.GetEnforcer):
                 "file_type": "parquet",
                 "input_type": "arrow",
                 "compression": "snappy",
-                "name": name,
+                # The benchmark name is now not part of the emitted tags anymore.
+                # "name": name,
             },
         )
         expected.update(
@@ -290,7 +291,7 @@ class TestCompareBenchmarksGet(_asserts.GetEnforcer):
                 "file_type": "parquet",
                 "input_type": "arrow",
                 "compression": "snappy",
-                "name": name,
+                # "name": name,
             },
         )
         expected.update(
@@ -369,7 +370,7 @@ class TestCompareBatchesGet(_asserts.GetEnforcer):
                     "file_type": "parquet",
                     "input_type": "arrow",
                     "compression": "snappy",
-                    "name": "read",
+                    # "name": "read",
                 },
                 {
                     "dataset": "nyctaxi_sample",
@@ -377,7 +378,7 @@ class TestCompareBatchesGet(_asserts.GetEnforcer):
                     "file_type": "parquet",
                     "input_type": "arrow",
                     "compression": "snappy",
-                    "name": "write",
+                    # "name": "write",
                 },
             ],
         )
@@ -471,7 +472,7 @@ class TestCompareRunsGet(_asserts.GetEnforcer):
                     "file_type": "parquet",
                     "input_type": "arrow",
                     "compression": "snappy",
-                    "name": "read",
+                    # "name": "read",
                 },
                 {
                     "dataset": "nyctaxi_sample",
@@ -479,7 +480,7 @@ class TestCompareRunsGet(_asserts.GetEnforcer):
                     "file_type": "parquet",
                     "input_type": "arrow",
                     "compression": "snappy",
-                    "name": "write",
+                    # "name": "write",
                 },
             ],
         )
@@ -522,7 +523,7 @@ class TestCompareRunsGet(_asserts.GetEnforcer):
                     "file_type": "parquet",
                     "input_type": "arrow",
                     "compression": "snappy",
-                    "name": "read",
+                    # "name": "read",
                 },
                 {
                     "dataset": "nyctaxi_sample",
@@ -530,7 +531,7 @@ class TestCompareRunsGet(_asserts.GetEnforcer):
                     "file_type": "parquet",
                     "input_type": "arrow",
                     "compression": "snappy",
-                    "name": "write",
+                    # "name": "write",
                 },
             ],
         )

--- a/conbench/tests/api/test_compare.py
+++ b/conbench/tests/api/test_compare.py
@@ -9,7 +9,7 @@ from ...api.compare import _get_pairs
 from ...tests.api import _asserts, _fixtures
 from ...tests.helpers import _uuid
 
-CASE = "compression=snappy, cpu_count=2, file_type=parquet, input_type=arrow, dataset=nyctaxi_sample"
+CASE = "compression=snappy, cpu_count=2, dataset=nyctaxi_sample, file_type=parquet, input_type=arrow"
 
 
 class FakeEntity:
@@ -248,8 +248,9 @@ class TestCompareBenchmarksGet(_asserts.GetEnforcer):
                 "file_type": "parquet",
                 "input_type": "arrow",
                 "compression": "snappy",
-                # The benchmark name is now not part of the emitted tags anymore.
-                # "name": name,
+                # The benchmark name should in the future not be part of the
+                # emitted tags anymore.
+                "name": name,
             },
         )
         expected.update(
@@ -291,7 +292,7 @@ class TestCompareBenchmarksGet(_asserts.GetEnforcer):
                 "file_type": "parquet",
                 "input_type": "arrow",
                 "compression": "snappy",
-                # "name": name,
+                "name": name,
             },
         )
         expected.update(
@@ -370,7 +371,7 @@ class TestCompareBatchesGet(_asserts.GetEnforcer):
                     "file_type": "parquet",
                     "input_type": "arrow",
                     "compression": "snappy",
-                    # "name": "read",
+                    "name": "read",
                 },
                 {
                     "dataset": "nyctaxi_sample",
@@ -378,7 +379,7 @@ class TestCompareBatchesGet(_asserts.GetEnforcer):
                     "file_type": "parquet",
                     "input_type": "arrow",
                     "compression": "snappy",
-                    # "name": "write",
+                    "name": "write",
                 },
             ],
         )
@@ -472,7 +473,7 @@ class TestCompareRunsGet(_asserts.GetEnforcer):
                     "file_type": "parquet",
                     "input_type": "arrow",
                     "compression": "snappy",
-                    # "name": "read",
+                    "name": "read",
                 },
                 {
                     "dataset": "nyctaxi_sample",
@@ -480,7 +481,7 @@ class TestCompareRunsGet(_asserts.GetEnforcer):
                     "file_type": "parquet",
                     "input_type": "arrow",
                     "compression": "snappy",
-                    # "name": "write",
+                    "name": "write",
                 },
             ],
         )
@@ -523,7 +524,7 @@ class TestCompareRunsGet(_asserts.GetEnforcer):
                     "file_type": "parquet",
                     "input_type": "arrow",
                     "compression": "snappy",
-                    # "name": "read",
+                    "name": "read",
                 },
                 {
                     "dataset": "nyctaxi_sample",
@@ -531,7 +532,7 @@ class TestCompareRunsGet(_asserts.GetEnforcer):
                     "file_type": "parquet",
                     "input_type": "arrow",
                     "compression": "snappy",
-                    # "name": "write",
+                    "name": "write",
                 },
             ],
         )


### PR DESCRIPTION
This addresses:
- #943
- #944 
- #400
- #942 
- #940, partially at least


I think this is getting interesting. Simplification, more or less with confidence. First, along terminology within code but especially in the UI (user-facing terminology).

This should make the 'case permutation' idea more explicit, and easier to understand for users. This is certainly a greatly helpful direction for me, wrapping my head around concepts.
