### PR TITLE
app: gunicorn: central cfg, single-process N threads

### DIFF
--- a/conbench/gunicorn-conf.py
+++ b/conbench/gunicorn-conf.py
@@ -43,3 +43,43 @@ from prometheus_flask_exporter.multiprocess import GunicornInternalPrometheusMet
 
 def child_exit(server, worker):
     GunicornInternalPrometheusMetrics.mark_process_dead_on_child_exit(worker.pid)
+
+
+# Canonical gunicorn config below this line.
+# https://docs.gunicorn.org/en/stable/settings.html#config-file
+
+
+bind = ["0.0.0.0:5000"]
+
+wsgi_app = "conbench:application"
+
+# Canonical format, plus response generation duration in seconds.
+access_log_format = (
+    '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" (%(L)s s)'
+)
+
+errorlog = "-"  # emit to stderr
+accesslog = "-"  # emit to stdout
+loglevel = "info"  # d efault
+
+# requires setprocname
+# proc_name = 'conbench-gunicorn'
+
+# Reduce connection backlog from default (2048)
+backlog = 300
+
+# Run gunicorn as a single-process N thread model (these are real threads,
+# based on CPython threading.Thread, using Unix pthreads). Assume that C copies
+# of this are created by higher-level orchestration (so that more than one CPU
+# core is after all serving requests).
+# https://github.com/conbench/conbench/issues/1018
+workers = 1
+threads = 10
+
+# This is the worker timeout; an observer process will terminate the observed
+# worker process if the observed process hasn't responded within that
+# timeframe. This was more relevant at times when we ran more than one worker
+# process per gunicorn, and a single HTTP request could render a single process
+# occupied. Keep a large value for now, for the case where all threads in the
+# process process genuine requests (which all take a while to respond to)
+timeout = 120

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,20 +3,8 @@
 #     docker compose -f docker-compose.yml -f docker-compose.dev.yml
 services:
   app:
-    # Add --reload to command, to reload on file change. Remove --preload
-    # to make this more robust
-    command: [
-      "gunicorn",
-      "-c", "conbench/gunicorn-conf.py",
-      "-b", "0.0.0.0:5000",
-      "-w", "2",
-      "-t", "120",
-      "conbench:application",
-      "--access-logfile=-",
-      "--access-logformat", '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" (%(L)s s)',
-      "--error-logfile=-",
-      "--reload"
-      ]
+    # Add --reload to command, to reload on file change.
+    command: ["gunicorn", "-c", "conbench/gunicorn-conf.py", "--reload"]
     volumes:
       # Left-hand path: relative to this compose file. Mount the directory
       # that this compose file resided in as `/app` into the container.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,17 +6,7 @@ services:
       # Note that currently this Dockerfile defines the image that' used for
       # Conbench production environments.
       dockerfile: Dockerfile
-    command: [
-          "gunicorn",
-          "-c", "conbench/gunicorn-conf.py",
-          "-b", "0.0.0.0:5000",
-          "-w", "5",
-          "-t", "120",
-          "conbench:application",
-          "--access-logfile=-",
-          "--access-logformat", '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" (%(L)s s)',
-          "--error-logfile=-"
-          ]
+    command: ["gunicorn", "-c", "conbench/gunicorn-conf.py"]
     ports:
       # When using the default value `127.0.0.1::5000` (two colons) then the
       # container-internal port 5000 will be dynamically mapped to a free port

--- a/k8s/conbench-deployment.templ.yml
+++ b/k8s/conbench-deployment.templ.yml
@@ -52,18 +52,7 @@ spec:
         # system by allowing for more containers (replicas). Having one process
         # per container also simplifies log output, removes the preload topic
         # and prom metrics coordination topic from the picture.
-        command: [
-          "gunicorn", "-b", "0.0.0.0:5000",
-          "-w", "5",
-          "-t", "120",
-          "conbench:application",
-          "--access-logfile=-",
-          # Add L specifier to access log, to log request processing duration. Also see
-          # https://github.com/conbench/conbench/issues/810
-          "--access-logformat", '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" (%(L)s s)',
-          "--error-logfile=-",
-          "--preload"
-          ]
+        command: ["gunicorn", "-c", "conbench/gunicorn-conf.py"]
         imagePullPolicy: "Always"
         ports:
           - name: gunicorn-port


### PR DESCRIPTION
See issue #1018.

One aspect that's maybe buried in #1018 and related discussion: this cuts the memory footprint of Conbench by a significant amount (let's say factor ~5, for simplicity). This will become relevant in the context of #1036.

This also centralizes more of the gunicorn config into a single place, for less duplication (see diff).

New process hiearchy during `make run-app-dev`:
```
root     2867775  0.0  0.0 720172 10240 ?        Sl   11:43   0:00 /usr/bin/containerd-shim-runc-v2 -namespace moby -id be174a1b07d567862bdb7c630686f73c288eea86b970089c11e5ec4de07f2545 -address /run/containerd/containerd.sock
root     2867802  6.2  0.1  44116 37240 ?        Ss   11:43   0:00  \_ /usr/local/bin/python /usr/local/bin/gunicorn -c conbench/gunicorn-conf.py --reload
root     2867871 54.5  0.4 970916 135624 ?       Sl   11:43   0:02      \_ /usr/local/bin/python /usr/local/bin/gunicorn -c conbench/gunicorn-conf.py --reload
```

This shows one observing gunicorn process, and one observed worker process. Good.