### PR TITLE
/api/benchmarks: start to use orjson for JSON-serialization

### DIFF
--- a/conbench/api/results.py
+++ b/conbench/api/results.py
@@ -2,10 +2,8 @@ import logging
 
 import flask as f
 import flask_login
-from sqlalchemy import select
-
-
 import orjson
+from sqlalchemy import select
 
 from ..api import rule
 from ..api._docs import spec
@@ -179,6 +177,7 @@ class BenchmarkListAPI(ApiEndpoint, BenchmarkValidationMixin):
         # See https://github.com/conbench/conbench/issues/999 -- for rather
         # typical queries, using orjson instead of stdlib can significantly
         # cut JSON serialization time.
+
         jsonbytes: bytes = orjson.dumps(
             [r.to_dict_for_json_api() for r in benchmark_results],
             option=orjson.OPT_INDENT_2,

--- a/conbench/api/results.py
+++ b/conbench/api/results.py
@@ -176,6 +176,9 @@ class BenchmarkListAPI(ApiEndpoint, BenchmarkValidationMixin):
                 order_by=BenchmarkResult.timestamp.desc(), limit=500
             )
 
+        # See https://github.com/conbench/conbench/issues/999 -- for rather
+        # typical queries, using orjson instead of stdlib can significantly
+        # cut JSON serialization time.
         jsonbytes: bytes = orjson.dumps(
             [r.to_dict_for_json_api() for r in benchmark_results],
             option=orjson.OPT_INDENT_2,

--- a/conbench/api/results.py
+++ b/conbench/api/results.py
@@ -4,6 +4,9 @@ import flask as f
 import flask_login
 from sqlalchemy import select
 
+
+import orjson
+
 from ..api import rule
 from ..api._docs import spec
 from ..api._endpoint import ApiEndpoint, maybe_login_required

--- a/requirements-webapp.txt
+++ b/requirements-webapp.txt
@@ -16,6 +16,7 @@ marshmallow
 numpy
 oauthlib
 openapi-spec-validator
+orjson
 pandas
 prometheus-client
 prometheus-flask-exporter


### PR DESCRIPTION
As described in #999, the time it takes to JSON-serialize a large number of BenchmarkResult objects may actually _dominate_ the HTTP response generation duration.

With this patch, we improve this by a nice factor ~2.

This PR introduces [orjson](https://github.com/ijl/orjson) which claims to be sweet and hot and fast and awesome -- well, I have seen the project and read its README various times over the years; and I have generally followed JSON performance topics over many years (in the Mesos ecosystem this was always a big topic). This project seems to have fantastic trade-offs. I am happy to give it a try.

Example set of ~10000 Benchmark results:
- `self.serializer.many.dump(benchmark_results)` takes `0.70 s` (rather reproducibly)
- `orjson.dumps(
            [r.to_dict_for_json_api() for r in benchmark_results],
            option=orjson.OPT_INDENT_2,
        )` takes `0.38 s`, rather reproducibly

So, this cuts the "JSON serialization time" roughly by a half, in this particular case (which still _includes dictionary creation _before_ JSON serialization, so ... that's interesting).

## Output comparison

### Sample: before
```
$ time curl -v  http://127.0.0.1:5000/api/benchmarks/?run_id=edc63e1a607e45b8af0f8cff72319eba,ac5d5deb91404233be108cf347dd9ea0,a97353d044974e8bba5500c4762028ce > before_json
*   Trying 127.0.0.1:5000...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* Connected to 127.0.0.1 (127.0.0.1) port 5000 (#0)
> GET /api/benchmarks/?run_id=edc63e1a607e45b8af0f8cff72319eba,ac5d5deb91404233be108cf347dd9ea0,a97353d044974e8bba5500c4762028ce HTTP/1.1
> Host: 127.0.0.1:5000
> User-Agent: curl/7.85.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Server: gunicorn
< Date: Sat, 01 Apr 2023 15:07:59 GMT
< Connection: close
< Content-Type: application/json
< Content-Length: 14191077
```

### Sample: after
```
$ time curl -v  http://127.0.0.1:5000/api/benchmarks/?run_id=edc63e1a607e45b8af0f8cff72319eba,ac5d5deb91404233be108cf347dd9ea0,a97353d044974e8bba5500c4762028ce > after_json
*   Trying 127.0.0.1:5000...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* Connected to 127.0.0.1 (127.0.0.1) port 5000 (#0)
> GET /api/benchmarks/?run_id=edc63e1a607e45b8af0f8cff72319eba,ac5d5deb91404233be108cf347dd9ea0,a97353d044974e8bba5500c4762028ce HTTP/1.1
> Host: 127.0.0.1:5000
> User-Agent: curl/7.85.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Server: gunicorn
< Date: Sat, 01 Apr 2023 15:08:15 GMT
< Connection: close
< content-type: application/json
< Content-Length: 14191080
```

### diff

- response size 14191077 vs 14191080 bytes -- three bytes difference, probably whitespace.
- no output from ` $ diff -wu <(jq --sort-keys . before_json) <(jq --sort-keys . after_json)` (which does precise JSON comparison, not sensitive to ordering of properties

