### PR TITLE
metrics: emit endpoint, not path

### DIFF
--- a/conbench/metrics.py
+++ b/conbench/metrics.py
@@ -96,6 +96,11 @@ def decorate_flask_app_with_metrics(app) -> None:
     _inspect_prom_multiproc_dir()
     GunicornInternalPrometheusMetrics(
         app=app,
+        # See https://github.com/conbench/conbench/issues/1006
+        # We will have to maybe iterate on those endpoint names,
+        # and maybe, just maybe, add _some_ URL paths back when we understand
+        # that we need them.
+        group_by="endpoint",
         # Set bucket boundaries (unit: seconds) for tracking the distribution
         # of HTTP request processing durations (Prometheus metric of type
         # histogram). The default histogram buckets are not so useful for


### PR DESCRIPTION
This resolves #1006 for now. It's a bit of a drastic move, but I think a really important one. We might lose quite a bit of granularity/insight, but in this case I think it's better to work from coarse-grained to fine-grained, gradually, as we learn.

Note: we always have the access log showing specific URL paths + request duration times.