### PR TITLE
Makefile: jsonnet build: debug info (for BK deploy pipeline)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,19 +285,20 @@ set-build-info:
 # do modifications for CI and local dev on minikube. Modify JSONNET file. Maybe
 # it's chaotic to do sed-based templating on top of JSONNET, we can maybe do
 # that better in the future based on JSONNET external variables?
+# Note: the default jsonnetfile.json file is the outcome of `jb init`.
 .PHONY: jsonnet-kube-prom-manifests
 jsonnet-kube-prom-manifests:
 #	rm -rf _kpbuild
 	mkdir -p _kpbuild && cd _kpbuild  && mkdir -p cb-kube-prometheus
-	cd _kpbuild/cb-kube-prometheus && \
-		docker run --user $$(id -u):$$(id -g) --rm -v $$(pwd):$$(pwd) --workdir $$(pwd) quay.io/coreos/jsonnet-ci \
-			jb init || echo "exists: ignore, proceed"
+	cd _kpbuild/cb-kube-prometheus && echo '{"version": 1, "dependencies": [], "legacyImports": true}' > jsonnetfile.json
 	cd _kpbuild/cb-kube-prometheus && \
 		time docker run --user $$(id -u):$$(id -g) --rm -v $$(pwd):$$(pwd) --workdir $$(pwd) quay.io/coreos/jsonnet-ci \
 			jb install github.com/prometheus-operator/kube-prometheus/jsonnet/kube-prometheus@v0.12.0
+	cd _kpbuild/cb-kube-prometheus && /bin/ls -ahl
 	cp k8s/kube-prometheus/conbench-flavor.jsonnet _kpbuild/cb-kube-prometheus
 	cp k8s/kube-prometheus/conbench-grafana-dashboard.json _kpbuild/cb-kube-prometheus
 	cp k8s/kube-prometheus/kube-prom-no-req-no-lim.jsonnet _kpbuild/cb-kube-prometheus
+	cd _kpbuild/cb-kube-prometheus && /bin/ls -ahl
 	@if [ -z "$${MUTATE_JSONNET_FILE_FOR_MINIKUBE:=}" ]; then \
 			echo "MUTATE_JSONNET_FILE_FOR_MINIKUBE not set"; \
 		else \


### PR DESCRIPTION
In BK deploy pipeline we saw
```
  kpbuild/cb-kube-prometheus/jsonnetfile.json: no such file or directory
```
this is surprising. Maybe this has to do with the docker agent config and file system permissions, because artifacts are written from within container(s) into the host file system, and the Docker setup on BK might be configured different from e.g. my machine.

Generate this file directly (`jb init` creates a predictable outcome I think). And add debug info.