### PR TITLE
ui: datatable footer: smaller pagination, layout fix

### DIFF
--- a/conbench/static/app.css
+++ b/conbench/static/app.css
@@ -20,6 +20,13 @@ table.dataTable thead .sorting_desc {
   background : none;
 }
 
+/* Remove border around and within pagination bar
+   in a datatables presentation */
+.dataTables_paginate .page-link {
+  border: none;
+}
+
+/*
 table.dataTable td {
   font-size: 13.4px;
 }
@@ -28,6 +35,7 @@ table.dataTable td {
   color: #1F77B4;
 }
 
+*/
 [data-href] {
   cursor: pointer;
 }

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -107,14 +107,17 @@ $(document).ready(function () {
         "order": [[0, 'desc']],
         // https://datatables.net/reference/option/dom
         // put `l` to the bottom to show the "show N entries" menu at bottom
-        "dom": "lfrtip",
+        "dom": 'lfrt<"row"<"col-6"i><".col-6"p>>',
         "language": {
             "searchPlaceholder": "search across all columns",
         },
         initComplete: function () {
           var api = this.api();
+          // reveal only after DOM modification is complete (reduce loading
+          // layout shift artifacts)
           $('table.cb-runs-table').show();
           api.columns.adjust();
+          $('.pagination').addClass('pagination-sm'); // add BS class for smaller pagination bar
         },
       })
     }

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -177,8 +177,16 @@
 <script type="text/javascript">
 var table = $('#benchmarks').dataTable( {
     "responsive": true,
+    // Take rather precise control of layouting elements, put bottom elements
+    // into a mult-col single row, using BS's grid system.
+    "dom": 'lfrt<"row"<"col-6"i><".col-6"p>>',
     "order": [[5, 'asc']],
-    "columnDefs": [{ "orderable": false, "targets": [4] }]
+    "columnDefs": [{ "orderable": false, "targets": [4] }],
+    initComplete: function () {
+      var api = this.api();
+      //api.columns.adjust();
+      $('.pagination').addClass('pagination-sm'); // add BS class for smaller pagination bar
+    },
 } );
 
 column_search_implementation($('#benchmarks'));


### PR DESCRIPTION
Fixes #1082.

Notes:
- decided to remove borders around pagination elements, looks cleaner.
- the `"dom": 'lfrt<"row"<"col-6"i><".col-6"p>>',` syntax is documented here: https://datatables.net/examples/basic_init/dom.html
- outcommented legacy CSS that I don't think we want/need. `app.css` requires a proper overhaul.
- added more comments around non-obvious javascript config
- todo: de-duplicate datatables initialization code across HTML template files

new look:
![image](https://user-images.githubusercontent.com/265630/231204012-d95cdc77-3ff4-49f9-9eee-742d0a7877f3.png)
