### PR TITLE
legacy runner: Validate `name` == `tags["name"]` if both set

### DIFF
--- a/conbench/runner.py
+++ b/conbench/runner.py
@@ -246,7 +246,8 @@ class Conbench(Connection, MixinPython, MixinR):
             output,
         ) = self._init(kwargs)
 
-        tags["name"] = name
+        if (tags.get("name") is None) or (tags["name"] == ""):
+            tags["name"] = name
 
         batch_id = options.get("batch_id")
         if not batch_id:

--- a/conbench/runner.py
+++ b/conbench/runner.py
@@ -246,8 +246,12 @@ class Conbench(Connection, MixinPython, MixinR):
             output,
         ) = self._init(kwargs)
 
-        if (tags.get("name") is None) or (tags["name"] == ""):
-            tags["name"] = name
+        if (tags.get("name") is not None) and (name == tags["name"]):
+            raise ValueError(
+                f"`name` and `tags[\"name\"] are both supplied and do not match: {name=} != {tags['name']=}"
+            )
+
+        tags["name"] = name
 
         batch_id = options.get("batch_id")
         if not batch_id:


### PR DESCRIPTION
Closes #1042 by only setting `tags["name"]` in the legacy runner if there is not already something there. If it's already set, ~that now takes precedence~ it checks if they match and error if not. This should lead to less confusion and surprise when the `name` param differs from `tags["name"]` (they shouldn't, but people do things) and metadata changes before posting.