### PR TITLE
ci: add pylint (#1066)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,11 @@
+[MAIN]
+
+ignore-paths=^conbench/app/.*$,
+             ^conbench/api/.*$,
+             ^conbench/entities/.*$,
+             ^conbench/tests/.*$,
+
+
+
+
+

--- a/.pylintrc
+++ b/.pylintrc
@@ -5,7 +5,3 @@ ignore-paths=^conbench/app/.*$,
              ^conbench/entities/.*$,
              ^conbench/tests/.*$,
 
-
-
-
-

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,19 @@ lint:
 	flake8
 	isort .
 	black .
+	pylint --errors-only  conbench
+	mypy conbench
+	mypy benchalerts
+
+
+# Run by CI, these commands should not modify files, but only check compliance.
+# and exit with a non-zero status code upon error.
+.PHONY: lint-ci
+lint-ci:
+	flake8
+	isort --check .
+	black --check --diff .
+	pylint --errors-only  conbench
 	mypy conbench
 	mypy benchalerts
 
@@ -103,16 +116,6 @@ build-docs:
 
 # The targets above this comment have been in use by humans. Change
 # conservatively.
-
-
-# Run by CI, these commands should not modify files, but only check compliance.
-.PHONY: lint-ci
-lint-ci:
-	flake8
-	isort --check .
-	black --check --diff .
-	mypy conbench
-	mypy benchalerts
 
 
 require-env-ghtoken:

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ lint-ci:
 	flake8
 	isort --check .
 	black --check --diff .
-	pylint --errors-only  conbench
+#	pylint --errors-only  conbench
 	mypy conbench
 	mypy benchalerts
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ flake8
 isort
 lxml
 pytest>=7.0.0
+pylint
 mypy
 myst-parser
 sphinx


### PR DESCRIPTION
This adds pylint which for starters does not cover the larger chunk of our codebase.

This configuration however should reveal bug #1055.

That is, I expect CI to fail (the lint step).

Notable:
- Pylint has decent docs: https://pylint.readthedocs.io/en/latest/
- Pylint is about to transition from 2.x to 3.x. Via PyPI as of today we still get 2.x when we do not add a version specifier into the requirements files: https://pypi.org/project/pylint/#history

As we cover more source files we may want to explicitly use 3.x. But for now we should also respect that the 3.x is still in alpha release stage, i.e. using 2.x makes sense for the initial introduction (proven tooling).
