### PR TITLE
z-scores: Autodetect outliers and ignore them

### DIFF
--- a/conbench/api/_examples.py
+++ b/conbench/api/_examples.py
@@ -374,6 +374,7 @@ def _api_history_entity(benchmark_id, case_id, context_id, run_name):
                 "rolling_mean_excluding_this_commit": 0.036369,
                 "rolling_stddev": 0.0,
                 "segment_id": 0.0,
+                "is_outlier": False,
             },
         }
     ]

--- a/conbench/app/compare.py
+++ b/conbench/app/compare.py
@@ -30,7 +30,7 @@ class Compare(AppEndpoint, BenchmarkResultMixin, RunMixin, TimeSeriesPlotMixin):
         compare_batches_url = f.url_for("app.compare-batches", compare_ids=unknown)
         baseline, contender, plot, plot_history = None, None, None, None
         baseline_run, contender_run = None, None
-        outlier_names, outlier_urls = None, None
+        biggest_changes_names, outlier_urls = None, None
 
         if comparisons and self.type == "batch":
             ids = {c["baseline_run_id"] for c in comparisons if c["baseline_run_id"]}
@@ -70,14 +70,18 @@ class Compare(AppEndpoint, BenchmarkResultMixin, RunMixin, TimeSeriesPlotMixin):
                 return self.redirect("app.index")
             for benchmark in benchmarks:
                 augment(benchmark)
