### PR TITLE
app: HTTPException handler: emit additional properties in JSON doc

### DIFF
--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -19,9 +19,6 @@ import logging
 import os
 from typing import TYPE_CHECKING
 
-import werkzeug
-import werkzeug.exceptions
-
 import conbench.logger
 
 try:
@@ -38,6 +35,9 @@ if TYPE_CHECKING:
     # Yes one could do `-> "flask.Response"`` but then
     # https://github.com/PyCQA/pyflakes/issues/340  ¯\_(ツ)_/¯
     import flask
+    import werkzeug
+    import werkzeug.exceptions
+
 
 # Pre-configure logging before reading user-given configuration.
 conbench.logger.setup(level_stderr="DEBUG", level_file=None, level_sqlalchemy="WARNING")

--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -93,6 +93,7 @@ def create_application(config) -> "flask.Flask":
 def _init_flask_application(app):
     import flask
     import flask_swagger_ui
+    import werkzeug.exceptions
 
     from .api import api
     from .app import app as blueprint_app

--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -17,6 +17,10 @@ import importlib.metadata as importlib_metadata
 import json
 import logging
 import os
+from typing import TYPE_CHECKING
+
+import werkzeug
+import werkzeug.exceptions
 
 import conbench.logger
 
@@ -29,12 +33,18 @@ except Exception:
 del importlib_metadata
 
 
+if TYPE_CHECKING:
+    # https://stackoverflow.com/a/39757388/145400
+    # Yes one could do `-> "flask.Response"`` but then
+    # https://github.com/PyCQA/pyflakes/issues/340  ¯\_(ツ)_/¯
+    import flask
+
 # Pre-configure logging before reading user-given configuration.
 conbench.logger.setup(level_stderr="DEBUG", level_file=None, level_sqlalchemy="WARNING")
 log = logging.getLogger(__name__)
 
 
-def create_application(config):
+def create_application(config) -> "flask.Flask":
     import flask as f
 
     import conbench.metrics
@@ -83,7 +93,6 @@ def create_application(config):
 def _init_flask_application(app):
     import flask
     import flask_swagger_ui
-    import werkzeug.exceptions
 
     from .api import api
     from .app import app as blueprint_app
@@ -165,16 +174,34 @@ def _init_api_docs(application):
             spec.path(view=view_fn)
 
 
-def _json_http_errors(e):
+def _json_http_errors(
+    exc: werkzeug.exceptions.HTTPException,
+) -> werkzeug.wrappers.Response:
+    """
+    Turn an HTTPException object into a JSON response where exception detail
+    is emitted as part of the JSON document.
+    """
+    # Note(JP): I understand this is against cyclic imports, but having this as
+    # part of requently called error handler (even if the import machinery is
+    # fast and cached) is a code smell -- let's see about this.
     import flask as f
 
-    response = e.get_response()
-    data = {"code": e.code, "name": e.name}
-    if e.code == 400:
-        data["description"] = e.description
-    response.data = f.json.dumps(data)
-    response.content_type = "application/json"
-    return response
+    data = {"code": exc.code, "name": exc.name}
+
+    # When for example calling flask.abort(404, foo="bar") then the
+    # resulting HTTPException object has a property "foo".
+    for attr in vars(exc):
+        # denylist or allowlist? Hm.
+        if attr not in ("response", "www_authenticate"):
+            data[attr] = getattr(exc, attr)
+
+    # documented with "Get a response object. If one was passed to the
+    # exception it’s returned directly.""
+    resp = exc.get_response()
+    resp.data = f.json.dumps(data)
+    resp.content_type = "application/json"
+
+    return resp
 
 
 def dict_or_objattrs_to_nonsensitive_string(obj):

--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -174,9 +174,7 @@ def _init_api_docs(application):
             spec.path(view=view_fn)
 
 
-def _json_http_errors(
-    exc: werkzeug.exceptions.HTTPException,
-) -> werkzeug.wrappers.Response:
+def _json_http_errors(exc) -> werkzeug.wrappers.Response:
     """
     Turn an HTTPException object into a JSON response where exception detail
     is emitted as part of the JSON document.

--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -174,7 +174,7 @@ def _init_api_docs(application):
             spec.path(view=view_fn)
 
 
-def _json_http_errors(exc) -> werkzeug.wrappers.Response:
+def _json_http_errors(exc) -> "werkzeug.wrappers.Response":
     """
     Turn an HTTPException object into a JSON response where exception detail
     is emitted as part of the JSON document.

--- a/conbench/api/_errors.py
+++ b/conbench/api/_errors.py
@@ -4,6 +4,11 @@ from ..api._docs import spec
 
 
 class ErrorSchema(marshmallow.Schema):
+    # Allow for additional properties:
+    # https://marshmallow.readthedocs.io/en/stable/quickstart.html#handling-unknown-fields
+    class Meta:
+        unknown = marshmallow.INCLUDE
+
     code = marshmallow.fields.Int(
         metadata={"description": "HTTP error code"}, required=True
     )

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -86,8 +86,8 @@
         {% if messages %}
             <!-- Categories: success (green), info (blue), warning (yellow), danger (red) -->
             {% for category, message in messages %}
-            <div class="alert alert-{{ category }}" role="alert">
-                <p class="fs-5"><i class="bi bi-exclamation-diamond-fill"></i> {{ message }}</p>
+            <div class="fs-5 alert alert-{{ category }} text-center" role="alert">
+                <i class="bi bi-info-circle"></i> {{ message }}
             </div>
             {% endfor %}
         {% endif %}

--- a/conbench/tests/api/_asserts.py
+++ b/conbench/tests/api/_asserts.py
@@ -66,8 +66,9 @@ class ApiEndpointTest:
 
     def assert_404_not_found(self, r):
         assert r.status_code == 404, r.status_code
-        assert r.content_type == "application/json", r.content_type
-        assert r.json == {"code": 404, "name": "Not Found"}, r.json
+        assert r.content_type == "application/json", r.content_type + " " + r.text
+        assert r.json["code"] == 404
+        assert r.json["name"] == "Not Found"
         errors = ErrorSchema().validate(r.json)
         assert errors == {}, errors
 

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -1136,6 +1136,7 @@
                 "type": "object",
             },
             "Error": {
+                "additionalProperties": True,
                 "properties": {
                     "code": {"description": "HTTP error code", "type": "integer"},
                     "name": {"description": "HTTP error name", "type": "string"},
@@ -1144,6 +1145,7 @@
                 "type": "object",
             },
             "ErrorBadRequest": {
+                "additionalProperties": True,
                 "properties": {
                     "code": {"description": "HTTP error code", "type": "integer"},
                     "description": {


### PR DESCRIPTION
Mainly for #1053.

This allows for doing for example
```
            f.abort(
                404,
                description=f"no benchmark results found for batch ID: '{batch_id}'",
            )
```

which is a valuable thing to do towards addressing #1038.
