### PR TITLE
UI: introduce /benchmark-results/<brid>, keep old route, add test, more renames in code

### DIFF
--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -343,11 +343,29 @@ class BenchmarkResultList(AppEndpoint, ContextMixin):
 
 rule(
     "/benchmark-results/",
-    view_func=BenchmarkResultList.as_view("benchmarks"),
+    view_func=BenchmarkResultList.as_view("benchmark-results"),
     methods=["GET"],
 )
+
 rule(
     "/benchmark-results/<benchmark_id>/",
+    view_func=BenchmarkResult.as_view("benchmark-result"),
+    methods=["GET", "POST"],
+)
+
+
+# Legacy route, which people have used to communicate a URL e.g. via Slack or
+# email, or in downstream reporting, to point to a specific benchmark result
+# view. Keep this working _in addition to_ the new, more descriptive
+# `/benchmark-results/<benchmark_id>/` path. Keep this working for as long as
+# we can do so with ease. Next step for this outstretched transition might be
+# to build custom logic that would act on the shape of <benchmark_id> and emit
+# a redirect response. Note that this needs a different name argument passed to
+# the as_view() method, otherwise one sees an error like `View function mapping
+# is overwriting an existing endpoint function: app.benchmark`
+# Context: https://github.com/conbench/conbench/pull/966#issuecomment-1487072612
+rule(
+    "/benchmarks/<benchmark_id>/",
     view_func=BenchmarkResult.as_view("benchmark"),
     methods=["GET", "POST"],
 )

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -59,10 +59,11 @@ class ContextMixin:
 
 class BenchmarkResultMixin:
     def get_display_benchmark(self, benchmark_id):
+        # this gets a benchmark _result_, we need more renaming.
         benchmark, response = self._get_benchmark(benchmark_id)
 
         if response.status_code == 404:
-            self.flash(f"unknown benchmark ID: {benchmark_id}", "info")
+            self.flash(f"unknown benchmark result ID: {benchmark_id}", "info")
 
         if response.status_code != 200:
             # Note(JP): quick band-aid to at least not swallow err detail, need
@@ -85,7 +86,9 @@ class BenchmarkResultMixin:
 
         return benchmark
 
+    # this gets a benchmark result, we need more renaming.
     def _get_benchmark(self, benchmark_id):
+        # TODO: remove re-serialization indirection.
         response = self.api_get(
             "api.benchmark",
             benchmark_id=benchmark_id,
@@ -262,7 +265,7 @@ class BenchmarkResult(AppEndpoint, BenchmarkResultMixin, RunMixin, TimeSeriesPlo
                 )
                 if delete_response.status_code == 204:
                     self.flash(f"Benchmark result {benchmark_id} deleted.", "info")
-                    return self.redirect("app.benchmarks")
+                    return self.redirect("app.benchmark-results")
 
         elif update_form.validate_on_submit():
             # toggle_distribution_change button pressed

--- a/conbench/app/compare.py
+++ b/conbench/app/compare.py
@@ -8,7 +8,7 @@ from ..app import rule
 from ..app._endpoint import AppEndpoint, authorize_or_terminate
 from ..app._plots import TimeSeriesPlotMixin, simple_bar_plot
 from ..app._util import augment
-from ..app.benchmarks import BenchmarkMixin, RunMixin
+from ..app.benchmarks import BenchmarkResultMixin, RunMixin
 from ..config import Config
 from ..entities.run import commit_hardware_run_map
 
@@ -23,7 +23,7 @@ def all_keys(dict1, dict2, attr):
     )
 
 
-class Compare(AppEndpoint, BenchmarkMixin, RunMixin, TimeSeriesPlotMixin):
+class Compare(AppEndpoint, BenchmarkResultMixin, RunMixin, TimeSeriesPlotMixin):
     def page(self, comparisons, regressions, improvements, baseline_id, contender_id):
         unknown = "unknown...unknown"
         compare_runs_url = f.url_for("app.compare-runs", compare_ids=unknown)

--- a/conbench/templates/benchmark-list.html
+++ b/conbench/templates/benchmark-list.html
@@ -37,12 +37,12 @@
                              <div>{{ benchmark.display_bmname }}</div>
                            </a>
                          </td>