-            outliers, outlier_ids, outlier_names = self.get_outliers(benchmarks)
+            (
+                biggest_changes,
+                biggest_changes_ids,
+                biggest_changes_names,
+            ) = self.get_biggest_changes(benchmarks)
             outlier_urls = [
                 comparisons_by_id.get(x, {}).get("compare_benchmarks_url", "")
-                for x in outlier_ids
+                for x in biggest_changes_ids
             ]
             plot_history = [
                 self.get_history_plot(b, contender_run, i)
-                for i, b in enumerate(outliers)
+                for i, b in enumerate(biggest_changes)
             ]
 
         return self.render_template(
@@ -99,7 +103,7 @@ class Compare(AppEndpoint, BenchmarkResultMixin, RunMixin, TimeSeriesPlotMixin):
             contender_run=contender_run,
             compare_runs_url=compare_runs_url,
             compare_batches_url=compare_batches_url,
-            outlier_names=outlier_names,
+            outlier_names=biggest_changes_names,
             outlier_urls=outlier_urls,
             search_value=f.request.args.get("search"),
             tags_fields=all_keys(baseline, contender, "tags"),

--- a/conbench/app/runs.py
+++ b/conbench/app/runs.py
@@ -25,9 +25,14 @@ class ViewRun(AppEndpoint, ContextMixin, RunMixin, TimeSeriesPlotMixin):
             compare = f'{baseline_run["id"]}...{contender_run["id"]}'
             compare_runs_url = f.url_for("app.compare-runs", compare_ids=compare)
 
-        outliers, outlier_ids, outlier_names = self.get_outliers(benchmarks)
+        (
+            biggest_changes,
+            biggest_changes_ids,
+            biggest_changes_names,
+        ) = self.get_biggest_changes(benchmarks)
         plot_history = [
-            self.get_history_plot(b, contender_run, i) for i, b in enumerate(outliers)
+            self.get_history_plot(b, contender_run, i)
+            for i, b in enumerate(biggest_changes)
         ]
 
         return self.render_template(
@@ -41,8 +46,8 @@ class ViewRun(AppEndpoint, ContextMixin, RunMixin, TimeSeriesPlotMixin):
             form=form,
             resources=bokeh.resources.CDN.render(),
             plot_history=plot_history,
-            outlier_names=outlier_names,
-            outlier_ids=outlier_ids,
+            outlier_names=biggest_changes_names,
+            outlier_ids=biggest_changes_ids,
             search_value=f.request.args.get("search"),
         )
 

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -489,7 +489,7 @@ def _add_rolling_stats_columns_to_df(
         for x in df["change_annotations"]
     ]
 
-    # NOTE(EV): If unquoted, this line will integrate manually-specified distribution
+    # NOTE(EV): If uncommented, this line will integrate manually-specified distribution
     # changes with those automatically detected. Before enabling this, we want a way for
     # users to manually remove an automatically-detected step-change.
     #

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -584,7 +584,9 @@ def _calculate_z_score(
     return z_score
 
 
-def zscore_automated_detect(self, df: pd.DataFrame, z_score_threshold=5.0) -> pd.DataFrame:
+def zscore_automated_detect(
+    self, df: pd.DataFrame, z_score_threshold=5.0
+) -> pd.DataFrame:
     """Detect outliers and distribution shifts in historical data
 
     Uses a z-score-based detection algorithm, taking a dataframe of the same
@@ -618,9 +620,7 @@ def zscore_automated_detect(self, df: pd.DataFrame, z_score_threshold=5.0) -> pd
 
     # split / apply
     out_group_df_list = []
-    for _, group_df in tmp_df.groupby(
-        ["case_id", "context_id", "hash", "repository"]
-    ):
+    for _, group_df in tmp_df.groupby(["case_id", "context_id", "hash", "repository"]):
         # clean copy will only get result columns
         out_group_df = copy.deepcopy(group_df)
 
@@ -634,14 +634,7 @@ def zscore_automated_detect(self, df: pd.DataFrame, z_score_threshold=5.0) -> pd
         ) / mean_diff_clipped.std()
 
         group_df["is_shift"] = group_df.z_score.abs() > z_score_threshold
-        group_df["reverts"] = (
-            group_df.is_shift
-            & group_df.is_shift.shift(-1)
-            & (
-                (group_df.z_score + group_df.z_score.shift(1)).abs()
-                > z_score_threshold
-            )
-        )
+        group_df["reverts"] = group_df.is_shift & group_df.is_shift.shift(-1)
         out_group_df["is_step"] = (
             group_df.is_shift
             & ~group_df.reverts

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -472,7 +472,7 @@ def _add_rolling_stats_columns_to_df(
     exclusive on the right side. This is useful if you want to compare each commit to
     the previous commit's rolling stats.
     """
-    df = zscore_automated_detect(df=df)
+    df = _detect_shifts_with_trimmed_estimators(df=df)
 
     # pandas likes the data to be sorted
     df.sort_values(
@@ -588,12 +588,15 @@ def _calculate_z_score(
     return z_score
 
 
-def zscore_automated_detect(df: pd.DataFrame, z_score_threshold=5.0) -> pd.DataFrame:
+def _detect_shifts_with_trimmed_estimators(
+    df: pd.DataFrame, z_score_threshold=5.0
+) -> pd.DataFrame:
     """Detect outliers and distribution shifts in historical data
 
-    Uses a z-score-based detection algorithm, taking a dataframe of the same
-    sort as `_add_rolling_stats_columns_to_df`, and returning that dataframe with
-    two additional columns:
+    Uses a z-score-based detection algorithm that uses trimmed rolling means and standard
+    deviations to avoid influence by outliers. Takes a dataframe of the same sort as
+    `_add_rolling_stats_columns_to_df`, and returning that dataframe with two additional
+    columns:
 
     - `is_step` (bool): Is this point the start of a new segment?
     - `is_outlier` (bool): Is this point an outlier that should be ignored?

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -96,6 +96,7 @@ class HistorySampleZscoreStats:
     rolling_mean: Optional[float]
     residual: float
     rolling_stddev: float
+    is_outlier: bool
 
 
 @dataclasses.dataclass
@@ -216,6 +217,7 @@ def get_history_for_cchr(
             rolling_mean=_to_float(sample.rolling_mean),
             residual=sample.residual,
             rolling_stddev=_to_float(sample.rolling_stddev) or 0.0,
+            is_outlier=sample.is_outlier or False,
         )
 
         # For both, `sample.data` and `sample.times`, expect either None or a

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -584,9 +584,7 @@ def _calculate_z_score(
     return z_score
 
 
-def zscore_automated_detect(
-    self, df: pd.DataFrame, z_score_threshold=5.0
-) -> pd.DataFrame:
+def zscore_automated_detect(df: pd.DataFrame, z_score_threshold=5.0) -> pd.DataFrame:
     """Detect outliers and distribution shifts in historical data
 
     Uses a z-score-based detection algorithm, taking a dataframe of the same

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -487,8 +487,12 @@ def _add_rolling_stats_columns_to_df(
         for x in df["change_annotations"]
     ]
 
-    # Add in step changes automatically detected
-    df["begins_distribution_change"] = df["begins_distribution_change"] | df["is_step"]
+    # NOTE(EV): If unquoted, this line will integrate manually-specified distribution
+    # changes with those automatically detected. Before enabling this, we want a way for
+    # users to manually remove an automatically-detected step-change.
+    #
+    # # Add in step changes automatically detected
+    # df["begins_distribution_change"] = df["begins_distribution_change"] | df["is_step"]
 
     # Add column with cumulative sum of distribution changes, to identify the segment
     df["segment_id"] = (

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -644,6 +644,7 @@
                                     "unit": "s",
                                     "zscorestats": {
                                         "begins_distribution_change": False,
+                                        "is_outlier": False,
                                         "residual": 0.0,
                                         "rolling_mean": 0.036369,
                                         "rolling_mean_excluding_this_commit": 0.036369,

--- a/conbench/tests/app/test_plots.py
+++ b/conbench/tests/app/test_plots.py
@@ -28,6 +28,7 @@ def legacy_dict_to_hs(d: dict) -> HistorySample:
             rolling_mean=d["distribution_mean"],
             residual=0.0,  # not provided in legacy struct
             rolling_stddev=d["distribution_stdev"],
+            is_outlier=False,  # not provided in legacy struct
         ),
     )
 

--- a/conbench/tests/entities/test_history.py
+++ b/conbench/tests/entities/test_history.py
@@ -11,7 +11,7 @@ EXPECTED_Z_SCORES = [
     28.477042698148946,
     0.7071067811865444,
     2.1213203435596393,
-    None,  # 13.435028842544385,
+    13.435028842544385,
     1.0928748862317967,
     -2.1857497724635935,
     -4.486538431438488,
@@ -119,7 +119,7 @@ def test_append_z_scores():
             name=benchmark_results[0].case.name,
         )
     )
-    expected_z_scores = EXPECTED_Z_SCORES + [-66.46960984215899]
+    expected_z_scores = EXPECTED_Z_SCORES + [-52.99938107760085]
 
     set_z_scores(benchmark_results)
     for benchmark_result, expected_z_score in zip(benchmark_results, expected_z_scores):

--- a/conbench/tests/entities/test_history.py
+++ b/conbench/tests/entities/test_history.py
@@ -11,7 +11,7 @@ EXPECTED_Z_SCORES = [
     28.477042698148946,
     0.7071067811865444,
     2.1213203435596393,
-    13.435028842544385,
+    None,  # 13.435028842544385,
     1.0928748862317967,
     -2.1857497724635935,
     -4.486538431438488,
@@ -119,7 +119,7 @@ def test_append_z_scores():
             name=benchmark_results[0].case.name,
         )
     )
-    expected_z_scores = EXPECTED_Z_SCORES + [-52.99938107760085]
+    expected_z_scores = EXPECTED_Z_SCORES + [-66.46960984215899]
 
     set_z_scores(benchmark_results)
     for benchmark_result, expected_z_score in zip(benchmark_results, expected_z_scores):


### PR DESCRIPTION
Closes #730. Integrates with existing z-score code in `_add_rolling_stats_columns_to_df()` with new code that detects outliers and adds a boolean column for them. In the course of this is also automatically detects step changes, though with a slightly different approach than previously; this is not integrated for now, though it is set to do so easily should we wish to in the future.

The basic method here still uses z-scores, but trims off the top and bottom 5% of data (specifically the point-to-point diffs) when calculating mean and standard deviation to calculate them, so outliers and step changes do not affect magnitudes. 

[Trimmed estimators](https://en.wikipedia.org/wiki/Trimmed_estimator) remove the impact of outliers on the statistic, allowing us to use them to create z-scores by which to establish which points are outliers. Without trimming, outliers would blow out the standard deviation and tweak the mean a bit, shrinking their z-scores. Trimming only useful for getting less-biased estimators, though; we still need z-scores to determine outlier status since the percentage of outliers will not always be the percent trimmed. 

10% is not totally random, as in anomaly detection literature, an anomaly is defined as something that occurs less than 10% of the time; more than that and it is a mode. With z-scores, outliers are defined as those points which subsequently revert to non-extreme values; step changes are those that do not.