### PR TITLE
app util: define error page not on AppEndpoint

### DIFF
--- a/conbench/app/_endpoint.py
+++ b/conbench/app/_endpoint.py
@@ -8,8 +8,6 @@ import flask.views
 import flask_login
 import werkzeug
 
-from conbench.app._util import error_page
-
 from .. import __version__
 from ..buildinfo import BUILD_INFO
 
@@ -143,16 +141,6 @@ class AppEndpoint(flask.views.MethodView):
         # inject/overwrite
         kwargs["version_string_footer"] = VERSION_STRING_FOOTER
         return f.render_template(template, **kwargs)
-
-    def error_page(self, msg: str, alert_level="danger") -> str:
-        """
-        Generate HTML text which shows an error page, presenting an error
-        message.
-
-        This is OK to be delivered in a status-200 HTTP response for now.
-        """
-        # add more as desired
-        error_page(msg, alert_level)
 
     def flash(self, *args):
         return f.flash(*args)

--- a/conbench/app/_endpoint.py
+++ b/conbench/app/_endpoint.py
@@ -8,11 +8,10 @@ import flask.views
 import flask_login
 import werkzeug
 
+from conbench.app._util import error_page
+
 from .. import __version__
 from ..buildinfo import BUILD_INFO
-from ..config import Config
-
-from conbench.app._util import error_page
 
 log = logging.getLogger(__name__)
 

--- a/conbench/app/_endpoint.py
+++ b/conbench/app/_endpoint.py
@@ -12,6 +12,8 @@ from .. import __version__
 from ..buildinfo import BUILD_INFO
 from ..config import Config
 
+from conbench.app._util import error_page
+
 log = logging.getLogger(__name__)
 
 
@@ -151,14 +153,7 @@ class AppEndpoint(flask.views.MethodView):
         This is OK to be delivered in a status-200 HTTP response for now.
         """
         # add more as desired
-        assert alert_level in ("info", "danger", "primary", "warning")
-        return f.render_template(
-            "error.html",
-            error_message=msg,
-            application=Config.APPLICATION_NAME,
-            title=self.title,  # type: ignore
-            alert_level=alert_level,
-        )
+        error_page(msg, alert_level)
 
     def flash(self, *args):
         return f.flash(*args)

--- a/conbench/app/_util.py
+++ b/conbench/app/_util.py
@@ -5,7 +5,7 @@ from ..hacks import set_display_benchmark_name, set_display_case_permutation
 from ..units import formatter_for_unit
 
 
-def error_page(msg: str, alert_level="danger") -> str:
+def error_page(msg: str, alert_level="danger", subtitle="") -> str:
     """
     Generate HTML text which shows an error page, presenting an error
     message.
@@ -18,7 +18,8 @@ def error_page(msg: str, alert_level="danger") -> str:
         "error.html",
         error_message=msg,
         application=Config.APPLICATION_NAME,
-        title=Config.APPLICATION_NAME,  # self.title,  # type: ignore
+        # The (sub)title of the page
+        title=subtitle,
         alert_level=alert_level,
     )
 

--- a/conbench/app/_util.py
+++ b/conbench/app/_util.py
@@ -1,8 +1,9 @@
 import flask as f
 
+from ..config import Config
 from ..hacks import set_display_benchmark_name, set_display_case_permutation
 from ..units import formatter_for_unit
-from ..config import Config
+
 
 def error_page(msg: str, alert_level="danger") -> str:
     """

--- a/conbench/app/_util.py
+++ b/conbench/app/_util.py
@@ -1,6 +1,8 @@
+import flask as f
+
 from ..hacks import set_display_benchmark_name, set_display_case_permutation
 from ..units import formatter_for_unit
-
+from ..config import Config
 
 def error_page(msg: str, alert_level="danger") -> str:
     """

--- a/conbench/app/_util.py
+++ b/conbench/app/_util.py
@@ -2,6 +2,24 @@ from ..hacks import set_display_benchmark_name, set_display_case_permutation
 from ..units import formatter_for_unit
 
 
+def error_page(msg: str, alert_level="danger") -> str:
+    """
+    Generate HTML text which shows an error page, presenting an error
+    message.
+
+    This is OK to be delivered in a status-200 HTTP response for now.
+    """
+    # add more as desired
+    assert alert_level in ("info", "danger", "primary", "warning")
+    return f.render_template(
+        "error.html",
+        error_message=msg,
+        application=Config.APPLICATION_NAME,
+        title=Config.APPLICATION_NAME,  # self.title,  # type: ignore
+        alert_level=alert_level,
+    )
+
+
 def augment(benchmark, contexts=None):
     set_display_benchmark_name(benchmark)
     set_display_time(benchmark)

