### PR TITLE
legacy conbench library: publish stats even if error

### DIFF
--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -399,7 +399,13 @@ class BenchmarkResultStatsSchema(marshmallow.Schema):
                 iteration, the second element is the second iteration, etc.).
                 If an iteration did not complete but others did and you want to
                 send partial data, mark each iteration that didn't complete as
-                `null`."""
+                `null`.
+
+                You may populate both this field and the "error" field in the top level
+                of the benchmark result payload. In that case, this field measures
+                the metric's values before the error occurred. These values will not be
+                compared to non-errored values in analyses and comparisons.
+                """
             )
         },
     )
@@ -416,6 +422,12 @@ class BenchmarkResultStatsSchema(marshmallow.Schema):
                 second iteration, etc.). If an iteration did not complete but
                 others did and you want to send partial data, mark each
                 iteration that didn't complete as `null`.
+
+                You may populate both this field and the "error" field in the top level
+                of the benchmark result payload. In that case, this field measures
+                how long the benchmark took to run before the error occurred. These
+                values will not be compared to non-errored values in analyses and
+                comparisons.
                 """
             )
         },
@@ -600,7 +612,17 @@ class _BenchmarkResultCreateSchema(marshmallow.Schema):
     error = marshmallow.fields.Dict(
         required=False,
         metadata={
-            "description": "Details about an error that occured while the benchamrk was running (free-form JSON)."
+            "description": conbench.util.dedent_rejoin(
+                """
+                Details about an error that occurred while the benchmark was running
+                (free-form JSON).
+
+                You may populate both this field and the "data" field of the "stats"
+                object. In that case, the "data" field measures the metric's values
+                before the error occurred. Those values will not be compared to
+                non-errored values in analyses and comparisons.
+                """
+            )
         },
     )
     tags = marshmallow.fields.Dict(

--- a/conbench/runner.py
+++ b/conbench/runner.py
@@ -308,7 +308,8 @@ class Conbench(Connection, MixinPython, MixinR):
         }
         if error:
             benchmark_result["error"] = error
-        else:
+
+        if result and result["data"]:
             benchmark_result["stats"] = self._stats(
                 result["data"],
                 result["unit"],

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -995,7 +995,7 @@
                         "type": "object",
                     },
                     "error": {
-                        "description": "Details about an error that occured while the benchamrk was running (free-form JSON).",
+                        "description": 'Details about an error that occurred while the benchmark was running (free-form JSON).  You may populate both this field and the "data" field of the "stats" object. In that case, the "data" field measures the metric\'s values before the error occurred. Those values will not be compared to non-errored values in analyses and comparisons.',
                         "type": "object",
                     },
                     "github": {"$ref": "#/components/schemas/GitHubCreate"},
@@ -1051,7 +1051,7 @@
             "BenchmarkResultStats": {
                 "properties": {
                     "data": {
-                        "description": "A list of benchmark results (e.g. durations, throughput). This will be used as the main + only metric for regression and improvement. The values should be ordered in the order the iterations were executed (the first element is the first iteration, the second element is the second iteration, etc.). If an iteration did not complete but others did and you want to send partial data, mark each iteration that didn't complete as `null`.",
+                        "description": "A list of benchmark results (e.g. durations, throughput). This will be used as the main + only metric for regression and improvement. The values should be ordered in the order the iterations were executed (the first element is the first iteration, the second element is the second iteration, etc.). If an iteration did not complete but others did and you want to send partial data, mark each iteration that didn't complete as `null`.  You may populate both this field and the \"error\" field in the top level of the benchmark result payload. In that case, this field measures the metric's values before the error occurred. These values will not be compared to non-errored values in analyses and comparisons.",
                         "items": {"nullable": True, "type": "number"},
                         "type": "array",
                     },
@@ -1096,7 +1096,7 @@
                         "type": "string",
                     },
                     "times": {
-                        "description": "A list of benchmark durations. If `data` is a duration measure, this should be a duplicate of that object. The values should be ordered in the order the iterations were executed (the first element is the first iteration, the second element is the second iteration, etc.). If an iteration did not complete but others did and you want to send partial data, mark each iteration that didn't complete as `null`.",
+                        "description": 'A list of benchmark durations. If `data` is a duration measure, this should be a duplicate of that object. The values should be ordered in the order the iterations were executed (the first element is the first iteration, the second element is the second iteration, etc.). If an iteration did not complete but others did and you want to send partial data, mark each iteration that didn\'t complete as `null`.  You may populate both this field and the "error" field in the top level of the benchmark result payload. In that case, this field measures how long the benchmark took to run before the error occurred. These values will not be compared to non-errored values in analyses and comparisons.',
                         "items": {"nullable": True, "type": "number"},
                         "type": "array",
                     },

--- a/conbench/tests/benchmark/_example_benchmarks.py
+++ b/conbench/tests/benchmark/_example_benchmarks.py
@@ -136,6 +136,33 @@ class ExternalBenchmark(conbench.runner.Benchmark):
 
 
 @conbench.runner.register_benchmark
+class DataAndErrorBenchmark(conbench.runner.Benchmark):
+    """Example benchmark that supplies both data and an error."""
+
+    external = True
+    name = "data_and_error"
+
+    def run(self, **kwargs):
+        # external results from an API call, command line execution, etc
+        result = {
+            "data": [100, 200, 300],
+            "unit": "i/s",
+            "times": [0.100, 0.200, 0.300],
+            "time_unit": "s",
+        }
+
+        context = {"benchmark_language": "C++"}
+        yield self.conbench.record(
+            result,
+            self.name,
+            error={"something": "bad"},
+            context=context,
+            options=kwargs,
+            output=result,
+        )
+
+
+@conbench.runner.register_benchmark
 class ExternalBenchmarkR(conbench.runner.Benchmark):
     """Example benchmark that records an R benchmark result."""
 

--- a/conbench/tests/benchmark/test_cli.py
+++ b/conbench/tests/benchmark/test_cli.py
@@ -20,6 +20,7 @@ Options:
 
 Commands:
   addition               Run addition benchmark.
+  data_and_error         Run data_and_error benchmark.
   division-with-failure  Run division-with-failure benchmark.
   external               Run external benchmark.
   external-r             Run external-r benchmark.
@@ -35,6 +36,9 @@ CONBENCH_LIST = """
 [
   {
     "command": "addition --iterations=2"
+  },
+  {
+    "command": "data_and_error --iterations=2"
   },
   {
     "command": "division-with-failure --iterations=2"

--- a/conbench/tests/benchmark/test_runner.py
+++ b/conbench/tests/benchmark/test_runner.py
@@ -8,6 +8,7 @@ from ...tests.api import _fixtures
 from ...tests.helpers import _uuid
 from ._example_benchmarks import (
     CasesBenchmark,
+    DataAndErrorBenchmark,
     ExternalBenchmark,
     ExternalBenchmarkWithWrongName,
     SimpleBenchmark,
@@ -154,6 +155,14 @@ def test_runner_external_benchmark():
     assert len(result["stats"]["data"]) == 3
     assert result["context"] == {"benchmark_language": "C++"}
     assert_repo_is_valid(result["github"]["repository"])
+
+
+def test_runner_supplies_both_data_and_error():
+    benchmark = DataAndErrorBenchmark()
+    [(result, _)] = benchmark.run()
+    assert result["stats"]["iterations"] == 3
+    assert len(result["stats"]["data"]) == 3
+    assert result["error"] == {"something": "bad"}
 
 
 def test_runner_can_specify_run_and_batch_id():


### PR DESCRIPTION
Fixes #1073.

This PR lets the legacy `conbench` library post stats to conbench even if an error was provided.