### PR TITLE
UI/API: hide case ID/primary key, update history plot title

### DIFF
--- a/conbench/api/_examples.py
+++ b/conbench/api/_examples.py
@@ -490,7 +490,6 @@ def _api_run_entity(
 
 BENCHMARK_ENTITY = _api_benchmark_entity(
     "some-benchmark-uuid-1",
-    "some-case-uuid-1",
     "some-info-uuid-1",
     "some-context-uuid-1",
     "some-batch-uuid-1",

--- a/conbench/api/_examples.py
+++ b/conbench/api/_examples.py
@@ -125,7 +125,6 @@ def _api_benchmark_entity(
         "optional_benchmark_info": optional_benchmark_info,
         "change_annotations": {},
         "tags": {
-            "id": case_id,
             "compression": "snappy",
             "cpu_count": 2,
             "dataset": "nyctaxi_sample",

--- a/conbench/api/_examples.py
+++ b/conbench/api/_examples.py
@@ -24,7 +24,6 @@ def _api_user_entity(user):
 
 def _api_benchmark_entity(
     benchmark_result_id,
-    case_id,
     info_id,
     context_id,
     batch_id,

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -605,7 +605,9 @@ class _BenchmarkFacadeSchemaCreate(marshmallow.Schema):
                 such as `compression_method` (values: `gzip`, `lzma`, ...),
                 `file_format` (values: `csv`, `hdf5`, ...), `dataset_name`
                 (values: `foo`, `bar`, ...). For each conceptual benchmark, it
-                is OK to have no or many case permutations.
+                is valid to have one or many case permutations (if you supply
+                no tags, there is necessarily a single mutation with the
+                special property that it has no tags).
                 """
             )
         },

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -416,7 +416,7 @@ class _Serializer(EntitySerializer):
         # Note(JP): this is interesting, here we put the `name` and `id` keys
         # into tags. That is, the `tags` as returned may look different from
         # the tags as injected.
-        tags = {"id": case.id, "name": case.name}
+        tags = {"name": case.name}
         tags.update(case.tags)
         return {
             "id": benchmark_result.id,

--- a/conbench/templates/benchmark-result.html
+++ b/conbench/templates/benchmark-result.html
@@ -18,11 +18,13 @@
 </nav>
 
 
+
 <br />
 {% if history_plot_info.jsondoc is not none %}
-<div align="center"><p class="fs-4">{{ benchmark.display_bmname }}</p></div>
-<div align="center">{{ benchmark.display_case_perm }}</div>
-<div id="plot-history-0" align="center"></div>
+<h3>History plot for benchmark '{{ benchmark.display_bmname }}'</h3>
+<p class="fst-italic fw-light">For a specific case permutation and hardware/context (see below)</p>
+<!-- <div>{{ benchmark.display_case_perm }}</div> -->
+<div class="mt-4" id="plot-history-0" align="center"></div>
 <div class="row">
   <div class="col-md-12" style="padding-top: 10px;">
     Click on a benchmark result (grey point) in the plot to see a corresponding benchmark result summary.

--- a/conbench/templates/benchmark-result.html
+++ b/conbench/templates/benchmark-result.html
@@ -10,7 +10,10 @@
     <li class="breadcrumb-item active">
       <a href="{{ url_for('app.batch', batch_id=benchmark.batch_id) }}">Batch</a>
     </li>
-    <li class="breadcrumb-item active aria-current="page">Benchmark result {{ benchmark.id }}</li>
+    <li class="breadcrumb-item active aria-current="page">
+      <a href="{{ url_for('app.benchmark', benchmark_id=benchmark.id) }}">
+      Benchmark result {{ benchmark.id[:7] }}...</a>
+    </li>
   </ol>
 </nav>
 

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -105,7 +105,6 @@
                                 "cpu_count": 2,
                                 "dataset": "nyctaxi_sample",
                                 "file_type": "parquet",
-                                "id": "some-case-uuid-1",
                                 "input_type": "arrow",
                                 "name": "file-write",
                             },
@@ -178,7 +177,6 @@
                                 "cpu_count": 2,
                                 "dataset": "nyctaxi_sample",
                                 "file_type": "parquet",
-                                "id": "some-case-uuid-1",
                                 "input_type": "arrow",
                                 "name": "file-write",
                             },
@@ -252,7 +250,6 @@
                                     "cpu_count": 2,
                                     "dataset": "nyctaxi_sample",
                                     "file_type": "parquet",
-                                    "id": "some-case-uuid-1",
                                     "input_type": "arrow",
                                     "name": "file-write",
                                 },
@@ -1027,7 +1024,7 @@
                     },
                     "stats": {"$ref": "#/components/schemas/BenchmarkResultCreate"},
                     "tags": {
-                        "description": 'The set of key/value pairs that defines a benchmark case permutation. Top-level keys must be strings. Allowed value types are ... (to be specified).  The special key "name" must be provided with a string value: it indicates the name of the conceptual benchmark that was performed for obtaining the result at hand. All case permutations of a conceptual benchmark by definition have this name in common.  We advise that each unique case (as defined by the complete set of key/value pairs) indeed corresponds to unique benchmarking behavior. That is, typically, these key/value pairs directly correspond to input parameters to your benchmarking method.  Example: a conceptual benchmark with name "foo-write-file" might have meaningful case permutations involving tag names such as `compression_method` (values: `gzip`, `lzma`, ...), `file_format` (values: `csv`, `hdf5`, ...), `dataset_name` (values: `foo`, `bar`, ...). For each conceptual benchmark, it is OK to have no or many case permutations.',
+                        "description": 'The set of key/value pairs that defines a benchmark case permutation. Top-level keys must be strings. Allowed value types are ... (to be specified).  The special key "name" must be provided with a string value: it indicates the name of the conceptual benchmark that was performed for obtaining the result at hand. All case permutations of a conceptual benchmark by definition have this name in common.  We advise that each unique case (as defined by the complete set of key/value pairs) indeed corresponds to unique benchmarking behavior. That is, typically, these key/value pairs directly correspond to input parameters to your benchmarking method.  Example: a conceptual benchmark with name "foo-write-file" might have meaningful case permutations involving tag names such as `compression_method` (values: `gzip`, `lzma`, ...), `file_format` (values: `csv`, `hdf5`, ...), `dataset_name` (values: `foo`, `bar`, ...). For each conceptual benchmark, it is valid to have one or many case permutations (if you supply no tags, there is necessarily a single mutation with the special property that it has no tags).',
                         "type": "object",
                     },
                     "timestamp": {

--- a/conbench/tests/api/test_benchmarks.py
+++ b/conbench/tests/api/test_benchmarks.py
@@ -16,7 +16,6 @@ CONBENCH_REPO = "https://github.com/conbench/conbench"
 def _expected_entity(benchmark_result: BenchmarkResult, stats=None):
     return _api_benchmark_entity(
         benchmark_result.id,
-        benchmark_result.case_id,
         benchmark_result.info_id,
         benchmark_result.context_id,
         benchmark_result.batch_id,

--- a/conbench/tests/app/test_benchmarks.py
+++ b/conbench/tests/app/test_benchmarks.py
@@ -33,7 +33,7 @@ class TestBenchmarkDelete(_asserts.DeleteEnforcer):
         self.authenticate(client)
         response = client.get(f"/benchmarks/{benchmark_id}/")
         self.assert_page(response, "Benchmark")
-        assert f"{benchmark_id}</li>".encode() in response.data
+        assert f"{benchmark_id[:6]}".encode() in response.data
 
         # delete benchmark
         data = {"delete": ["Delete"], "csrf_token": self.get_csrf_token(response)}


### PR DESCRIPTION
What's currently exposed as `tags.id` is an implementation detail. It is in fact the primary key of a `case` entity in the DB.

It should not be exposed by the API, in particular not as part of `tags`. This is confusing; because it looks like this was added at the input side of things.

Bringing structure into this has the nice side effect of automatically resolving #949.

For "case ID" we want to have a concept, yes. Ideally there is _one_ way to stringify a case so that it unambiguously represents the case, without information loss. This relates to the discussion we have in https://github.com/conbench/conbench/pull/948.

Also see commit msgs.

For paper trail, I'd love to state that this is a breaking change in the HTTP/JSON API surface in the sense that on the output side of things the `tags` JSON object will now not have the `id` property anymore.

Also worked a bit on history plot title, after discussing this a bit last week in Conbenchat:

![Screenshot from 2023-03-24 16-52-07](https://user-images.githubusercontent.com/265630/227945970-d73ca1cd-8f77-4d8e-a87f-3eb6e06d8364.png)