--- a/conbench/app/compare.py
+++ b/conbench/app/compare.py
@@ -9,7 +9,7 @@ import flask as f
 from ..app import rule
 from ..app._endpoint import AppEndpoint, authorize_or_terminate
 from ..app._plots import TimeSeriesPlotMixin, simple_bar_plot
-from ..app._util import augment
+from ..app._util import augment, error_page
 from ..app.results import BenchmarkResultMixin, RunMixin
 from ..config import Config
 from ..entities.run import commit_hardware_run_map
@@ -169,19 +169,19 @@ class Compare(AppEndpoint, BenchmarkResultMixin, RunMixin, TimeSeriesPlotMixin):
         """
 
         if "..." not in compare_ids:
-            return self.error_page(  # type: ignore
+            return error_page(  # type: ignore
                 "Got unexpected URL path pattern. Expected: <id>...<id>"
             )
 
         baseline_id, contender_id = compare_ids.split("...", 1)
 
         if not baseline_id:
-            return self.error_page(  # type: ignore
+            return error_page(  # type: ignore
                 "No baseline ID was provided. Expected format: <baseline_id>...<contender_id>"
             )
 
         if not contender_id:
-            return self.error_page(  # type: ignore
+            return error_page(  # type: ignore
                 "No contender ID was provided. Expected format: <baseline-id>...<contender-id>"
             )
 
@@ -193,12 +193,12 @@ class Compare(AppEndpoint, BenchmarkResultMixin, RunMixin, TimeSeriesPlotMixin):
         ) = self._compare(baseline_id=baseline_id, contender_id=contender_id)
 
         if error_string is not None:
-            return self.error_page(  # type: ignore
+            return error_page(  # type: ignore
                 f"cannot perform comparison: {error_string}", alert_level="info"
             )
 
         if len(comparison_results) == 0:
-            return self.error_page(  # type: ignore
+            return error_page(  # type: ignore
                 "comparison yielded 0 benchmark results",
                 alert_level="info",
             )

--- a/conbench/app/compare.py
+++ b/conbench/app/compare.py
@@ -169,20 +169,23 @@ class Compare(AppEndpoint, BenchmarkResultMixin, RunMixin, TimeSeriesPlotMixin):
         """
 
         if "..." not in compare_ids:
-            return error_page(  # type: ignore
-                "Got unexpected URL path pattern. Expected: <id>...<id>"
+            return error_page(
+                "Got unexpected URL path pattern. Expected: <id>...<id>",
+                subtitle=self.title,  # type: ignore
             )
 
         baseline_id, contender_id = compare_ids.split("...", 1)
 
         if not baseline_id:
-            return error_page(  # type: ignore
-                "No baseline ID was provided. Expected format: <baseline_id>...<contender_id>"
+            return error_page(
+                "No baseline ID was provided. Expected format: <baseline_id>...<contender_id>",
+                subtitle=self.title,  # type: ignore
             )
 
         if not contender_id:
-            return error_page(  # type: ignore
-                "No contender ID was provided. Expected format: <baseline-id>...<contender-id>"
+            return error_page(
+                "No contender ID was provided. Expected format: <baseline-id>...<contender-id>",
+                subtitle=self.title,  # type: ignore
             )
 
         (
@@ -193,14 +196,17 @@ class Compare(AppEndpoint, BenchmarkResultMixin, RunMixin, TimeSeriesPlotMixin):
         ) = self._compare(baseline_id=baseline_id, contender_id=contender_id)
 
         if error_string is not None:
-            return error_page(  # type: ignore
-                f"cannot perform comparison: {error_string}", alert_level="info"
+            return error_page(
+                f"cannot perform comparison: {error_string}",
+                alert_level="info",
+                subtitle=self.title,  # type: ignore
             )
 
         if len(comparison_results) == 0:
             return error_page(  # type: ignore
                 "comparison yielded 0 benchmark results",
                 alert_level="info",
+                subtitle=self.title,  # type: ignore
             )
 
         return self.page(


### PR DESCRIPTION
This helper function is useful everywhere where we build a UI view and want to pragmatically display an error/info message to the user. `AppEndpoint` is not a good common place.

I need this in the "conceptual benchmarks list PoC".