### PR TITLE
kube-prometheus: use pvcs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,10 +288,12 @@ set-build-info:
 # default jsonnetfile.json file is the outcome of `jb init`. Note2: in BK the
 # --user $$(id -u):$$(id -g) didn't help to achieve useful file permissions in
 # the host filesystem. Resort to doing a brute-force `chmod -R 777 *'` in the
-# container, while writing into a dir on the host.
+# container, while writing into a dir on the host. kudos to kudos to "5.
+# Selective Deletion of Certain Lines / 68. Print all lines in the file except
+# a section between two regular expressions." using a "range match" (not the
+# substitute command!).
 .PHONY: jsonnet-kube-prom-manifests
 jsonnet-kube-prom-manifests:
-#	rm -rf _kpbuild
 	mkdir -p _kpbuild && cd _kpbuild  && mkdir -p cb-kube-prometheus
 	cd _kpbuild/cb-kube-prometheus && echo '{"version": 1, "dependencies": [], "legacyImports": true}' > jsonnetfile.json
 	cd _kpbuild/cb-kube-prometheus && \
@@ -307,6 +309,7 @@ jsonnet-kube-prom-manifests:
 		else \
 			echo "MUTATE_JSONNET_FILE_FOR_MINIKUBE set, mutate JSONNET"; \
 			sed -i.bak 's|// "auth.anonymous"|"auth.anonymous"|g' _kpbuild/cb-kube-prometheus/conbench-flavor.jsonnet; \
+			sed -i.bak '/\/\/ <comment-used-by-ci: pvc-start>/,/\/\/ <comment-used-by-ci: pvc-end>/d' _kpbuild/cb-kube-prometheus/conbench-flavor.jsonnet; \
 			cat _kpbuild/cb-kube-prometheus/conbench-flavor.jsonnet; \
 		fi
 	@if [ -z "$${PROM_REMOTE_WRITE_ENDPOINT_URL:=}" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,7 @@ jsonnet-kube-prom-manifests:
 		else \
 			echo "MUTATE_JSONNET_FILE_FOR_MINIKUBE set, mutate JSONNET"; \
 			sed -i.bak 's|// "auth.anonymous"|"auth.anonymous"|g' _kpbuild/cb-kube-prometheus/conbench-flavor.jsonnet; \
-			sed -i.bak '/\/\/ <comment-used-by-ci: pvc-start>/,/\/\/ <comment-used-by-ci: pvc-end>/d' _kpbuild/cb-kube-prometheus/conbench-flavor.jsonnet; \
+			sed -i.bak '\|// <comment-used-by-ci: pvc-start>|,\|// <comment-used-by-ci: pvc-end>|d' _kpbuild/cb-kube-prometheus/conbench-flavor.jsonnet; \
 			cat _kpbuild/cb-kube-prometheus/conbench-flavor.jsonnet; \
 		fi
 	@if [ -z "$${PROM_REMOTE_WRITE_ENDPOINT_URL:=}" ]; then \


### PR DESCRIPTION
So little code. That does so much. This is for #1034.

Not sure what I find more fascinating, the little `sed` expression in here or that this introduces a `fundisk-elb-backed` storage class in vd-2 from which the Prometheus StatefulSet pods can request and obtain persistent volumes. This is (has to be) ephemeral, but works beautifully:
```
± kubectl get pv
NAME                CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                           STORAGECLASS         REASON   AGE
local-pv-a9e4d628   19Gi       RWO            Retain           Bound    monitoring/prometheus-k8s-db-prometheus-k8s-1   fundisk-elb-backed            17m
local-pv-bfe2fe30   9915Mi     RWO            Retain           Bound    monitoring/prometheus-k8s-db-prometheus-k8s-0   fundisk-elb-backed            17m
```

A buffer on steroids, that can truly do some best-effort data-forwarding.

About the sed expression; this is not a substitute command, but a range match or [address range](https://www.gnu.org/software/sed/manual/html_node/Range-Addresses.html).

See
- https://catonmat.net/sed-one-liners-explained-part-two, recipe 67 for intro
- https://catonmat.net/sed-one-liners-explained-part-three, recipe `5. Selective deletion of certain lines`
- combined with the idea that a different regex delimiter can be used (when [escaped](https://backreference.org/2010/02/20/using-different-delimiters-in-sed/index.html#comment-25209) when _not_ using the substitute command)

