### PR TITLE
webapp: build psycopg2 from source against modern libpq (fix #957)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ FROM python:3.11-slim
 # curl is needed for docker-compose health checks. `git` is needed by some unit
 # tests as of today.
 RUN apt-get update && apt-get install -y -q --no-install-recommends \
-    curl git build-essential && apt-get clean && rm -rf /var/lib/apt/lists/*
+    curl git build-essential libpq-dev && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY requirements-webapp.txt /tmp/
 COPY requirements-dev.txt /tmp/
@@ -72,3 +72,4 @@ COPY ./buildinfo.json /buildinfo.json
 # Re-active this to get ideas for how the image size can be further reduced.
 #RUN echo "biggest dirs"
 #RUN cd / && du -ha . | sort -r -h | head -n 50 || true
+

--- a/conbench/db.py
+++ b/conbench/db.py
@@ -1,12 +1,11 @@
 import functools
 import logging
 
+import psycopg2
 import sqlalchemy.exc
 import tenacity
-import psycopg2
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
-
 
 from .config import Config
 

--- a/conbench/db.py
+++ b/conbench/db.py
@@ -3,8 +3,10 @@ import logging
 
 import sqlalchemy.exc
 import tenacity
+import psycopg2
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
+
 
 from .config import Config
 
@@ -14,6 +16,9 @@ Session = scoped_session(session_maker)
 
 
 log = logging.getLogger(__name__)
+
+
+log.info("psycopg2.__libpq_version__: %s", psycopg2.__libpq_version__)
 
 
 def configure_engine(url):

--- a/requirements-webapp.txt
+++ b/requirements-webapp.txt
@@ -20,7 +20,7 @@ pandas
 prometheus-client
 prometheus-flask-exporter
 psutil
-psycopg2-binary
+psycopg2
 py-cpuinfo
 pytest>=7.0.0
 python-dotenv


### PR DESCRIPTION
This should reliably use psycopg2 with libpq 13 across platforms, because the Python-3.11-slim Docker image that we use as build environment here is based on Debian Bullseye which uses libpq 13.

Previously, on M1 (AArch64) the psycopg2 binary we used was statically linked against libpq 9 (built in a manylinux 2.24 environment). See #957 for details.