### PR TITLE
api/index.py: fix alembic version query

### DIFF
--- a/conbench/api/index.py
+++ b/conbench/api/index.py
@@ -159,7 +159,6 @@ class PingAPI(ApiEndpoint):
         if Config.TESTING:
             alembic_version = "not-set-in-testing"
         else:
-            query = text("SELECT version_num FROM alembic_version")
             try:
                 # In local deployment the PostgreSQL server logs: `ERROR:  relation
                 # "alembic_version" does not exist at character 25`. That is
@@ -167,7 +166,9 @@ class PingAPI(ApiEndpoint):
                 # Should we make it so that this table exists also for those
                 # dev/from-scratch deployments? Update(JP): pragmatic solution:
                 # do not query in TESTING mode.
-                alembic_version = list(Session.execute(query))[0]["version_num"]
+                alembic_version = list(
+                    Session.execute(text("SELECT version_num FROM alembic_version"))
+                )[0][0]
             except Exception as exc:
                 # Reduce noise: do not log full error, and also only on debug
                 # level.


### PR DESCRIPTION
This fixes issue #994. Not sure if the old query ever worked, but the dict-based lookup `["version_num"]` was throwing an exception. The version I use in this patch works locally; of course I am not entirely sure if it also works in deployments. But the exception shown in #994 happened in Arrow Conbench and I could reproduce this locally; so it's likely that this patch repairs the lookup for all of our environments. 