### PR TITLE
webapp: more renames:  benchmark -> benchmark result, mostly internal

### DIFF
--- a/benchclients/python/README.md
+++ b/benchclients/python/README.md
@@ -59,8 +59,8 @@ log.setLevel(logging.DEBUG)
 
 conbench = ConbenchClient()
 
-benchmark_id = "4e0e569d82724667b3e929dedb730edc"
-res = conbench.get(f"/benchmarks/{benchmark_id}")
+benchmark_result_id = "4e0e569d82724667b3e929dedb730edc"
+res = conbench.get(f"/benchmarks/{benchmark_result_id}")
 #> DEBUG [2023-02-10 12:56:48,492] GET https://conbench.ursa.dev/api/benchmarks/4e0e569d82724667b3e929dedb730edc
 
 res

--- a/conbench/api/_examples.py
+++ b/conbench/api/_examples.py
@@ -167,11 +167,11 @@ def _api_commit_entity(commit_id, parent_id, links=True):
     return result
 
 
-def _api_compare_entity(benchmark_ids, batch_ids, run_ids, batch, benchmark, tags):
+def _api_compare_entity(benchmark_result_ids, batch_ids, run_ids, batch, benchmark, tags):
     return {
         "baseline": "0.036 s",
         "baseline_error": None,
-        "baseline_id": benchmark_ids[0],
+        "baseline_id": benchmark_result_ids[0],
         "baseline_batch_id": batch_ids[0],
         "baseline_run_id": run_ids[0],
         "batch": batch,
@@ -190,7 +190,7 @@ def _api_compare_entity(benchmark_ids, batch_ids, run_ids, batch, benchmark, tag
         "contender_z_improvement": False,
         "contender": "0.036 s",
         "contender_error": None,
-        "contender_id": benchmark_ids[1],
+        "contender_id": benchmark_result_ids[1],
         "contender_batch_id": batch_ids[1],
         "contender_run_id": run_ids[1],
         "less_is_better": True,
@@ -351,10 +351,10 @@ def _api_context_entity(context_id, links=True):
     return result
 
 
-def _api_history_entity(benchmark_id, case_id, context_id, run_name):
+def _api_history_entity(benchmark_result_id, case_id, context_id, run_name):
     return [
         {
-            "benchmark_result_id": benchmark_id,
+            "benchmark_result_id": benchmark_result_id,
             "case_id": case_id,
             "commit_hash": "02addad336ba19a654f9c857ede546331be7b631",
             "commit_msg": "ARROW-11771: [Developer][Archery] Move benchmark tests (so CI runs them)",

--- a/conbench/api/_examples.py
+++ b/conbench/api/_examples.py
@@ -167,7 +167,9 @@ def _api_commit_entity(commit_id, parent_id, links=True):
     return result
 
 
-def _api_compare_entity(benchmark_result_ids, batch_ids, run_ids, batch, benchmark, tags):
+def _api_compare_entity(
+    benchmark_result_ids, batch_ids, run_ids, batch, benchmark, tags
+):
     return {
         "baseline": "0.036 s",
         "baseline_error": None,

--- a/conbench/api/compare.py
+++ b/conbench/api/compare.py
@@ -281,12 +281,12 @@ class CompareListEndpoint(ApiEndpoint, CompareMixin):
 
 
 class CompareBenchmarksAPI(CompareEntityEndpoint):
-    def _get_results(self, benchmark_id) -> List[BenchmarkResult]:
+    def _get_results(self, benchmark_result_id) -> List[BenchmarkResult]:
         try:
-            benchmark_result = BenchmarkResult.one(id=benchmark_id)
+            benchmark_result = BenchmarkResult.one(id=benchmark_result_id)
         except NotFound:
             f.abort(
-                404, description="no benchmark result found with ID: '{benchmark_id}'"
+                404, description="no benchmark result found with ID: '{benchmark_result_id}'"
             )
         return [benchmark_result]
 

--- a/conbench/api/compare.py
+++ b/conbench/api/compare.py
@@ -286,7 +286,8 @@ class CompareBenchmarksAPI(CompareEntityEndpoint):
             benchmark_result = BenchmarkResult.one(id=benchmark_result_id)
         except NotFound:
             f.abort(
-                404, description="no benchmark result found with ID: '{benchmark_result_id}'"
+                404,
+                description="no benchmark result found with ID: '{benchmark_result_id}'",
             )
         return [benchmark_result]
 

--- a/conbench/api/history.py
+++ b/conbench/api/history.py
@@ -10,7 +10,7 @@ class HistoryEntityAPI(ApiEndpoint):
     serializer = HistorySerializer()
 
     @maybe_login_required
-    def get(self, benchmark_id):
+    def get(self, benchmark_result_id):
         """
         ---
         description: Get benchmark history.
@@ -19,7 +19,7 @@ class HistoryEntityAPI(ApiEndpoint):
             "401": "401"
             "404": "404"
         parameters:
-          - name: benchmark_id
+          - name: benchmark_result_id
             in: path
             schema:
                 type: string
@@ -30,7 +30,7 @@ class HistoryEntityAPI(ApiEndpoint):
         # happen? If it can happen: which response would we want to emit to the
         # HTTP client? An empty array, or something more convenient?
         try:
-            samples = get_history_for_benchmark(benchmark_result_id=benchmark_id)
+            samples = get_history_for_benchmark(benchmark_result_id=benchmark_result_id)
         except NotFound:
             self.abort_404_not_found()
 
@@ -44,7 +44,7 @@ class HistoryEntityAPI(ApiEndpoint):
 history_entity_view = HistoryEntityAPI.as_view("history")
 
 rule(
-    "/history/<benchmark_id>/",
+    "/history/<benchmark_result_id>/",
     view_func=history_entity_view,
     methods=["GET"],
 )

--- a/conbench/api/results.py
+++ b/conbench/api/results.py
@@ -30,15 +30,15 @@ class BenchmarkEntityAPI(ApiEndpoint, BenchmarkValidationMixin):
     serializer = BenchmarkResultSerializer()
     schema = BenchmarkResultFacadeSchema()
 
-    def _get(self, benchmark_id):
+    def _get(self, benchmark_result_id):
         try:
-            benchmark_result = BenchmarkResult.one(id=benchmark_id)
+            benchmark_result = BenchmarkResult.one(id=benchmark_result_id)
         except NotFound:
             self.abort_404_not_found()
         return benchmark_result
 
     @maybe_login_required
-    def get(self, benchmark_id):
+    def get(self, benchmark_result_id):
         """
         ---
         description: |
@@ -57,11 +57,11 @@ class BenchmarkEntityAPI(ApiEndpoint, BenchmarkValidationMixin):
         tags:
           - Benchmarks
         """
-        benchmark_result = self._get(benchmark_id)
+        benchmark_result = self._get(benchmark_result_id)
         return self.serializer.one.dump(benchmark_result)
 
     @flask_login.login_required
-    def put(self, benchmark_id):
+    def put(self, benchmark_result_id):
         """
         ---
         description: Edit a benchmark result.
@@ -81,13 +81,13 @@ class BenchmarkEntityAPI(ApiEndpoint, BenchmarkValidationMixin):
         tags:
           - Benchmarks
         """
-        benchmark_result = self._get(benchmark_id)
+        benchmark_result = self._get(benchmark_result_id)
         data = self.validate_benchmark(self.schema.update)
         benchmark_result.update(data)
         return self.serializer.one.dump(benchmark_result)
 
     @flask_login.login_required
-    def delete(self, benchmark_id):
+    def delete(self, benchmark_result_id):
         """
         ---
         description: Delete a benchmark result.
@@ -103,7 +103,7 @@ class BenchmarkEntityAPI(ApiEndpoint, BenchmarkValidationMixin):
         tags:
           - Benchmarks
         """
-        benchmark_result = self._get(benchmark_id)
+        benchmark_result = self._get(benchmark_result_id)
         benchmark_result.delete()
         return self.response_204_no_content()
 
@@ -298,7 +298,7 @@ rule(
     methods=["GET", "POST"],
 )
 rule(
-    "/benchmarks/<benchmark_id>/",
+    "/benchmarks/<benchmark_result_id>/",
     view_func=benchmark_entity_view,
     methods=["GET", "DELETE", "PUT"],
 )

--- a/conbench/api/results.py
+++ b/conbench/api/results.py
@@ -50,7 +50,7 @@ class BenchmarkEntityAPI(ApiEndpoint, BenchmarkValidationMixin):
             "401": "401"
             "404": "404"
         parameters:
-          - name: benchmark_id
+          - name: benchmark_result_id
             in: path
             schema:
                 type: string
@@ -70,7 +70,7 @@ class BenchmarkEntityAPI(ApiEndpoint, BenchmarkValidationMixin):
             "401": "401"
             "404": "404"
         parameters:
-          - name: benchmark_id
+          - name: benchmark_result_id
             in: path
             schema:
                 type: string
@@ -96,7 +96,7 @@ class BenchmarkEntityAPI(ApiEndpoint, BenchmarkValidationMixin):
             "401": "401"
             "404": "404"
         parameters:
-          - name: benchmark_id
+          - name: benchmark_result_id
             in: path
             schema:
                 type: string

--- a/conbench/app/results.py
+++ b/conbench/app/results.py
@@ -252,8 +252,8 @@ class BenchmarkResult(AppEndpoint, BenchmarkResultMixin, RunMixin, TimeSeriesPlo
         )
 
     @authorize_or_terminate
-    def get(self, benchmark_id):
-        benchmark, run = self._get_benchmark_and_run(benchmark_id)
+    def get(self, benchmark_result_id):
+        benchmark, run = self._get_benchmark_and_run(benchmark_result_id)
         return self.page(
             benchmark, run, BenchmarkResultDeleteForm(), BenchmarkResultUpdateForm()
         )
@@ -356,7 +356,7 @@ rule(
 )
 
 rule(
-    "/benchmark-results/<benchmark_id>/",
+    "/benchmark-results/<benchmark_result_id>/",
     view_func=BenchmarkResult.as_view("benchmark-result"),
     methods=["GET", "POST"],
 )

--- a/conbench/app/results.py
+++ b/conbench/app/results.py
@@ -59,12 +59,12 @@ class ContextMixin:
 
 
 class BenchmarkResultMixin:
-    def get_display_benchmark(self, benchmark_id):
+    def get_display_benchmark(self, benchmark_result_id):
         # this gets a benchmark _result_, we need more renaming.
-        benchmark, response = self._get_benchmark(benchmark_id)
+        benchmark, response = self._get_benchmark(benchmark_result_id)
 
         if response.status_code == 404:
-            self.flash(f"unknown benchmark result ID: {benchmark_id}", "info")
+            self.flash(f"unknown benchmark result ID: {benchmark_result_id}", "info")
 
         if response.status_code != 200:
             # Note(JP): quick band-aid to at least not swallow err detail, need
@@ -88,11 +88,11 @@ class BenchmarkResultMixin:
         return benchmark
 
     # this gets a benchmark result, we need more renaming.
-    def _get_benchmark(self, benchmark_id):
+    def _get_benchmark(self, benchmark_result_id):
         # TODO: remove re-serialization indirection.
         response = self.api_get(
             "api.benchmark",
-            benchmark_id=benchmark_id,
+            benchmark_id=benchmark_result_id,
         )
         return response.json, response
 
@@ -375,7 +375,7 @@ rule(
 # is overwriting an existing endpoint function: app.benchmark`
 # Context: https://github.com/conbench/conbench/pull/966#issuecomment-1487072612
 rule(
-    "/benchmarks/<benchmark_id>/",
+    "/benchmarks/<benchmark_result_id>/",
     view_func=BenchmarkResult.as_view("benchmark"),
     methods=["GET", "POST"],
 )

--- a/conbench/app/results.py
+++ b/conbench/app/results.py
@@ -92,7 +92,7 @@ class BenchmarkResultMixin:
         # TODO: remove re-serialization indirection.
         response = self.api_get(
             "api.benchmark",
-            benchmark_id=benchmark_result_id,
+            benchmark_result_id=benchmark_result_id,
         )
         return response.json, response
 

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -348,7 +348,7 @@ class BenchmarkResult(Base, EntityMixin):
             "links": {
                 "list": f.url_for("api.benchmarks", _external=True),
                 "self": f.url_for(
-                    "api.benchmark", benchmark_id=benchmark_result.id, _external=True
+                    "api.benchmark", benchmark_result_id=benchmark_result.id, _external=True
                 ),
                 "info": f.url_for(
                     "api.info", info_id=benchmark_result.info_id, _external=True

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -348,7 +348,9 @@ class BenchmarkResult(Base, EntityMixin):
             "links": {
                 "list": f.url_for("api.benchmarks", _external=True),
                 "self": f.url_for(
-                    "api.benchmark", benchmark_result_id=benchmark_result.id, _external=True
+                    "api.benchmark",
+                    benchmark_result_id=benchmark_result.id,
+                    _external=True,
                 ),
                 "info": f.url_for(
                     "api.info", info_id=benchmark_result.info_id, _external=True

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -61,7 +61,7 @@ class _Serializer(EntitySerializer):
         # as `times`.
 
         return {
-            "benchmark_id": history.id,
+            "benchmark_result_id": history.id,
             "case_id": history.case_id,
             "context_id": history.context_id,
             "mean": _to_float(history.mean),

--- a/conbench/templates/batch.html
+++ b/conbench/templates/batch.html
@@ -71,7 +71,7 @@
                      <td>
                          <div>{{ benchmark.display_bmname }}</div>
                      </td>
-                     <td><a href="{{ url_for('app.benchmark', benchmark_id=benchmark.id) }}">
+                     <td><a href="{{ url_for('app.benchmark-result', benchmark_result_id=benchmark.id) }}">
                          <div>{{ benchmark.display_case_perm }}</div>
                      </a></td>
                      <td style="white-space: nowrap;">{{ benchmark.display_mean }}</td>

--- a/conbench/templates/benchmark-list.html
+++ b/conbench/templates/benchmark-list.html
@@ -42,7 +42,7 @@
                          </a></td>
                          <td>{{ benchmark.display_mean }}</td>
                          {% if not current_user.is_anonymous %}
-                         <td data-cbcustom-href="{{ url_for('app.benchmark-result', benchmark_id=benchmark.id) }}"
+                         <td data-cbcustom-href="{{ url_for('app.benchmark-result', benchmark_result_id=benchmark.id) }}"
                              data-bs-toggle="modal"
                              data-bs-target="#confirm-delete"
                              data-cbcustom-form-id="#delete-benchmark-form"

--- a/conbench/templates/benchmark-list.html
+++ b/conbench/templates/benchmark-list.html
@@ -37,7 +37,7 @@
                              <div>{{ benchmark.display_bmname }}</div>
                            </a>
                          </td>
-                         <td><a href="{{ url_for('app.benchmark-result', benchmark_id=benchmark.id) }}">
+                         <td><a href="{{ url_for('app.benchmark-result', benchmark_result_id=benchmark.id) }}">
                               <div>{{ benchmark.display_case_perm }}</div>
                          </a></td>
                          <td>{{ benchmark.display_mean }}</td>

--- a/conbench/templates/benchmark-result.html
+++ b/conbench/templates/benchmark-result.html
@@ -11,7 +11,7 @@
       <a href="{{ url_for('app.batch', batch_id=benchmark.batch_id) }}">Batch</a>
     </li>
     <li class="breadcrumb-item active aria-current="page">
-      <a href="{{ url_for('app.benchmark', benchmark_id=benchmark.id) }}">
+      <a href="{{ url_for('app.benchmark-result', benchmark_result_id=benchmark.id) }}">
       Benchmark result {{ benchmark.id[:7] }}...</a>
     </li>
   </ol>
@@ -262,7 +262,7 @@
     $("#delete-form").find("#delete").attr("data-bs-toggle", "modal");
     $("#delete-form").find("#delete").attr("data-bs-target", "#confirm-delete");
     $("#delete-form").find("#delete").attr("data-cbcustom-form-id", "#delete-form");
-    $("#delete-form").find("#delete").attr("data-cbcustom-href", "{{ url_for('app.benchmark', benchmark_id=benchmark.id) }}");
+    $("#delete-form").find("#delete").attr("data-cbcustom-href", "{{ url_for('app.benchmark-result', benchmark_result_id=benchmark.id) }}");
     $("#delete-form").find("#delete").attr("data-cbcustom-message", "<ul><li>Delete benchmark result: <strong>{{ benchmark.id }}</strong></li></ul>");
   });
 

--- a/conbench/templates/compare-entity.html
+++ b/conbench/templates/compare-entity.html
@@ -47,9 +47,9 @@ matching fields between baseline and contender are aligned and mismatched fields
         </li>
         <li class="breadcrumb-item active">Benchmarks</li>
         <li class="breadcrumb-item active" aria-current="page">
-          <a href="{{ url_for('app.benchmark', benchmark_id=baseline_id) }}">Baseline</a>
+          <a href="{{ url_for('app.benchmark-result', benchmark_result_id=baseline_id) }}">Baseline</a>
            ...
-          <a href="{{ url_for('app.benchmark', benchmark_id=contender_id) }}">Contender</a>
+          <a href="{{ url_for('app.benchmark-result', benchmark_result_id=contender_id) }}">Contender</a>
         </li>
       </ol>
     </nav>
@@ -132,7 +132,7 @@ matching fields between baseline and contender are aligned and mismatched fields
             <li class="list-group-item" style="overflow-y: auto;">
               <b>benchmark</b>
               <div align="right" style="display:inline-block; float: right;">
-                <a href="{{ url_for('app.benchmark', benchmark_id=baseline.id) }}">{{ baseline.display_case_perm }}</a>
+                <a href="{{ url_for('app.benchmark-result', benchmark_result_id=baseline.id) }}">{{ baseline.display_case_perm }}</a>
               </div>
             </li>
             {% if baseline_run %}
@@ -237,7 +237,7 @@ matching fields between baseline and contender are aligned and mismatched fields
             <li class="list-group-item" style="overflow-y: auto;">
               <b>benchmark</b>
               <div align="right" style="display:inline-block; float: right;">
-                <a href="{{ url_for('app.benchmark', benchmark_id=contender.id) }}">{{ contender.display_case_perm }}</a>
+                <a href="{{ url_for('app.benchmark-result', benchmark_result_id=contender.id) }}">{{ contender.display_case_perm }}</a>
               </div>
             </li>
             {% if contender_run %}

--- a/conbench/templates/compare-list.html
+++ b/conbench/templates/compare-list.html
@@ -158,7 +158,7 @@
                          </td>
 
                          {% if c.baseline_error is not none %}
-                           <td><a href="{{ url_for('app.benchmark', benchmark_id=c.baseline_id) }}">
+                           <td><a href="{{ url_for('app.benchmark-result', benchmark_result_id=c.baseline_id) }}">
                                <i class="glyphicon glyphicon-exclamation-sign text-danger"
                                   data-toggle="tooltip" data-placement="top" title="Has error">
                                </i></a>
@@ -170,7 +170,7 @@
                          {% endif %}
 
                          {% if c.contender_error is not none %}
-                           <td><a href="{{ url_for('app.benchmark', benchmark_id=c.contender_id) }}">
+                           <td><a href="{{ url_for('app.benchmark-result', benchmark_result_id=c.contender_id) }}">
                                <i class="glyphicon glyphicon-exclamation-sign text-danger"
                                   data-toggle="tooltip" data-placement="top" title="Has error">
                                </i></a>

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -42,7 +42,7 @@
         <div class="item">
         {% endif %}
         <div align="center">
-        <a href="{{ url_for('app.benchmark-result', benchmark_id=outlier_ids[loop.index - 1]) }}">
+        <a href="{{ url_for('app.benchmark-result', benchmark_result_id=outlier_ids[loop.index - 1]) }}">
           {{ outlier_names[loop.index - 1] }}
         </a>
         </div>
@@ -60,7 +60,7 @@
 {% endif %}
 
     <div class="col-md-12">
-        <h4>Benchmarks in run</h4>
+        <h4>Benchmark results in Run</h4>
         <table id="benchmarks" class="table table-hover">
         <!-- does not display right: <caption>Benchmarks{% include 'units-tooltip.html' %}</caption>-->
             <thead>
@@ -84,7 +84,7 @@
                          {{ benchmark.display_bmname }}
                        </a>
                      </td>
-                     <td><a href="{{ url_for('app.benchmark-result', benchmark_id=benchmark.id) }}">
+                     <td><a href="{{ url_for('app.benchmark-result', benchmark_result_id=benchmark.id) }}">
                          {{ benchmark.display_case_perm}}
                      </a></td>
                      <td style="white-space: nowrap;">{{ benchmark.display_mean }}</td>
@@ -100,7 +100,7 @@
                        <td></td>
                      {% endif %}
                 <td>
-                    {%  if benchmark.error %}<a href="{{ url_for('app.benchmark-result', benchmark_id=benchmark.id) }}">
+                    {%  if benchmark.error %}<a href="{{ url_for('app.benchmark-result', benchmark_result_id=benchmark.id) }}">
                         <i class="glyphicon glyphicon-exclamation-sign text-danger"
                            data-toggle="tooltip" data-placement="top" title="Has error">
                         </i><span>Error</span></a>

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -1374,13 +1374,13 @@
                 "tags": ["Benchmarks"],
             },
         },
-        "/api/benchmarks/{benchmark_id}/": {
+        "/api/benchmarks/{benchmark_result_id}/": {
             "delete": {
                 "description": "Delete a benchmark result.",
                 "parameters": [
                     {
                         "in": "path",
-                        "name": "benchmark_id",
+                        "name": "benchmark_result_id",
                         "required": True,
                         "schema": {"type": "string"},
                     }
@@ -1397,7 +1397,7 @@
                 "parameters": [
                     {
                         "in": "path",
-                        "name": "benchmark_id",
+                        "name": "benchmark_result_id",
                         "required": True,
                         "schema": {"type": "string"},
                     }
@@ -1414,7 +1414,7 @@
                 "parameters": [
                     {
                         "in": "path",
-                        "name": "benchmark_id",
+                        "name": "benchmark_result_id",
                         "required": True,
                         "schema": {"type": "string"},
                     }
@@ -1642,13 +1642,13 @@
                 "tags": ["Hardware"],
             }
         },
-        "/api/history/{benchmark_id}/": {
+        "/api/history/{benchmark_result_id}/": {
             "get": {
                 "description": "Get benchmark history.",
                 "parameters": [
                     {
                         "in": "path",
-                        "name": "benchmark_id",
+                        "name": "benchmark_result_id",
                         "required": True,
                         "schema": {"type": "string"},
                     }

--- a/conbench/tests/api/test_compare.py
+++ b/conbench/tests/api/test_compare.py
@@ -233,11 +233,11 @@ class TestCompareBenchmarksGet(_asserts.GetEnforcer):
             f"/api/compare/benchmarks/{compare.id}/", query_string=query_string
         )
 
-        benchmark_ids = [e.id for e in new_entities]
+        benchmark_result_ids = [e.id for e in new_entities]
         batch_ids = [e.batch_id for e in new_entities]
         run_ids = [e.run_id for e in new_entities]
         expected = _api_compare_entity(
-            benchmark_ids,
+            benchmark_result_ids,
             batch_ids,
             run_ids,
             name,
@@ -277,11 +277,11 @@ class TestCompareBenchmarksGet(_asserts.GetEnforcer):
         )
         response = client.get(f"/api/compare/benchmarks/{compare.id}/")
 
-        benchmark_ids = [e.id for e in new_entities]
+        benchmark_result_ids = [e.id for e in new_entities]
         batch_ids = [e.batch_id for e in new_entities]
         run_ids = [e.run_id for e in new_entities]
         expected = _api_compare_entity(
-            benchmark_ids,
+            benchmark_result_ids,
             batch_ids,
             run_ids,
             name,

--- a/conbench/tests/api/test_results.py
+++ b/conbench/tests/api/test_results.py
@@ -1013,7 +1013,7 @@ class TestBenchmarkPost(_asserts.PostEnforcer):
         resp = client.post(self.url, json=payload)
         assert resp.status_code == 201, f"unexpected response: {resp.text}"
 
-        benchmark_id = resp.json["id"]
+        benchmark_result_id = resp.json["id"]
         # Confirm that an empty context was created.
         context_url = resp.json["links"]["context"]
         resp = client.get(context_url)
@@ -1027,7 +1027,7 @@ class TestBenchmarkPost(_asserts.PostEnforcer):
         # object. There was a time when the benchmark-entity template failed
         # rendering for empty contexts, see
         # https://github.com/conbench/conbench/issues/365
-        resp = client.get(f"/benchmark-results/{benchmark_id}/")
+        resp = client.get(f"/benchmark-results/{benchmark_result_id}/")
         assert resp.status_code == 200, f"unexpected response: {resp.text}"
 
         # As of today the rendered view shows the context ID. Confirm that. In

--- a/conbench/tests/app/_asserts.py
+++ b/conbench/tests/app/_asserts.py
@@ -81,9 +81,9 @@ class AppEndpointTest:
         self.authenticate(client)
         response = client.post("/api/benchmarks/", json=_fixtures.VALID_PAYLOAD)
         assert response.status_code == 201, response.text
-        benchmark_id = response.json["id"]
+        benchmark_result_id = response.json["id"]
         self.logout(client)
-        return benchmark_id
+        return benchmark_result_id
 
 
 class Enforcer(AppEndpointTest):

--- a/conbench/tests/app/test_compare.py
+++ b/conbench/tests/app/test_compare.py
@@ -21,8 +21,8 @@ class TestCompareBenchmark(_asserts.GetEnforcer):
     redirect_on_unknown = False
 
     def _create(self, client):
-        benchmark_id = self.create_benchmark(client)
-        return f"{benchmark_id}...{benchmark_id}"
+        benchmark_result_id = self.create_benchmark(client)
+        return f"{benchmark_result_id}...{benchmark_result_id}"
 
     def test_flash_messages(self, client):
         self.authenticate(client)

--- a/conbench/tests/app/test_plots.py
+++ b/conbench/tests/app/test_plots.py
@@ -12,7 +12,7 @@ def legacy_dict_to_hs(d: dict) -> HistorySample:
         commit_msg=d["message"],
         commit_timestamp=util.tznaive_iso8601_to_tzaware_dt(d["timestamp"]),
         commit_hash=d["sha"],
-        benchmark_result_id=d["benchmark_id"],
+        benchmark_result_id=d["benchmark_result_id"],
         repository=d["repository"],
         case_id=d["case_id"],
         context_id=d["context_id"],
@@ -35,7 +35,7 @@ def legacy_dict_to_hs(d: dict) -> HistorySample:
 
 legacy_HISTORY = [
     {
-        "benchmark_id": "b4466622481f4e3a927e962008309724",
+        "benchmark_result_id": "b4466622481f4e3a927e962008309724",
         "case_id": "bdca99e75fee41e8aec77c2c1bc220ab",
         "context_id": "a348db873c3641a9a13b57e934984525",
         "distribution_mean": "392130886.117931",
@@ -50,7 +50,7 @@ legacy_HISTORY = [
         "unit": "B/s",
     },
     {
-        "benchmark_id": "de97178de12846c7bd9252f998150bff",
+        "benchmark_result_id": "de97178de12846c7bd9252f998150bff",
         "case_id": "bdca99e75fee41e8aec77c2c1bc220ab",
         "context_id": "a348db873c3641a9a13b57e934984525",
         "distribution_mean": "388236410.822258",
@@ -65,7 +65,7 @@ legacy_HISTORY = [
         "unit": "B/s",
     },
     {
-        "benchmark_id": "27f3b6fda2d64fe4b4cc2af16ccefc00",
+        "benchmark_result_id": "27f3b6fda2d64fe4b4cc2af16ccefc00",
         "case_id": "bdca99e75fee41e8aec77c2c1bc220ab",
         "context_id": "a348db873c3641a9a13b57e934984525",
         "distribution_mean": "386395506.239738",
@@ -80,7 +80,7 @@ legacy_HISTORY = [
         "unit": "B/s",
     },
     {
-        "benchmark_id": "feac4ec1ca014a6bb7b7cb84869cdebb",
+        "benchmark_result_id": "feac4ec1ca014a6bb7b7cb84869cdebb",
         "case_id": "bdca99e75fee41e8aec77c2c1bc220ab",
         "context_id": "a348db873c3641a9a13b57e934984525",
         "distribution_mean": "387124231.233692",
@@ -95,7 +95,7 @@ legacy_HISTORY = [
         "unit": "B/s",
     },
     {
-        "benchmark_id": "eca009ba5ce0427ab32fadeb28d27143",
+        "benchmark_result_id": "eca009ba5ce0427ab32fadeb28d27143",
         "case_id": "bdca99e75fee41e8aec77c2c1bc220ab",
         "context_id": "a348db873c3641a9a13b57e934984525",
         "distribution_mean": "387968509.336751",

--- a/conbench/tests/app/test_results.py
+++ b/conbench/tests/app/test_results.py
@@ -76,11 +76,13 @@ class TestBenchmarkDelete(_asserts.DeleteEnforcer):
         self.assert_login_page(response)
 
     def test_no_csrf_token(self, client):
-        benchmark_id = self.create_benchmark(client)
+        benchmark_result_id = self.create_benchmark(client)
         self.authenticate(client)
         data = {"delete": ["Delete"]}
         response = client.post(
-            f"/benchmark-results/{benchmark_id}/", data=data, follow_redirects=True
+            f"/benchmark-results/{benchmark_result_id}/",
+            data=data,
+            follow_redirects=True,
         )
         self.assert_page(response, "Benchmark")
         assert b"The CSRF token is missing." in response.data

--- a/conbench/tests/app/test_results.py
+++ b/conbench/tests/app/test_results.py
@@ -50,7 +50,9 @@ class TestBenchmarkDelete(_asserts.DeleteEnforcer):
         # delete benchmark
         data = {"delete": ["Delete"], "csrf_token": self.get_csrf_token(response)}
         response = client.post(
-            f"/benchmark-results/{benchmark_result_id}/", data=data, follow_redirects=True
+            f"/benchmark-results/{benchmark_result_id}/",
+            data=data,
+            follow_redirects=True,
         )
         self.assert_page(response, "Benchmarks")
         assert re.search(
@@ -71,7 +73,9 @@ class TestBenchmarkDelete(_asserts.DeleteEnforcer):
         self.logout(client)
         data = {"delete": ["Delete"]}
         response = client.post(
-            f"/benchmark-results/{benchmark_result_id}/", data=data, follow_redirects=True
+            f"/benchmark-results/{benchmark_result_id}/",
+            data=data,
+            follow_redirects=True,
         )
         self.assert_login_page(response)
 

--- a/conbench/tests/app/test_results.py
+++ b/conbench/tests/app/test_results.py
@@ -39,18 +39,18 @@ class TestBenchmarkGet(_asserts.GetEnforcer):
 
 class TestBenchmarkDelete(_asserts.DeleteEnforcer):
     def test_authenticated(self, client):
-        benchmark_id = self.create_benchmark(client)
+        benchmark_result_id = self.create_benchmark(client)
 
         # can get benchmark before
         self.authenticate(client)
-        response = client.get(f"/benchmark-results/{benchmark_id}/")
+        response = client.get(f"/benchmark-results/{benchmark_result_id}/")
         self.assert_page(response, "Benchmark")
-        assert f"{benchmark_id[:6]}".encode() in response.data
+        assert f"{benchmark_result_id[:6]}".encode() in response.data
 
         # delete benchmark
         data = {"delete": ["Delete"], "csrf_token": self.get_csrf_token(response)}
         response = client.post(
-            f"/benchmark-results/{benchmark_id}/", data=data, follow_redirects=True
+            f"/benchmark-results/{benchmark_result_id}/", data=data, follow_redirects=True
         )
         self.assert_page(response, "Benchmarks")
         assert re.search(
@@ -59,7 +59,7 @@ class TestBenchmarkDelete(_asserts.DeleteEnforcer):
 
         # cannot get benchmark after
         response = client.get(
-            f"/benchmark-results/{benchmark_id}/", follow_redirects=True
+            f"/benchmark-results/{benchmark_result_id}/", follow_redirects=True
         )
         self.assert_index_page(response)
         assert re.search(
@@ -67,11 +67,11 @@ class TestBenchmarkDelete(_asserts.DeleteEnforcer):
         )
 
     def test_unauthenticated(self, client):
-        benchmark_id = self.create_benchmark(client)
+        benchmark_result_id = self.create_benchmark(client)
         self.logout(client)
         data = {"delete": ["Delete"]}
         response = client.post(
-            f"/benchmark-results/{benchmark_id}/", data=data, follow_redirects=True
+            f"/benchmark-results/{benchmark_result_id}/", data=data, follow_redirects=True
         )
         self.assert_login_page(response)
 

--- a/conbench/tests/populate_local_conbench.py
+++ b/conbench/tests/populate_local_conbench.py
@@ -288,7 +288,7 @@ def post_benchmark_result(data):
             # takes too long. Also see
             # https://github.com/conbench/conbench/issues/555
             res = session.post(url, json=data)
-            benchmark_id = res.json()["id"]
+            benchmark_result_id = res.json()["id"]
             break
         except requests.exceptions.RequestException as exc:
             log.info(
@@ -309,7 +309,7 @@ def post_benchmark_result(data):
     if str(res.status_code).startswith("4"):
         log.info("4xx response body: %s", res.text)
 
-    return benchmark_id
+    return benchmark_result_id
 
 
 def update_run(run_id, data):
@@ -416,7 +416,7 @@ def create_benchmarks_data_with_history():
 
     runs = []
 
-    benchmark_ids = []
+    benchmark_result_ids = []
 
     i = 0
     n = 0
@@ -457,8 +457,8 @@ def create_benchmarks_data_with_history():
                         repo_url="https://github.com/apache/arrow",
                     )
 
-                benchmark_id = post_benchmark_result(benchmark_data)
-                benchmark_ids.append(benchmark_id)
+                benchmark_result_id = post_benchmark_result(benchmark_data)
+                benchmark_result_ids.append(benchmark_result_id)
                 runs.append((run_id, timestamp))
 
 
@@ -476,7 +476,7 @@ def generate_synthetic_benchmark_history(commit_hashes: List[str], repo_url: str
     distribution = statistics.NormalDist(mu=distr_mean, sigma=distr_std)
 
     # Collect benchmark IDs as returned by the Conbench API after submission.
-    benchmark_ids = []
+    benchmark_result_ids = []
 
     def sample_slowdown(s, offset: float):
         # "slowdown" refers to the idea that the individual number has a time
@@ -546,11 +546,11 @@ def generate_synthetic_benchmark_history(commit_hashes: List[str], repo_url: str
             "times": [],
         }
 
-        benchmark_ids.append(post_benchmark_result(bdata))
+        benchmark_result_ids.append(post_benchmark_result(bdata))
 
     log.info("now, emit a benchmark ID on stdout")
     # That benchmark ID is consumed and used by CI.
-    print(benchmark_ids[0])
+    print(benchmark_result_ids[0])
 
 
 """


### PR DESCRIPTION
More work towards #878, for less internal and external terminology confusion.