### PR TITLE
address performance issue: remove history analysis from `/api/benchmark?run_id=<>` query

### DIFF
--- a/conbench/api/results.py
+++ b/conbench/api/results.py
@@ -40,9 +40,7 @@ class BenchmarkEntityAPI(ApiEndpoint, BenchmarkValidationMixin):
     def get(self, benchmark_id):
         """
         ---
-        description:
-            Get a benchmark result. This includes on-the-fly processing
-            with the lookback z-score change detection method.
+        description: Get a benchmark result.
         responses:
             "200": "BenchmarkEntity"
             "401": "401"
@@ -117,7 +115,6 @@ class BenchmarkListAPI(ApiEndpoint, BenchmarkValidationMixin):
         """
         ---
         description: Get a list of benchmarks.
-
         responses:
             "200": "BenchmarkList"
             "401": "401"

--- a/conbench/api/results.py
+++ b/conbench/api/results.py
@@ -1,10 +1,13 @@
+import logging
+
 import flask as f
 import flask_login
-
 from sqlalchemy import select
+
 from ..api import rule
 from ..api._docs import spec
 from ..api._endpoint import ApiEndpoint, maybe_login_required
+from ..db import Session
 from ..entities._entity import NotFound
 from ..entities.benchmark_result import (
     BenchmarkResult,
@@ -13,10 +16,6 @@ from ..entities.benchmark_result import (
 )
 from ..entities.case import Case
 from ..entities.history import set_z_scores
-from ..db import Session
-
-import logging
-
 
 log = logging.getLogger(__name__)
 

--- a/conbench/api/results.py
+++ b/conbench/api/results.py
@@ -118,11 +118,19 @@ class BenchmarkListAPI(ApiEndpoint, BenchmarkValidationMixin):
         """
         ---
         description:
-            Get a list of benchmark results.
+            Return a JSON array of benchmark results.
 
             On-the-fly processing with the lookback z-score change detection
             method is only performed when requesting a specific "batch" via the
             `batch_id` query parameter.
+
+            When fetching benchmark results for a specific conceptual benchmark
+            (with the `name` query parameter) then at most 10000 results
+            are returned.
+
+            Benchmark results are usually returned in order of their
+            timestamp property (user-given benchmark start time), newest first.
+
         responses:
             "200": "BenchmarkList"
             "401": "401"
@@ -144,9 +152,9 @@ class BenchmarkListAPI(ApiEndpoint, BenchmarkValidationMixin):
         """
         # Note(JP): "case name" is the conceptual benchmark name. Interesting,
         # so this is like asking "give me results for this benchmark".
-        # There was no limit here, that does not make sense. Introduce an
-        # arbitrary limit for now.
         if name_arg := f.request.args.get("name"):
+            # TODO: This needs a limit, and sorting behavior.
+            # arbitrary limit for now.
             benchmark_results = BenchmarkResult.search(
                 filters=[Case.name == name_arg],
                 joins=[Case],

--- a/conbench/api/results.py
+++ b/conbench/api/results.py
@@ -116,19 +116,7 @@ class BenchmarkListAPI(ApiEndpoint, BenchmarkValidationMixin):
     def get(self):
         """
         ---
-        description:
-            Return a JSON array of benchmark results.
-
-            On-the-fly processing with the lookback z-score change detection
-            method is only performed when requesting a specific "batch" via the
-            `batch_id` query parameter.
-
-            When fetching benchmark results for a specific conceptual benchmark
-            (with the `name` query parameter) then at most 10000 results
-            are returned.
-
-            Benchmark results are usually returned in order of their
-            timestamp property (user-given benchmark start time), newest first.
+        description: Get a list of benchmarks.
 
         responses:
             "200": "BenchmarkList"


### PR DESCRIPTION
This addresses a part of #1001.

This fixes #978.

This patch changes the HTTP response generation duration for `/api/benchmark` when used with the `run_id` query parameter by one or two orders of magnitude.

The specific query I showed in https://github.com/conbench/conbench/issues/978 now takes ~1 second in my development environment, instead of ~20 seconds (current HEAD of `main`).

The user-facing change is that we do not perform history analysis anymore (the lookback z-score method is not applied). In the team we seem to have the shared opinion that this should only be performed when demanded / expected by the user.

So far we had underspecified behavior in that regard anyway; the API docs made no promise about this type of analysis being performed or not.


