### PR TITLE
kube-prometheus conbench flavor: allow for monitoring other namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,6 @@ jsonnet-kube-prom-manifests:
 			echo "MUTATE_JSONNET_FILE_FOR_MINIKUBE not set"; \
 		else \
 			echo "MUTATE_JSONNET_FILE_FOR_MINIKUBE set, mutate JSONNET"; \
-			sed -i.bak 's|// (import "kube-prom|(import "kube-prom|g' _kpbuild/cb-kube-prometheus/conbench-flavor.jsonnet; \
 			sed -i.bak 's|// "auth.anonymous"|"auth.anonymous"|g' _kpbuild/cb-kube-prometheus/conbench-flavor.jsonnet; \
 			cat _kpbuild/cb-kube-prometheus/conbench-flavor.jsonnet; \
 		fi

--- a/ci/minikube/test-conbench-on-mk.sh
+++ b/ci/minikube/test-conbench-on-mk.sh
@@ -100,6 +100,14 @@ export PROM_REMOTE_WRITE_CLUSTER_LABEL_VALUE="ci-conbench-on-$(hostname -s)"
 export MUTATE_JSONNET_FILE_FOR_MINIKUBE=true
 ( cd "${CONBENCH_REPO_ROOT_DIR}" && make jsonnet-kube-prom-manifests )
 
+# The kube-prometheus stack's custom JSONNET stack is configured to allow for
+# monitoring the `staging` namespace. I've done this to resemble a "prod"
+# environment where Conbench is deployed in a k8s namespace called `staging`.
+# With that setup, the namespace needs to exist before deploying
+# kube-prometheus.
+# kudos to https://stackoverflow.com/a/65411733/145400
+kubectl create namespace staging --dry-run=client -o yaml | kubectl apply -f -
+
 # Set up the kube-prometheus stack. This follows the customization instructions
 # at https://github.com/prometheus-operator/kube-prometheus/blob/v0.12.0/docs/customizing.md
 pushd "${CONBENCH_REPO_ROOT_DIR}"/_kpbuild/cb-kube-prometheus/

--- a/k8s/kube-prometheus/conbench-flavor.jsonnet
+++ b/k8s/kube-prometheus/conbench-flavor.jsonnet
@@ -14,13 +14,23 @@ local kp =
   // (import 'kube-prometheus/addons/custom-metrics.libsonnet') +
   // (import 'kube-prometheus/addons/external-metrics.libsonnet') +
   // (import 'kube-prometheus/addons/pyrra.libsonnet') +
-  // (import "kube-prom-no-req-no-lim.jsonnet") +  // auto-uncommented-by-ci
+  // Pretend to almost not need any resources. Of course this can be dangerous.
+  // This is to make it easier to get going with testing in k8s environments
+  // that have limited resource offers.
+  (import 'kube-prom-no-req-no-lim.jsonnet') +
   {
     values+:: {
       prometheus+: {
         externalLabels: {
           cluster: 'PROM_REMOTE_WRITE_CLUSTER_LABEL_VALUE',
         },
+        // Configure the namespaces that should be monitored; this is important
+        // for automated privilege configuration. If a namespace not configured
+        // here has a ServiceMonitor object then the scraper Prometheuses try
+        // to act on it, but will fail with errors like
+        // `User \"system:serviceaccount:monitoring:prometheus-k8s\" cannot list resource ...`
+        // Also see https://github.com/prometheus-operator/kube-prometheus/blob/main/docs/monitoring-other-namespaces.md
+        namespaces: ['default', 'kube-system', 'monitoring', 'staging'],
       },
       common+: {
         namespace: 'monitoring',


### PR DESCRIPTION
Also, apply `kube-prom-no-req-no-lim.jsonnet` always for now, because even our prod k8s clusters are rather small with 2 CPU cores per node, and two nodes.

This addresses a privilege issue:
```
kubectl logs pods/prometheus-k8s-0 -n monitoring | less
```


```
ts=2023-03-30T10:33:20.091Z caller=klog.go:108 level=warn component=k8s_client_runtime func=Warningf msg="pkg/mod/k8s.io/client-go@v0.26.0/tools/cache/reflector.go:169: failed to list *v1.Endpoints: endpoints is forbidden: User \"system:serviceaccount:monitoring:prometheus-k8s\" cannot list resource \"endpoints\" in API group \"\" in the namespace \"staging\""
ts=2023-03-30T10:33:20.091Z caller=klog.go:116 level=error component=k8s_client_runtime func=ErrorDepth msg="pkg/mod/k8s.io/client-go@v0.26.0/tools/cache/reflector.go:169: Failed to watch *v1.Endpoints: failed to list *v1.Endpoints: endpoints is forbidden: User \"system:serviceaccount:monitoring:prometheus-k8s\" cannot list resource \"endpoints\" in API group \"\" in the namespace \"staging\""
```

key fragment: `User \"system:serviceaccount:monitoring:prometheus-k8s\" cannot list resource ...`

> This is intentional. kube-prometheus configures Prometheus with the principle of least privilege, meaning permission is granted specifically for each namespace when needed instead of for every namespace, even where it's not needed.

(https://github.com/prometheus-operator/kube-prometheus/issues/492#issuecomment-613321437)

Interesting: https://github.com/prometheus-operator/kube-prometheus/issues/492#issuecomment-1450074518

I think in the meantime this has been nicely documented here: https://github.com/prometheus-operator/kube-prometheus/blob/main/docs/monitoring-other-namespaces.md

> By default the RBAC rules are only enabled for the Default and kube-system namespaces.
> You have to give the list of the namespaces that you want to be able to monitor. This is done in the variable prometheus.roleSpecificNamespaces. You usually set this in your .jsonnet file when building the manifests.