### PR TITLE
api/runs: ensure baseline run is always on default branch

### DIFF
--- a/conbench/entities/compare.py
+++ b/conbench/entities/compare.py
@@ -8,7 +8,7 @@ from ..entities.run import Run
 class _Serializer(EntitySerializer):
     def _dump(self, commits):
         def _run(contender):
-            baseline = contender.get_baseline_run()
+            baseline = contender.get_default_baseline_run()
             baseline_url, contender_url, compare_url = None, None, None
             baseline_timestamp, contender_timestamp = None, None
 

--- a/conbench/tests/entities/test_run.py
+++ b/conbench/tests/entities/test_run.py
@@ -4,33 +4,19 @@ from ..api import _fixtures
 
 
 @pytest.mark.parametrize(
-    ["on_default_branch", "give_case_and_context", "expected_baseline_run_indexes"],
+    ["give_case_and_context", "expected_baseline_run_indexes"],
     [
         (
-            False,
-            False,
-            [None, 0, 1, 2, 1, 1, 5, 6, 5, 5, None, None, None, None, None, None, 5],
-        ),
-        (
-            False,
-            True,
-            [None, 0, 1, 2, 1, 1, 5, 6, 5, 5, None, None, None, None, None, None, 5],
-        ),
-        (
-            True,
             False,
             [None, 0, 1, 1, 1, 1, 5, 5, 5, 5, None, None, None, None, None, None, 5],
         ),
         (
-            True,
             True,
             [None, 0, 1, 1, 1, 1, 5, 5, 5, 5, None, None, None, None, None, None, 5],
         ),
     ],
 )
-def test_get_baseline_run(
-    on_default_branch, give_case_and_context, expected_baseline_run_indexes
-):
+def test_get_default_baseline_run(give_case_and_context, expected_baseline_run_indexes):
     commits, benchmark_results = _fixtures.gen_fake_data()
     assert len(benchmark_results) == len(
         expected_baseline_run_indexes
@@ -42,8 +28,8 @@ def test_get_baseline_run(
         case_id = benchmark_result.case_id if give_case_and_context else None
         context_id = benchmark_result.context_id if give_case_and_context else None
 
-        actual_baseline_run = benchmark_result.run.get_baseline_run(
-            on_default_branch=on_default_branch, case_id=case_id, context_id=context_id
+        actual_baseline_run = benchmark_result.run.get_default_baseline_run(
+            case_id=case_id, context_id=context_id
         )
         if expected_baseline_run_ix is None:
             assert actual_baseline_run is None
@@ -60,8 +46,8 @@ def test_get_baseline_run(
         commit=commits["44444"],
     )
     assert (
-        benchmark_result.run.get_baseline_run(
-            on_default_branch=on_default_branch, case_id=case_id, context_id=context_id
+        benchmark_result.run.get_default_baseline_run(
+            case_id=case_id, context_id=context_id
         )
         == new_one.run
     )


### PR DESCRIPTION
Closes #992. After this patch, all baseline runs returned from `/api/runs` should be on the default branch.