### PR TITLE
benchalerts: fix language in comments and checks

### DIFF
--- a/benchalerts/benchalerts/message_formatting.py
+++ b/benchalerts/benchalerts/message_formatting.py
@@ -89,11 +89,10 @@ def github_check_summary(
             There weren't enough matching historic runs in Conbench to make a call on
             whether there were regressions or not.
 
-            To use the lookback z-score method of determining regressions, there needs
-            to be at least one historic run on the default branch which, when compared
-            to one of the runs on the contender commit, is in the same repository, on
-            the same hardware, and has at least one of the same benchmark case and
-            context pairs.
+            To use the lookback z-score method of determining regressions, there need to
+            be at least two historic runs on the default branch which, when compared to
+            one of the runs on the contender commit, are on the same hardware, and have
+            at least one of the same benchmark case and context pairs.
             """
         )
         # exit early
@@ -185,7 +184,7 @@ def pr_comment_link_to_check(
         comment += _clean(
             f"""
             There {were} {len(full_comparison.benchmarks_with_z_regressions)} benchmark
-            result{s} with a performance regression:
+            result{s} indicating a performance regression:
             """
         )
         comment += _list_results(full_comparison.benchmarks_with_z_regressions, limit=2)

--- a/benchalerts/benchalerts/message_formatting.py
+++ b/benchalerts/benchalerts/message_formatting.py
@@ -11,6 +11,27 @@ def _clean(text: str) -> str:
     return textwrap.fill(textwrap.dedent(text), 10000).replace("  ", "\n\n").strip()
 
 
+class _Pluralizer:
+    """Depending on the length of the input list, return the correct pluralization
+    suffixes and plural forms of special English words.
+    """
+
+    def __init__(self, some_list: list) -> None:
+        self.plural = len(some_list) != 1
+
+    @property
+    def were(self):
+        return "were" if self.plural else "was"
+
+    @property
+    def s(self):
+        return "s" if self.plural else ""
+
+
+def _run_bullet(reason: str, time: str, link: str) -> str:
+    return f"- {reason.title()} Run at [{time}]({link})"
+
+
 def _list_results(benchmark_results: List[BenchmarkResultInfo]) -> str:
     """Create a Markdown list of benchmark result information."""
     out = ""
@@ -19,9 +40,11 @@ def _list_results(benchmark_results: List[BenchmarkResultInfo]) -> str:
     for benchmark_result in benchmark_results:
         # Separate each run into a section, with a title for the run
         if benchmark_result.run_id != previous_run_id:
-            out += (
-                f"\n\n- {benchmark_result.run_reason.title()} Run at "
-                f"[{benchmark_result.run_time}]({benchmark_result.run_link})"
+            out += "\n\n"
+            out += _run_bullet(
+                benchmark_result.run_reason,
+                benchmark_result.run_time,
+                benchmark_result.run_link,
             )
             previous_run_id = benchmark_result.run_id
         out += f"\n  - [{benchmark_result.name}]({benchmark_result.link})"
@@ -45,8 +68,8 @@ def github_check_summary(
             ## Benchmarks with errors
 
             These are errors that were caught while running the benchmarks. You can
-            click the link next to each result to go to the Conbench entry for that
-            benchmark, which might have more information about what the error was.
+            click each link to go to the Conbench entry for that benchmark, which might
+            have more information about what the error was.
             """
         )
         summary += _list_results(full_comparison.benchmarks_with_errors)
