### PR TITLE
k8s deploy.yml: tweak ALB group prio

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -138,7 +138,9 @@ metadata:
     # (also spread across multiple k8s namespaces) can configure the _same_ ALB
     # in AWS.
     alb.ingress.kubernetes.io/group.name: cb-alb-group
-    alb.ingress.kubernetes.io/group.order: "1"
+    # allow for higher-prio config elsewhere, this can be important for path
+    # evaluation rules.
+    alb.ingress.kubernetes.io/group.order: "9"
     # Configure health check against Conbench containers
     alb.ingress.kubernetes.io/healthcheck-protocol: HTTP
     alb.ingress.kubernetes.io/healthcheck-path: /api/ping/


### PR DESCRIPTION
https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1223#issuecomment-729998307 mentions the IngressGroup feature in https://github.com/kubernetes-sigs/aws-load-balancer-controller. 

It's also briefly documented here: https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html

In https://github.com/conbench/conbench/pull/990 I started introducing that concept. This here is a small correction, allowing for higher-prio ingress objects next to `"conbench-ingress"`.

