### PR TITLE
ui: add error page template, misc changes

### DIFF
--- a/conbench/api/_resp.py
+++ b/conbench/api/_resp.py
@@ -1,0 +1,22 @@
+import flask
+
+
+def resp400(description: str) -> flask.Response:
+    """
+    Utility for canonical generation of 400 Bad Request response with an
+    error description. Define elsewhere once used elsewhere.
+    """
+    return flask.make_response(
+        # This puts a JSON body into the response with a JSON object with one
+        # key, the description
+        flask.jsonify(description=description),
+        400,
+    )
+
+
+def json_response_for_byte_sequence(data: bytes, status_code: int) -> flask.Response:
+    # Note(JP): it's documented that a byte sequence can be passed in:
+    # https://flask.palletsprojects.com/en/2.2.x/api/#flask.Flask.make_response
+    return flask.make_response(
+        (data, status_code, {"content-type": "application/json"})
+    )

--- a/conbench/api/results.py
+++ b/conbench/api/results.py
@@ -16,6 +16,7 @@ from ..entities.benchmark_result import (
     BenchmarkResultSerializer,
 )
 from ..entities.case import Case
+from ._resp import json_response_for_byte_sequence, resp400
 
 log = logging.getLogger(__name__)
 
@@ -112,7 +113,7 @@ class BenchmarkListAPI(ApiEndpoint, BenchmarkValidationMixin):
     schema = BenchmarkResultFacadeSchema()
 
     @maybe_login_required
-    def get(self):
+    def get(self) -> f.Response:
         """
         ---
         description: |
@@ -198,7 +199,7 @@ class BenchmarkListAPI(ApiEndpoint, BenchmarkValidationMixin):
             option=orjson.OPT_INDENT_2,
         )
 
-        return make_json_response(jsonbytes, 200)
+        return json_response_for_byte_sequence(jsonbytes, 200)
 
     @flask_login.login_required
     def post(self) -> f.Response:
@@ -286,25 +287,6 @@ class BenchmarkListAPI(ApiEndpoint, BenchmarkValidationMixin):
         benchmark_result = BenchmarkResult.create(data)
 
         return self.response_201_created(self.serializer.one.dump(benchmark_result))
-
-
-def make_json_response(data: bytes, status_code: int) -> f.Response:
-    # Note(JP): it's documented that a byte sequence can be passed in:
-    # https://flask.palletsprojects.com/en/2.2.x/api/#flask.Flask.make_response
-    return f.make_response((data, status_code, {"content-type": "application/json"}))
-
-
-def resp400(description: str) -> f.Response:
-    """
-    Utility for canonical generation of 400 Bad Request response with an
-    error description. Define elsewhere once used elsewhere.
-    """
-    return f.make_response(
-        # This puts a JSON body into the response with a JSON object with one
-        # key, the description
-        f.jsonify(description=description),
-        400,
-    )
 
 
 benchmark_entity_view = BenchmarkEntityAPI.as_view("benchmark")

--- a/conbench/app/_endpoint.py
+++ b/conbench/app/_endpoint.py
@@ -11,6 +11,8 @@ import werkzeug
 from .. import __version__
 from ..buildinfo import BUILD_INFO
 
+from ..config import Config
+
 log = logging.getLogger(__name__)
 
 
@@ -140,8 +142,24 @@ class AppEndpoint(flask.views.MethodView):
     def render_template(self, template, **kwargs):
         # inject/overwrite
         kwargs["version_string_footer"] = VERSION_STRING_FOOTER
-
         return f.render_template(template, **kwargs)
+
+    def error_page(self, msg: str, alert_level="danger") -> str:
+        """
+        Generate HTML text which shows an error page, presenting an error
+        message.
+
+        This is OK to be delivered in a status-200 HTTP response for now.
+        """
+        # add more as desired
+        assert alert_level in ("info", "danger", "primary", "warning")
+        return f.render_template(
+            "error.html",
+            error_message=msg,
+            application=Config.APPLICATION_NAME,
+            title=self.title,
+            alert_level=alert_level,
+        )
 
     def flash(self, *args):
         return f.flash(*args)

--- a/conbench/app/_endpoint.py
+++ b/conbench/app/_endpoint.py
@@ -10,7 +10,6 @@ import werkzeug
 
 from .. import __version__
 from ..buildinfo import BUILD_INFO
-
 from ..config import Config
 
 log = logging.getLogger(__name__)

--- a/conbench/app/_endpoint.py
+++ b/conbench/app/_endpoint.py
@@ -156,7 +156,7 @@ class AppEndpoint(flask.views.MethodView):
             "error.html",
             error_message=msg,
             application=Config.APPLICATION_NAME,
-            title=self.title,
+            title=self.title,  # type: ignore
             alert_level=alert_level,
         )
 

--- a/conbench/templates/error.html
+++ b/conbench/templates/error.html
@@ -1,0 +1,8 @@
+{% extends "app.html" %}
+{% block app_content %}
+
+<div class="fs-5 alert alert-{{ alert_level }}" role="alert">
+{{ error_message }}
+</div>
+
+{% endblock %}

--- a/conbench/tests/api/_asserts.py
+++ b/conbench/tests/api/_asserts.py
@@ -69,6 +69,7 @@ class ApiEndpointTest:
         assert r.content_type == "application/json", r.content_type + " " + r.text
         assert r.json["code"] == 404
         assert r.json["name"] == "Not Found"
+        # allow for additional properties
         errors = ErrorSchema().validate(r.json)
         assert errors == {}, errors
 

--- a/conbench/tests/populate_local_conbench.py
+++ b/conbench/tests/populate_local_conbench.py
@@ -357,7 +357,7 @@ def create_benchmarks_data():
         for hardware_type in hardware_types:
             for benchmark_language in benchmark_languages:
                 for benchmark_name in benchmark_names:
-                    run_id = f"{hardware_type}{i+1}"
+                    run_id = f"run-on-{hardware_type}-{i+1}"
                     commit, branch = commits[i], branches[i]
                     mean, reason = means[i], reasons[i]
                     timestamp = datetime.datetime.now() + datetime.timedelta(hours=i)


### PR DESCRIPTION
- Add a new HTML template for displaying error/info messages. For https://github.com/conbench/conbench/issues/1038.
- Add `api/_resp.py` for helpers to generate responses.
- Add more type annotations.
- Tweak generated run names.