### PR TITLE
benchalerts: rip out warning if we skipped over git commits

### DIFF
--- a/benchalerts/benchalerts/message_formatting.py
+++ b/benchalerts/benchalerts/message_formatting.py
@@ -62,9 +62,7 @@ def _list_results(
     return out
 
 
-def github_check_summary(
-    full_comparison: FullComparisonInfo, warn_if_baseline_isnt_parent: bool
-) -> str:
+def github_check_summary(full_comparison: FullComparisonInfo) -> str:
     """Generate a Markdown summary of what happened regarding errors and regressions."""
     hash = full_comparison.commit_hash[:8]
     summary = ""
@@ -119,19 +117,6 @@ def github_check_summary(
             comparison.contender_reason,
             comparison.contender_datetime,
             comparison.contender_link,
-        )
-    summary += "\n\n"
-
-    if full_comparison.no_baseline_is_parent and warn_if_baseline_isnt_parent:
-        summary += _clean(
-            """
-            ### Note
-
-            No baseline run was on the immediate parent commit of the contender commit.
-            This probably means that no matching benchmarks (with the same repository,
-            hardware, case, and context) successfully ran on the parent commit. See the
-            link below for details.
-            """
         )
 
     return summary

--- a/benchalerts/tests/unit_tests/expected_md/summary_errors_baselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_errors_baselines.md
@@ -23,7 +23,3 @@ Contender commit `abc` had 3 performance regressions using the lookback z-score 
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
-
-### Note
-
-No baseline run was on the immediate parent commit of the contender commit. This probably means that no matching benchmarks (with the same repository, hardware, case, and context) successfully ran on the parent commit. See the link below for details.

--- a/benchalerts/tests/unit_tests/expected_md/summary_noregressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_noregressions.md
@@ -6,7 +6,3 @@ Contender commit `abc` had 0 performance regressions using the lookback z-score 
 
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
-
-### Note
-
-No baseline run was on the immediate parent commit of the contender commit. This probably means that no matching benchmarks (with the same repository, hardware, case, and context) successfully ran on the parent commit. See the link below for details.

--- a/benchalerts/tests/unit_tests/expected_md/summary_regressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_regressions.md
@@ -13,7 +13,3 @@ Contender commit `no_basel` had 2 performance regressions using the lookback z-s
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
-
-### Note
-
-No baseline run was on the immediate parent commit of the contender commit. This probably means that no matching benchmarks (with the same repository, hardware, case, and context) successfully ran on the parent commit. See the link below for details.

--- a/benchalerts/tests/unit_tests/test_pipeline_steps/test_github.py
+++ b/benchalerts/tests/unit_tests/test_pipeline_steps/test_github.py
@@ -45,14 +45,12 @@ def test_GitHubCheckStep(
             GitHubCheckStep(
                 github_client=GitHubRepoClient(repo="some/repo", adapter=MockAdapter()),
                 comparison_step_name="comparison_step",
-                warn_if_baseline_isnt_parent=True,
             )
         return
 
     step = GitHubCheckStep(
         github_client=GitHubRepoClient(repo="some/repo", adapter=MockAdapter()),
         comparison_step_name="comparison_step",
-        warn_if_baseline_isnt_parent=True,
     )
     gh_res, full_comparison = step.run_step({"comparison_step": mock_comparison_info})
     assert gh_res


### PR DESCRIPTION
As an add-on to https://github.com/conbench/conbench/pull/952#issuecomment-1485696348, this PR rips out the warning in the GitHub Check report if we couldn't find any matching runs on the parent commit. We will do this better in #969.