### PR TITLE
api/compare: respect baseline entity when doing lookback z-score analysis

### DIFF
--- a/conbench/api/compare.py
+++ b/conbench/api/compare.py
@@ -135,7 +135,13 @@ class CompareEntityEndpoint(ApiEndpoint, CompareMixin):
 
         baseline_benchmark_result = self._get(baseline_id)
         contender_benchmark_result = self._get(contender_id)
-        set_z_scores([baseline_benchmark_result, contender_benchmark_result])
+        set_z_scores(
+            benchmark_results=[contender_benchmark_result],
+            baseline_commit=baseline_benchmark_result.run.commit,
+        )
+        # TODO: remove baseline-z-score-related keys from this endpoint
+        baseline_benchmark_result.z_score = None
+
         set_display_case_permutation(baseline_benchmark_result)
         set_display_case_permutation(contender_benchmark_result)
         set_display_benchmark_name(baseline_benchmark_result)
@@ -189,7 +195,12 @@ class CompareListEndpoint(ApiEndpoint, CompareMixin):
 
         baselines = self._get(baseline_id)
         contenders = self._get(contender_id)
-        set_z_scores(baselines + contenders)
+        set_z_scores(
+            benchmark_results=contenders, baseline_commit=baselines[0].run.commit
+        )
+        # TODO: remove baseline-z-score-related keys from this endpoint
+        for baseline in baselines:
+            baseline.z_score = None
 
         baseline_items, contender_items = [], []
         for benchmark_result in baselines:

--- a/conbench/tests/api/test_compare.py
+++ b/conbench/tests/api/test_compare.py
@@ -322,6 +322,7 @@ class TestCompareBatchesGet(_asserts.GetEnforcer):
 
     def _create(self, verbose=False, run_id=None, batch_id=None):
         batch_id = batch_id if batch_id is not None else _uuid()
+        run_id = run_id if run_id is not None else _uuid()
         benchmark_result_1 = _fixtures.benchmark_result(
             name="read",
             run_id=run_id,

--- a/conbench/tests/api/test_compare.py
+++ b/conbench/tests/api/test_compare.py
@@ -315,6 +315,30 @@ class TestCompareBenchmarksGet(_asserts.GetEnforcer):
         response = client.get("/api/compare/benchmarks/foo...bar/")
         self.assert_404_not_found(response)
 
+    @pytest.mark.parametrize(
+        ["baseline_result_id", "expected_z_score"],
+        [
+            # result on the fork point commit
+            (5, -2.1857497724635935),
+            # result on the parent commit
+            (6, -2.8246140882627757),
+            # result on the head commit of the default branch
+            (8, 0.12045310863100521),
+        ],
+    )
+    def test_compare_different_baselines(
+        self, client, baseline_result_id, expected_z_score
+    ):
+        self.authenticate(client)
+        _, benchmark_results = _fixtures.gen_fake_data()
+        contender = benchmark_results[7]
+        baseline = benchmark_results[baseline_result_id]
+        response = client.get(
+            f"/api/compare/benchmarks/{baseline.id}...{contender.id}/"
+        )
+        assert response.status_code == 200, response.status_code
+        assert response.json["contender_z_score"] == expected_z_score
+
 
 class TestCompareBatchesGet(_asserts.GetEnforcer):
     url = "/api/compare/batches/{}/"
@@ -558,6 +582,28 @@ class TestCompareRunsGet(_asserts.GetEnforcer):
         self.authenticate(client)
         response = client.get("/api/compare/runs/foo...bar/")
         self.assert_404_not_found(response)
+
+    @pytest.mark.parametrize(
+        ["baseline_result_id", "expected_z_score"],
+        [
+            # result on the fork point commit
+            (5, -2.1857497724635935),
+            # result on the parent commit
+            (6, -2.8246140882627757),
+            # result on the head commit of the default branch
+            (8, 0.12045310863100521),
+        ],
+    )
+    def test_compare_different_baselines(
+        self, client, baseline_result_id, expected_z_score
+    ):
+        self.authenticate(client)
+        _, benchmark_results = _fixtures.gen_fake_data()
+        contender = benchmark_results[7].run_id
+        baseline = benchmark_results[baseline_result_id].run_id
+        response = client.get(f"/api/compare/runs/{baseline}...{contender}/")
+        assert response.status_code == 200, response.status_code
+        assert response.json[0]["contender_z_score"] == expected_z_score
 
 
 class TestCompareCommitsGet(_asserts.GetEnforcer):


### PR DESCRIPTION
Closes #1029. 

This PR ensures that the z-scores returned from the `/api/compare` endpoints respect the baseline entity that was requested.

It also deprecates populating `baseline_z_score` in those responses, because that's unnecessary overhead (and it's unclear what the baseline of the baseline is).