### PR TITLE
api/benchmarks: deprecate z-scores

### DIFF
--- a/conbench/api/results.py
+++ b/conbench/api/results.py
@@ -16,7 +16,6 @@ from ..entities.benchmark_result import (
     BenchmarkResultSerializer,
 )
 from ..entities.case import Case
-from ..entities.history import set_z_scores
 
 log = logging.getLogger(__name__)
 
@@ -44,9 +43,7 @@ class BenchmarkEntityAPI(ApiEndpoint, BenchmarkValidationMixin):
         description: |
             Get a specific benchmark result.
 
-            This includes on-the-fly analysis with the lookback z-score
-            change detection method, and the corresponding result is emitted
-            as part of the benchmark result object.
+            The "z_score" key in the response is deprecated and only returns null.
         responses:
             "200": "BenchmarkEntity"
             "401": "401"
@@ -60,7 +57,6 @@ class BenchmarkEntityAPI(ApiEndpoint, BenchmarkValidationMixin):
           - Benchmarks
         """
         benchmark_result = self._get(benchmark_id)
-        set_z_scores([benchmark_result])
         return self.serializer.one.dump(benchmark_result)
 
     @flask_login.login_required
@@ -87,7 +83,6 @@ class BenchmarkEntityAPI(ApiEndpoint, BenchmarkValidationMixin):
         benchmark_result = self._get(benchmark_id)
         data = self.validate_benchmark(self.schema.update)
         benchmark_result.update(data)
-        set_z_scores([benchmark_result])
         return self.serializer.one.dump(benchmark_result)
 
     @flask_login.login_required
@@ -289,8 +284,6 @@ class BenchmarkListAPI(ApiEndpoint, BenchmarkValidationMixin):
         # Note(JP): in the future this will also raise further validation
         # errors that are to be exposed via a 400 response to the HTTP client
         benchmark_result = BenchmarkResult.create(data)
-
-        set_z_scores([benchmark_result])
 
         return self.response_201_created(self.serializer.one.dump(benchmark_result))
 

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -1391,7 +1391,7 @@
                 "tags": ["Benchmarks"],
             },
             "get": {
-                "description": "Get a specific benchmark result.\n\nThis includes on-the-fly analysis with the lookback z-score\nchange detection method, and the corresponding result is emitted\nas part of the benchmark result object.\n",
+                "description": 'Get a specific benchmark result.\n\nThe "z_score" key in the response is deprecated and only returns null.\n',
                 "parameters": [
                     {
                         "in": "path",

--- a/conbench/tests/api/test_results.py
+++ b/conbench/tests/api/test_results.py
@@ -84,8 +84,8 @@ class TestBenchmarkGet(_asserts.GetEnforcer):
                 "q3": 2.5,
                 "stdev": 1.0,
                 "times": [],
-                "z_score": -abs(_fixtures.Z_SCORE_DOWN),
-                "z_regression": True,
+                "z_score": None,
+                "z_regression": False,
                 "unit": "i/s",
             }
         )
@@ -131,8 +131,8 @@ class TestBenchmarkGet(_asserts.GetEnforcer):
                 "q3": 25.0,
                 "stdev": 10.0,
                 "times": [],
-                "z_score": -abs(_fixtures.Z_SCORE_UP),
-                "z_regression": True,
+                "z_score": None,
+                "z_regression": False,
             }
         )
 
@@ -177,8 +177,8 @@ class TestBenchmarkGet(_asserts.GetEnforcer):
                 "q3": 25.0,
                 "stdev": 10.0,
                 "times": [],
-                "z_score": abs(_fixtures.Z_SCORE_UP),
-                "z_improvement": True,
+                "z_score": None,
+                "z_improvement": False,
                 "unit": "i/s",
             }
         )
@@ -224,8 +224,8 @@ class TestBenchmarkGet(_asserts.GetEnforcer):
                 "q3": 2.5,
                 "stdev": 1.0,
                 "times": [],
-                "z_score": abs(_fixtures.Z_SCORE_DOWN),
-                "z_improvement": True,
+                "z_score": None,
+                "z_improvement": False,
             }
         )
 


### PR DESCRIPTION
This PR is one step to address #1001 by removing the functionality of the `z_score` key returned in `/api/benchmarks` payloads. While it doesn't go as far as removing the keys, it will unblock my work on #1029.