@@ -55,21 +78,26 @@ def github_check_summary(
 
     if full_comparison.no_baseline_runs:
         summary += _clean(
-            f"""
-            Conbench could not find a baseline run for contender commit `{hash}`. A
-            baseline run needs to be on the default branch in the same repository, with
-            the same hardware, and have at least one of the same benchmark case/context
-            pairs as one of the runs on the contender commit.
+            """
+            There weren't enough matching historic runs in Conbench to make a call on
+            whether there were regressions or not.
+
+            To use the lookback z-score method of determining regressions, there needs
+            to be at least one historic run on the default branch which, when compared
+            to one of the runs on the contender commit, is in the same repository, on
+            the same hardware, and has at least one of the same benchmark case and
+            context pairs.
             """
         )
         # exit early
         return summary
 
+    s = _Pluralizer(full_comparison.benchmarks_with_z_regressions).s
     summary += _clean(
         f"""
         Contender commit `{hash}` had
-        {len(full_comparison.benchmarks_with_z_regressions)} performance regression(s)
-        compared to its baseline runs.
+        {len(full_comparison.benchmarks_with_z_regressions)} performance regression{s}
+        using the lookback z-score method.
         """
     )
     summary += "\n\n"
@@ -78,13 +106,25 @@ def github_check_summary(
         summary += "### Benchmarks with regressions:"
         summary += _list_results(full_comparison.benchmarks_with_z_regressions)
 
+    summary += "## All benchmark runs\n"
+    for comparison in full_comparison.run_comparisons:
+        summary += "\n"
+        summary += _run_bullet(
+            comparison.contender_reason,
+            comparison.contender_datetime,
+            comparison.contender_link,
+        )
+    summary += "\n\n"
+
     if full_comparison.no_baseline_is_parent and warn_if_baseline_isnt_parent:
         summary += _clean(
             """
             ### Note
 
             No baseline run was on the immediate parent commit of the contender commit.
-            See the link below for details.
+            This probably means that no matching benchmarks (with the same repository,
+            hardware, case, and context) successfully ran on the parent commit. See the
+            link below for details.
             """
         )
 
@@ -96,34 +136,65 @@ def github_check_details(full_comparison: FullComparisonInfo) -> Optional[str]:
     if full_comparison.no_baseline_runs:
         return None
 
+    s = _Pluralizer(full_comparison.run_comparisons).s
     details = _clean(
         f"""
-        Conbench has details about {len(full_comparison.run_comparisons)} total run(s)
-        on this commit.
+        Conbench has details about {len(full_comparison.run_comparisons)} run{s} on this
+        commit.
 
-        This report was generated using a z-score threshold of
-        {full_comparison.z_score_threshold}. A regression is defined as a benchmark
-        exhibiting a z-score higher than the threshold in the "bad" direction (e.g. down
-        for iterations per second; up for total time taken).
+        This report was generated using the lookback z-score method with a z-score
+        threshold of {full_comparison.z_score_threshold}. A regression is defined as a
+        benchmark exhibiting a z-score higher than the threshold in the "bad" direction
+        (e.g. down for iterations per second; up for total time taken).
         """
     )
     return details
 
 
-def pr_comment_link_to_check(summary: str, check_link: str) -> str:
+def pr_comment_link_to_check(
+    full_comparison: FullComparisonInfo, check_link: str
+) -> str:
     """Generate a GitHub PR comment that summarizes and links to a GitHub Check."""
-    summary_lines = summary.split("\n")
-
-    # Strip off the "note" and afterwards (would be noisy in a comment)
-    note_index = [ix for ix, line in enumerate(summary_lines) if line == "### Note"]
-    if note_index:
-        summary_lines = summary_lines[: note_index[0]]
-
-    summary_preview = "\n".join(summary_lines[:20])
-    if len(summary_lines) > 20:
-        summary_preview += "\n..."
-
-    return (
-        f"A [full benchmark report]({check_link}) is ready. Here is a preview:\n\n"
-        + summary_preview
+    comment = _clean(
+        f"""
+        A [full benchmark report]({check_link}) is ready for commit
+        `{full_comparison.commit_hash[:8]}`.
+        """
     )
+    comment += "\n\n"
+
+    if full_comparison.benchmarks_with_errors:
+        pluralizer = _Pluralizer(full_comparison.benchmarks_with_errors)
+        were = pluralizer.were
+        s = pluralizer.s
+        comment += _clean(
+            f"""
+            There {were} {len(full_comparison.benchmarks_with_errors)} benchmark
+            result{s} with an error.
+            """
+        )
+    elif full_comparison.no_baseline_runs:
+        comment += _clean(
+            """
+            There weren't enough matching historic runs to make a call on whether there
+            were regressions.
+            """
+        )
+    elif full_comparison.benchmarks_with_z_regressions:
+        pluralizer = _Pluralizer(full_comparison.benchmarks_with_z_regressions)
+        were = pluralizer.were
+        s = pluralizer.s
+        comment += _clean(
+            f"""
+            There {were} {len(full_comparison.benchmarks_with_z_regressions)} benchmark
+            result{s} with a performance regression.
+            """
+        )
+    else:
+        comment += _clean(
+            """
+            Based on this analysis, there were not any performance regressions.
+            """
+        )
+
+    return comment

--- a/benchalerts/tests/integration_tests/test_alert_pipeline.py
+++ b/benchalerts/tests/integration_tests/test_alert_pipeline.py
@@ -109,7 +109,7 @@ def test_alert_pipeline(monkeypatch: pytest.MonkeyPatch, github_auth: str):
         assert outputs["GitHubStatusStep"]["creator"]["type"] == "Bot"
         assert outputs["GitHubCheckStep"][0]["conclusion"] == "failure"
         if not os.getenv("CI"):
-            expected_comment = """There was 1 benchmark result with a performance regression:
+            expected_comment = """There was 1 benchmark result indicating a performance regression:
 
 - Commit Run at [2023-02-28 18:08:51Z](http://velox-conbench.voltrondata.run/compare/runs/GHA-4273957972-1...GHA-4296026775-1/)
   - [flatMap](http://velox-conbench.voltrondata.run/benchmarks/ff7a1a86df5a4d56b6dbfb006c13c638)

--- a/benchalerts/tests/unit_tests/expected_md/comment_errors_baselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_errors_baselines.md
@@ -1,0 +1,3 @@
+A [full benchmark report](https://github.com/github/hello-world/runs/4) is ready for commit `abc`.
+
+There were 3 benchmark results with an error.

--- a/benchalerts/tests/unit_tests/expected_md/comment_errors_baselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_errors_baselines.md
@@ -1,3 +1,15 @@
-A [full benchmark report](https://github.com/github/hello-world/runs/4) is ready for commit `abc`.
+There were 3 benchmark results with an error:
 
-There were 3 benchmark results with an error.
+- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_contender...some_contender/)
+  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmarks/some-benchmark-uuid-4)
+  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmarks/some-benchmark-uuid-4)
+- and 1 more (see the report linked below)
+
+There were 3 benchmark results with a performance regression:
+
+- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_contender...some_contender/)
+  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)
+  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)
+- and 1 more (see the report linked below)
+
+The [full Conbench report](https://github.com/github/hello-world/runs/4) for commit `abc` has more details.

--- a/benchalerts/tests/unit_tests/expected_md/comment_errors_baselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_errors_baselines.md
@@ -5,7 +5,7 @@ There were 3 benchmark results with an error:
   - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmarks/some-benchmark-uuid-4)
 - and 1 more (see the report linked below)
 
-There were 3 benchmark results with a performance regression:
+There were 3 benchmark results indicating a performance regression:
 
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_contender...some_contender/)
   - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)

--- a/benchalerts/tests/unit_tests/expected_md/comment_errors_nobaselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_errors_nobaselines.md
@@ -1,3 +1,9 @@
-A [full benchmark report](https://github.com/github/hello-world/runs/4) is ready for commit `no_basel`.
+There were 2 benchmark results with an error:
 
-There were 2 benchmark results with an error.
+- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+  - [file-write](http://localhost/benchmarks/some-benchmark-uuid-2)
+  - [file-write](http://localhost/benchmarks/some-benchmark-uuid-2)
+
+There weren't enough matching historic benchmark runs to make a call on whether there were regressions.
+
+The [full Conbench report](https://github.com/github/hello-world/runs/4) for commit `no_basel` has more details.

--- a/benchalerts/tests/unit_tests/expected_md/comment_errors_nobaselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_errors_nobaselines.md
@@ -1,0 +1,3 @@
+A [full benchmark report](https://github.com/github/hello-world/runs/4) is ready for commit `no_basel`.
+
+There were 2 benchmark results with an error.

--- a/benchalerts/tests/unit_tests/expected_md/comment_noerrors_nobaselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_noerrors_nobaselines.md
@@ -1,3 +1,3 @@
-A [full benchmark report](https://github.com/github/hello-world/runs/4) is ready for commit `no_basel`.
+There weren't enough matching historic benchmark runs to make a call on whether there were regressions.
 
-There weren't enough matching historic runs to make a call on whether there were regressions.
+The [full Conbench report](https://github.com/github/hello-world/runs/4) for commit `no_basel` has more details.

--- a/benchalerts/tests/unit_tests/expected_md/comment_noerrors_nobaselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_noerrors_nobaselines.md
@@ -1,0 +1,3 @@
+A [full benchmark report](https://github.com/github/hello-world/runs/4) is ready for commit `no_basel`.
+
+There weren't enough matching historic runs to make a call on whether there were regressions.

--- a/benchalerts/tests/unit_tests/expected_md/comment_noregressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_noregressions.md
@@ -1,0 +1,3 @@
+A [full benchmark report](https://github.com/github/hello-world/runs/4) is ready for commit `abc`.
+
+Based on this analysis, there were not any performance regressions.

--- a/benchalerts/tests/unit_tests/expected_md/comment_noregressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_noregressions.md
@@ -1,3 +1,3 @@
-A [full benchmark report](https://github.com/github/hello-world/runs/4) is ready for commit `abc`.
+There were no benchmark performance regressions. 🎉
 
-Based on this analysis, there were not any performance regressions.
+The [full Conbench report](https://github.com/github/hello-world/runs/4) for commit `abc` has more details.

--- a/benchalerts/tests/unit_tests/expected_md/comment_regressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_regressions.md
@@ -1,4 +1,4 @@
-There were 2 benchmark results with a performance regression:
+There were 2 benchmark results indicating a performance regression:
 
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_contender...some_contender/)
   - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)

--- a/benchalerts/tests/unit_tests/expected_md/comment_regressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_regressions.md
@@ -1,0 +1,3 @@
+A [full benchmark report](https://github.com/github/hello-world/runs/4) is ready for commit `no_basel`.
+
+There were 2 benchmark results with a performance regression.

--- a/benchalerts/tests/unit_tests/expected_md/comment_regressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_regressions.md
@@ -1,3 +1,7 @@
-A [full benchmark report](https://github.com/github/hello-world/runs/4) is ready for commit `no_basel`.
+There were 2 benchmark results with a performance regression:
 
-There were 2 benchmark results with a performance regression.
+- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_contender...some_contender/)
+  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)
+  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)
+
+The [full Conbench report](https://github.com/github/hello-world/runs/4) for commit `no_basel` has more details.

--- a/benchalerts/tests/unit_tests/expected_md/details_noregressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/details_noregressions.md
@@ -1,3 +1,3 @@
-Conbench has details about 2 total run(s) on this commit.
+Conbench has details about 2 runs on this commit.
 
-This report was generated using a z-score threshold of 500. A regression is defined as a benchmark exhibiting a z-score higher than the threshold in the "bad" direction (e.g. down for iterations per second; up for total time taken).
+This report was generated using the lookback z-score method with a z-score threshold of 500. A regression is defined as a benchmark exhibiting a z-score higher than the threshold in the "bad" direction (e.g. down for iterations per second; up for total time taken).

--- a/benchalerts/tests/unit_tests/expected_md/details_noregressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/details_noregressions.md
@@ -1,3 +1,1 @@
-Conbench has details about 2 runs on this commit.
-
-This report was generated using the lookback z-score method with a z-score threshold of 500. A regression is defined as a benchmark exhibiting a z-score higher than the threshold in the "bad" direction (e.g. down for iterations per second; up for total time taken).
+This report was generated using the lookback z-score method with a z-score threshold of 500.

--- a/benchalerts/tests/unit_tests/expected_md/details_regressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/details_regressions.md
@@ -1,3 +1,1 @@
-Conbench has details about 3 runs on this commit.
-
-This report was generated using the lookback z-score method with a z-score threshold of 5. A regression is defined as a benchmark exhibiting a z-score higher than the threshold in the "bad" direction (e.g. down for iterations per second; up for total time taken).
+This report was generated using the lookback z-score method with a z-score threshold of 5.

--- a/benchalerts/tests/unit_tests/expected_md/details_regressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/details_regressions.md
@@ -1,3 +1,3 @@
-Conbench has details about 3 total run(s) on this commit.
+Conbench has details about 3 runs on this commit.
 
-This report was generated using a z-score threshold of 5. A regression is defined as a benchmark exhibiting a z-score higher than the threshold in the "bad" direction (e.g. down for iterations per second; up for total time taken).
+This report was generated using the lookback z-score method with a z-score threshold of 5. A regression is defined as a benchmark exhibiting a z-score higher than the threshold in the "bad" direction (e.g. down for iterations per second; up for total time taken).

--- a/benchalerts/tests/unit_tests/expected_md/summary_errors_baselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_errors_baselines.md
@@ -1,6 +1,6 @@
 ## Benchmarks with errors
 
-These are errors that were caught while running the benchmarks. You can click the link next to each result to go to the Conbench entry for that benchmark, which might have more information about what the error was.
+These are errors that were caught while running the benchmarks. You can click each link to go to the Conbench entry for that benchmark, which might have more information about what the error was.
 
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_contender...some_contender/)
   - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmarks/some-benchmark-uuid-4)
@@ -9,7 +9,7 @@ These are errors that were caught while running the benchmarks. You can click th
 
 ## Benchmarks with performance regressions
 
-Contender commit `abc` had 3 performance regression(s) compared to its baseline runs.
+Contender commit `abc` had 3 performance regressions using the lookback z-score method.
 
 ### Benchmarks with regressions:
 
@@ -18,6 +18,12 @@ Contender commit `abc` had 3 performance regression(s) compared to its baseline 
   - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)
   - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)
 
+## All benchmark runs
+
+- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+
 ### Note
 
-No baseline run was on the immediate parent commit of the contender commit. See the link below for details.
+No baseline run was on the immediate parent commit of the contender commit. This probably means that no matching benchmarks (with the same repository, hardware, case, and context) successfully ran on the parent commit. See the link below for details.

--- a/benchalerts/tests/unit_tests/expected_md/summary_errors_baselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_errors_baselines.md
@@ -18,7 +18,7 @@ Contender commit `abc` had 3 performance regressions using the lookback z-score 
   - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)
   - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)
 
-## All benchmark runs
+## All benchmark runs on commit `abc`
 
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)

--- a/benchalerts/tests/unit_tests/expected_md/summary_errors_nobaselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_errors_nobaselines.md
@@ -10,4 +10,4 @@ These are errors that were caught while running the benchmarks. You can click ea
 
 There weren't enough matching historic runs in Conbench to make a call on whether there were regressions or not.
 
-To use the lookback z-score method of determining regressions, there needs to be at least one historic run on the default branch which, when compared to one of the runs on the contender commit, is in the same repository, on the same hardware, and has at least one of the same benchmark case and context pairs.
+To use the lookback z-score method of determining regressions, there need to be at least two historic runs on the default branch which, when compared to one of the runs on the contender commit, are on the same hardware, and have at least one of the same benchmark case and context pairs.

--- a/benchalerts/tests/unit_tests/expected_md/summary_errors_nobaselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_errors_nobaselines.md
@@ -1,6 +1,6 @@
 ## Benchmarks with errors
 
-These are errors that were caught while running the benchmarks. You can click the link next to each result to go to the Conbench entry for that benchmark, which might have more information about what the error was.
+These are errors that were caught while running the benchmarks. You can click each link to go to the Conbench entry for that benchmark, which might have more information about what the error was.
 
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
   - [file-write](http://localhost/benchmarks/some-benchmark-uuid-2)
@@ -8,4 +8,6 @@ These are errors that were caught while running the benchmarks. You can click th
 
 ## Benchmarks with performance regressions
 
-Conbench could not find a baseline run for contender commit `no_basel`. A baseline run needs to be on the default branch in the same repository, with the same hardware, and have at least one of the same benchmark case/context pairs as one of the runs on the contender commit.
+There weren't enough matching historic runs in Conbench to make a call on whether there were regressions or not.
+
+To use the lookback z-score method of determining regressions, there needs to be at least one historic run on the default branch which, when compared to one of the runs on the contender commit, is in the same repository, on the same hardware, and has at least one of the same benchmark case and context pairs.

--- a/benchalerts/tests/unit_tests/expected_md/summary_noerrors_nobaselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_noerrors_nobaselines.md
@@ -2,4 +2,4 @@
 
 There weren't enough matching historic runs in Conbench to make a call on whether there were regressions or not.
 
-To use the lookback z-score method of determining regressions, there needs to be at least one historic run on the default branch which, when compared to one of the runs on the contender commit, is in the same repository, on the same hardware, and has at least one of the same benchmark case and context pairs.
+To use the lookback z-score method of determining regressions, there need to be at least two historic runs on the default branch which, when compared to one of the runs on the contender commit, are on the same hardware, and have at least one of the same benchmark case and context pairs.

--- a/benchalerts/tests/unit_tests/expected_md/summary_noerrors_nobaselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_noerrors_nobaselines.md
@@ -1,3 +1,5 @@
 ## Benchmarks with performance regressions
 
-Conbench could not find a baseline run for contender commit `no_basel`. A baseline run needs to be on the default branch in the same repository, with the same hardware, and have at least one of the same benchmark case/context pairs as one of the runs on the contender commit.
+There weren't enough matching historic runs in Conbench to make a call on whether there were regressions or not.
+
+To use the lookback z-score method of determining regressions, there needs to be at least one historic run on the default branch which, when compared to one of the runs on the contender commit, is in the same repository, on the same hardware, and has at least one of the same benchmark case and context pairs.

--- a/benchalerts/tests/unit_tests/expected_md/summary_noregressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_noregressions.md
@@ -1,7 +1,12 @@
 ## Benchmarks with performance regressions
 
-Contender commit `abc` had 0 performance regression(s) compared to its baseline runs.
+Contender commit `abc` had 0 performance regressions using the lookback z-score method.
+
+## All benchmark runs
+
+- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
 
 ### Note
 
-No baseline run was on the immediate parent commit of the contender commit. See the link below for details.
+No baseline run was on the immediate parent commit of the contender commit. This probably means that no matching benchmarks (with the same repository, hardware, case, and context) successfully ran on the parent commit. See the link below for details.

--- a/benchalerts/tests/unit_tests/expected_md/summary_noregressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_noregressions.md
@@ -2,7 +2,7 @@
 
 Contender commit `abc` had 0 performance regressions using the lookback z-score method.
 
-## All benchmark runs
+## All benchmark runs on commit `abc`
 
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)

--- a/benchalerts/tests/unit_tests/expected_md/summary_regressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_regressions.md
@@ -1,6 +1,6 @@
 ## Benchmarks with performance regressions
 
-Contender commit `no_basel` had 2 performance regression(s) compared to its baseline runs.
+Contender commit `no_basel` had 2 performance regressions using the lookback z-score method.
 
 ### Benchmarks with regressions:
 
@@ -8,6 +8,12 @@ Contender commit `no_basel` had 2 performance regression(s) compared to its base
   - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)
   - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)
 
+## All benchmark runs
+
+- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+
 ### Note
 
-No baseline run was on the immediate parent commit of the contender commit. See the link below for details.
+No baseline run was on the immediate parent commit of the contender commit. This probably means that no matching benchmarks (with the same repository, hardware, case, and context) successfully ran on the parent commit. See the link below for details.

--- a/benchalerts/tests/unit_tests/expected_md/summary_regressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_regressions.md
@@ -8,7 +8,7 @@ Contender commit `no_basel` had 2 performance regressions using the lookback z-s
   - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)
   - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)
 
-## All benchmark runs
+## All benchmark runs on commit `no_basel`
 
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)


### PR DESCRIPTION
Closes #919.

This PR makes `benchalerts`'s PR comments less verbose and more actionable. It also clarifies some language around using the lookback z-score method, and adds links to all the commit's runs at the bottom of the report.

As usual, you can see the differences in the `expected_md` folder -- but [here](https://github.com/conbench/benchalerts/pull/5#issuecomment-1483311616) are some new-style comments posted from the integration tests too!