-                         <td><a href="{{ url_for('app.benchmark', benchmark_id=benchmark.id) }}">
+                         <td><a href="{{ url_for('app.benchmark-result', benchmark_id=benchmark.id) }}">
                               <div>{{ benchmark.display_case_perm }}</div>
                          </a></td>
                          <td>{{ benchmark.display_mean }}</td>
                          {% if not current_user.is_anonymous %}
-                         <td data-cbcustom-href="{{ url_for('app.benchmark', benchmark_id=benchmark.id) }}"
+                         <td data-cbcustom-href="{{ url_for('app.benchmark-result', benchmark_id=benchmark.id) }}"
                              data-bs-toggle="modal"
                              data-bs-target="#confirm-delete"
                              data-cbcustom-form-id="#delete-benchmark-form"

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -42,7 +42,7 @@
         <div class="item">
         {% endif %}
         <div align="center">
-        <a href="{{ url_for('app.benchmark', benchmark_id=outlier_ids[loop.index - 1]) }}">
+        <a href="{{ url_for('app.benchmark-result', benchmark_id=outlier_ids[loop.index - 1]) }}">
           {{ outlier_names[loop.index - 1] }}
         </a>
         </div>
@@ -84,7 +84,7 @@
                          {{ benchmark.display_bmname }}
                        </a>
                      </td>
-                     <td><a href="{{ url_for('app.benchmark', benchmark_id=benchmark.id) }}">
+                     <td><a href="{{ url_for('app.benchmark-result', benchmark_id=benchmark.id) }}">
                          {{ benchmark.display_case_perm}}
                      </a></td>
                      <td style="white-space: nowrap;">{{ benchmark.display_mean }}</td>
@@ -100,7 +100,7 @@
                        <td></td>
                      {% endif %}
                 <td>
-                    {%  if benchmark.error %}<a href="{{ url_for('app.benchmark', benchmark_id=benchmark.id) }}">
+                    {%  if benchmark.error %}<a href="{{ url_for('app.benchmark-result', benchmark_id=benchmark.id) }}">
                         <i class="glyphicon glyphicon-exclamation-sign text-danger"
                            data-toggle="tooltip" data-placement="top" title="Has error">
                         </i><span>Error</span></a>

--- a/conbench/tests/api/test_benchmarks.py
+++ b/conbench/tests/api/test_benchmarks.py
@@ -976,7 +976,7 @@ class TestBenchmarkPost(_asserts.PostEnforcer):
         # object. There was a time when the benchmark-entity template failed
         # rendering for empty contexts, see
         # https://github.com/conbench/conbench/issues/365
-        resp = client.get(f"/benchmarks/{benchmark_id}/")
+        resp = client.get(f"/benchmark-results/{benchmark_id}/")
         assert resp.status_code == 200, f"unexpected response: {resp.text}"
 
         # As of today the rendered view shows the context ID. Confirm that. In

--- a/conbench/tests/app/test_benchmarks.py
+++ b/conbench/tests/app/test_benchmarks.py
@@ -13,7 +13,7 @@ class TestBenchmarkList(_asserts.ListEnforcer):
 
 class TestBenchmarkGet(_asserts.GetEnforcer):
     url = "/benchmark-results/{}/"
-    title = "Benchmark"
+    title = "Benchmark result"
 
     def _create(self, client):
         return self.create_benchmark(client)
@@ -22,7 +22,19 @@ class TestBenchmarkGet(_asserts.GetEnforcer):
         self.authenticate(client)
         response = client.get("/benchmark-results/unknown/", follow_redirects=True)
         self.assert_index_page(response)
-        assert re.search(r"unknown benchmark ID: \w+", response.text, flags=re.ASCII)
+        assert re.search(
+            r"unknown benchmark result ID: \w+", response.text, flags=re.ASCII
+        )
+
+    def test_legacy_route(self, client):
+        # Context: https://github.com/conbench/conbench/pull/966#issuecomment-1487072612
+        response = client.get(
+            "/benchmarks/unknown-benchmark-result-id/", follow_redirects=True
+        )
+        self.assert_index_page(response)
+        assert re.search(
+            r"unknown benchmark result ID: \w+", response.text, flags=re.ASCII
+        )
 
 
 class TestBenchmarkDelete(_asserts.DeleteEnforcer):
@@ -50,7 +62,9 @@ class TestBenchmarkDelete(_asserts.DeleteEnforcer):
             f"/benchmark-results/{benchmark_id}/", follow_redirects=True
         )
         self.assert_index_page(response)
