### PR TITLE
landing page: fix perf regression #977 (do not display result count for now)

### DIFF
--- a/conbench/app/index.py
+++ b/conbench/app/index.py
@@ -44,7 +44,13 @@ class Index(AppEndpoint, RunMixin):
             rd = RunForDisplay(
                 ctime_for_table=r.timestamp.strftime("%Y-%m-%d %H:%M:%S UTC"),
                 commit_message_short=short_commit_msg(r.commit.message),
-                result_count=len(r.results),
+                # Temporary band-aid; we cannot fetch all last-1000-run-related
+                # BenchmarkResult objects each time we render the landing page.
+                # See https://github.com/conbench/conbench/issues/977 However,
+                # we will find a pragmatic way to still display a per-run
+                # result count (estimate). I want to leave this code intact for
+                # now and display a placeholder.
+                result_count="",
                 run=r,
             )
 
@@ -81,7 +87,7 @@ def repo_url_to_display_name(url: str) -> str:
 class RunForDisplay:
     ctime_for_table: str
     commit_message_short: str
-    result_count: int
+    result_count: str | int
     # Expose the raw Run object (but this needs to be used with a lot of
     # care, in the template -- for VSCode supporting Python variable types and
     # auot-completion in a jinja2 template see

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -72,12 +72,12 @@ class Run(Base, EntityMixin):
     hardware_id: Mapped[str] = NotNull(s.String(50), s.ForeignKey("hardware.id"))
     hardware: Mapped[Hardware] = relationship("Hardware", lazy="joined")
 
-    # Follow ttps://docs.sqlalchemy.org/en/20/orm/basic_relationships.html#one-to-many.
+    # Follow https://docs.sqlalchemy.org/en/20/orm/basic_relationships.html#one-to-many.
     # There is a one-to-many relationship between Run (one) and BenchmarkResult
     # (0, 1, many).
     # Ignorantly importing BenchmarkResult results in circular import err.
     results: Mapped[List["BenchmarkResult"]] = relationship(  # type: ignore # noqa
-        back_populates="run"
+        back_populates="run", lazy="select"
     )
 
     @staticmethod


### PR DESCRIPTION
Do not display result count for now, but an empty string -- pragmatic relaxation of the situation. My feeling is that we will display a result count again in the next couple of days.

With the Arrow Conbench DB state this again yields
```
± time curl -v http://127.0.0.1:5000/ >/dev/null
real	0m0.142s
```

Without the patch this was > `70 s` in my dev env.