### PR TITLE
k8s: ALB config: add Host header criterion, modernize TLS redirect

### DIFF
--- a/.buildkite/utils.sh
+++ b/.buildkite/utils.sh
@@ -1,5 +1,22 @@
 #!/bin/bash
 
+# Location of the Conbench web application container image. Note: it seems like
+# FLASK_APP has a static value: "conbench". Maybe we should hard-code this to
+# "conbench-webapp" or something like that.
+export IMAGE_SPEC="${DOCKER_REGISTRY}/${FLASK_APP}:${BUILDKITE_COMMIT}"
+
+# This script assumes that secrets have been injected via environment. (`env`
+# file fetched from S3, and sourced automatically on the Buildkite runner
+# before executing this logic). That is, secrets are available here as values
+# of a specific set of 'well-known' environment variables. Not all of these
+# configuration parameters are secrets, thought. Non-sensitive parameter names:
+#
+# CONBENCH_INTENDED_BASE_URL (scheme and DNS name)
+# EKS_CLUSTER (the name of the EKS cluster to operate on)
+# APPLICATION_NAME (shows up in the UI of the deployed web app)
+# NAMESPACE (indicating the k8s namespace to deploy into)
+# ...
+
 build_and_push() {
   set -x
   make set-build-info
@@ -82,10 +99,6 @@ run_migrations() {
 deploy() {
   set -x
 
-  # Note: it seems like FLASK_APP is always just "conbench". Maybe we should
-  # hard-code this to "conbench-webapp", indicating that this is the
-  # web application's container image.
-  export IMAGE_SPEC="${DOCKER_REGISTRY}/${FLASK_APP}:${BUILDKITE_COMMIT}"
 
   # Note(JP): This runs as part of a BK pipeline and uses AWS credentials that
   # have the `--group system:masters --username admin` privilege, see:

--- a/.buildkite/utils.sh
+++ b/.buildkite/utils.sh
@@ -27,8 +27,10 @@ build_and_push() {
 }
 
 deploy_secrets_and_config() {
+
   aws eks --region us-east-2 update-kubeconfig --name ${EKS_CLUSTER}
   kubectl config set-context --current --namespace=${NAMESPACE}
+
   if [ -z "$GOOGLE_CLIENT_ID" ]; then
       cat conbench-secret.yml | sed "\
         s/{{DB_PASSWORD}}/$(echo -n $DB_PASSWORD | base64)/g;\
@@ -52,7 +54,6 @@ deploy_secrets_and_config() {
 
   fi
 
-
   cat conbench-config.yml | sed "\
         s|{{CONBENCH_INTENDED_BASE_URL}}|${CONBENCH_INTENDED_BASE_URL}|g; \
         s/{{APPLICATION_NAME}}/${APPLICATION_NAME}/g;\
@@ -67,8 +68,6 @@ deploy_secrets_and_config() {
 
 run_migrations() {
   set -x
-
-  export IMAGE_SPEC="${DOCKER_REGISTRY}/${FLASK_APP}:${BUILDKITE_COMMIT}"
 
   aws eks --region us-east-2 update-kubeconfig --name ${EKS_CLUSTER}
   kubectl config set-context --current --namespace=${NAMESPACE}

--- a/k8s/conbench-cloud-ingress.templ.yml
+++ b/k8s/conbench-cloud-ingress.templ.yml
@@ -16,15 +16,16 @@ metadata:
     # (also spread across multiple k8s namespaces) can configure the _same_ ALB
     # in AWS.
     alb.ingress.kubernetes.io/group.name: cb-alb-group
-    # allow for higher-prio config elsewhere, this can be important for path
-    # evaluation rules.
+    # Allow for higher-priority config elsewhere. This can be important for
+    # path evaluation rules that need to take precedence (injected in another
+    # namespace).
     alb.ingress.kubernetes.io/group.order: "9"
-    # Configure health check against Conbench containers
+    # Configure health check against Conbench containers.
     alb.ingress.kubernetes.io/healthcheck-protocol: HTTP
     alb.ingress.kubernetes.io/healthcheck-path: /api/ping/
     alb.ingress.kubernetes.io/healthcheck-interval-seconds: '30'
     alb.ingress.kubernetes.io/success-codes: '200'
-    # Configure exposure to Internet
+    # Configure exposure to Internet.
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
     # Docs about ssl-redirect: "Once enabled, every HTTP listener will be
     # configured with a default action which redirects to HTTPS, other rules

--- a/k8s/conbench-cloud-ingress.templ.yml
+++ b/k8s/conbench-cloud-ingress.templ.yml
@@ -32,7 +32,6 @@ metadata:
     # configuration parameter that disallows serving traffic via non-TLS.
     alb.ingress.kubernetes.io/ssl-redirect: '443'
     alb.ingress.kubernetes.io/certificate-arn: <CERTIFICATE_ARN>
-    alb.ingress.kubernetes.io/certificate-arn: {{CERTIFICATE_ARN}}
   labels:
     app: conbench-ingress
 spec:

--- a/k8s/conbench-cloud-ingress.templ.yml
+++ b/k8s/conbench-cloud-ingress.templ.yml
@@ -37,7 +37,8 @@ metadata:
     app: conbench-ingress
 spec:
   rules:
-  - http:
+  - host: <CONBENCH_INTENDED_DNS_NAME>
+    http:
       paths:
       - path: /
         pathType: Prefix

--- a/k8s/conbench-cloud-ingress.templ.yml
+++ b/k8s/conbench-cloud-ingress.templ.yml
@@ -26,7 +26,12 @@ metadata:
     alb.ingress.kubernetes.io/success-codes: '200'
     # Configure exposure to Internet
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
-    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+    # Docs about ssl-redirect: "Once enabled, every HTTP listener will be
+    # configured with a default action which redirects to HTTPS, other rules
+    # will be ignored." That is preclisely what we want, a no-brainer
+    # configuration parameter that disallows serving traffic via non-TLS.
+    alb.ingress.kubernetes.io/ssl-redirect: '443'
+    alb.ingress.kubernetes.io/certificate-arn: <CERTIFICATE_ARN>
     alb.ingress.kubernetes.io/certificate-arn: {{CERTIFICATE_ARN}}
   labels:
     app: conbench-ingress
@@ -34,13 +39,6 @@ spec:
   rules:
   - http:
       paths:
-      - path: /*
-        pathType: ImplementationSpecific
-        backend:
-          service:
-            name: ssl-redirect
-            port:
-              name: use-annotation
       - path: /
         pathType: Prefix
         backend:


### PR DESCRIPTION
See commit messages. This is a patch in response to `conbench-private/issues/3`.

Some parts I have just tested manually, but for the real thing I need to see the deploy pipeline to execute this. Merging before CI passes (will cancel CI run).