-        assert re.search(r"unknown benchmark ID: \w+", response.text, flags=re.ASCII)
+        assert re.search(
+            r"unknown benchmark result ID: \w+", response.text, flags=re.ASCII
+        )
 
     def test_unauthenticated(self, client):
         benchmark_id = self.create_benchmark(client)

--- a/conbench/tests/app/test_benchmarks.py
+++ b/conbench/tests/app/test_benchmarks.py
@@ -4,7 +4,7 @@ from ...tests.app import _asserts
 
 
 class TestBenchmarkList(_asserts.ListEnforcer):
-    url = "/benchmarks/"
+    url = "/benchmark-results/"
     title = "Benchmarks"
 
     def _create(self, client):
@@ -12,7 +12,7 @@ class TestBenchmarkList(_asserts.ListEnforcer):
 
 
 class TestBenchmarkGet(_asserts.GetEnforcer):
-    url = "/benchmarks/{}/"
+    url = "/benchmark-results/{}/"
     title = "Benchmark"
 
     def _create(self, client):
@@ -20,7 +20,7 @@ class TestBenchmarkGet(_asserts.GetEnforcer):
 
     def test_flash_message(self, client):
         self.authenticate(client)
-        response = client.get("/benchmarks/unknown/", follow_redirects=True)
+        response = client.get("/benchmark-results/unknown/", follow_redirects=True)
         self.assert_index_page(response)
         assert re.search(r"unknown benchmark ID: \w+", response.text, flags=re.ASCII)
 
@@ -31,14 +31,14 @@ class TestBenchmarkDelete(_asserts.DeleteEnforcer):
 
         # can get benchmark before
         self.authenticate(client)
-        response = client.get(f"/benchmarks/{benchmark_id}/")
+        response = client.get(f"/benchmark-results/{benchmark_id}/")
         self.assert_page(response, "Benchmark")
         assert f"{benchmark_id[:6]}".encode() in response.data
 
         # delete benchmark
         data = {"delete": ["Delete"], "csrf_token": self.get_csrf_token(response)}
         response = client.post(
-            f"/benchmarks/{benchmark_id}/", data=data, follow_redirects=True
+            f"/benchmark-results/{benchmark_id}/", data=data, follow_redirects=True
         )
         self.assert_page(response, "Benchmarks")
         assert re.search(
@@ -46,7 +46,9 @@ class TestBenchmarkDelete(_asserts.DeleteEnforcer):
         )
 
         # cannot get benchmark after
-        response = client.get(f"/benchmarks/{benchmark_id}/", follow_redirects=True)
+        response = client.get(
+            f"/benchmark-results/{benchmark_id}/", follow_redirects=True
+        )
         self.assert_index_page(response)
         assert re.search(r"unknown benchmark ID: \w+", response.text, flags=re.ASCII)
 
@@ -55,7 +57,7 @@ class TestBenchmarkDelete(_asserts.DeleteEnforcer):
         self.logout(client)
         data = {"delete": ["Delete"]}
         response = client.post(
-            f"/benchmarks/{benchmark_id}/", data=data, follow_redirects=True
+            f"/benchmark-results/{benchmark_id}/", data=data, follow_redirects=True
         )
         self.assert_login_page(response)
 
@@ -64,7 +66,7 @@ class TestBenchmarkDelete(_asserts.DeleteEnforcer):
         self.authenticate(client)
         data = {"delete": ["Delete"]}
         response = client.post(
-            f"/benchmarks/{benchmark_id}/", data=data, follow_redirects=True
+            f"/benchmark-results/{benchmark_id}/", data=data, follow_redirects=True
         )
         self.assert_page(response, "Benchmark")
         assert b"The CSRF token is missing." in response.data


### PR DESCRIPTION
This is for #964.

Updated description:

This PR
- introduces a new URL path pattern for accessing an individual benchmark result view: `/benchmark-results/<benchmark-result-id>`
- changes the UI/app/template logic to generate URLs of the new shape
- keeps support for the old pattern `/benchmarks/<benchmark-result-id>`
- adds a test for covering the old pattern
- also contains valuable renames in code, all relating to the difference between "benchmark result" and "benchmark".

Note: we do not yet want to break those URLs to specific benchmark results that we have in the past shared in e.g. Slack. See comment below.

