### PR TITLE
k8s deploy.yaml: adjust Service and add ServiceMonitor

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -60,15 +60,21 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: "conbench-service"
+  labels:
+    app: conbench
   annotations:
     # "ip mode is required for sticky sessions to work with Application Load
     # Balancers"
     alb.ingress.kubernetes.io/target-type: ip
-  name: "conbench-service"
 spec:
   ports:
-  - port: 80
-    targetPort: 5000
+  - name: conbench-service-port
+    port: 80
+    # The port number above: the port that will be exposed by this service.
+    # `targetPort` is documented with "Number or name of the port to access on
+    # the pods targeted by the service."
+    targetPort: gunicorn-port
     protocol: TCP
   type: NodePort
   selector:

--- a/deploy.yml
+++ b/deploy.yml
@@ -80,6 +80,24 @@ spec:
   selector:
     app: "conbench"
 ---
+apiVersion: monitoring.coreos.com/v1
+# This is a CRD defined by the prometheus-operator/kube-prometheus project
+kind: ServiceMonitor
+metadata:
+  name: conbench-service-monitor
+spec:
+  selector:
+    matchLabels:
+      app: conbench
+  endpoints:
+    # It's important that ServiceMonitor i) refers to a Service port  and ii)
+    # refers to it via its name.
+    - port: conbench-service-port
+      path: /metrics
+      scheme: http
+      # This defines the time resolution.
+      interval: 30s
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/deploy.yml
+++ b/deploy.yml
@@ -34,7 +34,8 @@ spec:
           ]
         imagePullPolicy: "Always"
         ports:
-          - containerPort: 5000
+          - name: gunicorn-port
+            containerPort: 5000
         envFrom:
           - configMapRef:
               name: conbench-config


### PR DESCRIPTION
This defines a ServiceMonitor object; it refers to the corresponding Service by name; therefore a name is introduced here. For a bit of cleanup, we also introduce a name for the container port.

The ServiceMonitor object is a noop, unless kube-prometheus is also running in the same k8s cluster. If it is, then the ServiceMonitor object defines a monitoring target for the kube-prometheus stack.

This is tested and has been running in CI on minikube for a while. The current change brings this to our deployment pipeline, into the k8s cluster(s) that our Conbench deployment(s) run(s) on.

I have tested that manually in vd-2.