### PR TITLE
Add proof-of-concept / starting point for "list conceptual benchmarks" UI section

### DIFF
--- a/conbench/app/__init__.py
+++ b/conbench/app/__init__.py
@@ -23,3 +23,6 @@ from .runs import *  # noqa
 # "Type[conbench.app.users.User]", local name has type
 # "Type[conbench.entities.user.User]"))
 from .users import *  # type: ignore # noqa
+
+# register routes
+from .benchmarks import *

--- a/conbench/app/__init__.py
+++ b/conbench/app/__init__.py
@@ -14,7 +14,7 @@ from .benchmarks import *  # noqa
 from .compare import *  # noqa
 from .hardware import *  # noqa
 from .index import *  # noqa
-from .results import *  # noqa
+from .results import *  # type: ignore # noqa
 from .robots import *  # noqa
 from .runs import *  # noqa
 

--- a/conbench/app/__init__.py
+++ b/conbench/app/__init__.py
@@ -8,6 +8,9 @@ rule: Callable = app.add_url_rule
 
 from .auth import *  # noqa
 from .batches import *  # noqa
+
+# register routes
+from .benchmarks import *  # noqa
 from .compare import *  # noqa
 from .hardware import *  # noqa
 from .index import *  # noqa
@@ -23,6 +26,3 @@ from .runs import *  # noqa
 # "Type[conbench.app.users.User]", local name has type
 # "Type[conbench.entities.user.User]"))
 from .users import *  # type: ignore # noqa
-
-# register routes
-from .benchmarks import *

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -13,7 +13,7 @@ from conbench.job import _cache_bmrs
 log = logging.getLogger(__name__)
 
 
-@app.route("/c-benchmarks/", methods=["GET"])
+@app.route("/c-benchmarks/", methods=["GET"])  # type: ignore
 def list_benchmarks() -> str:
     return flask.render_template(
         "c-benchmarks.html",
@@ -26,7 +26,7 @@ def list_benchmarks() -> str:
     )
 
 
-@app.route("/c-benchmarks/<bname>", methods=["GET"])
+@app.route("/c-benchmarks/<bname>", methods=["GET"])  # type: ignore
 def show_benchmark_cases(bname: str) -> str:
     try:
         results = _cache_bmrs["by_benchmark_name"][bname]
@@ -70,7 +70,7 @@ class TypeUIPlotInfo(TypedDict):
     data_for_uplot: List[List]
 
 
-@app.route("/c-benchmarks/<bname>/<caseid>", methods=["GET"])
+@app.route("/c-benchmarks/<bname>/<caseid>", methods=["GET"])  # type: ignore
 def show_benchmark_results(bname: str, caseid: str) -> str:
     # First, filter by benchmark name.
     try:
@@ -119,7 +119,7 @@ def show_benchmark_results(bname: str, caseid: str) -> str:
                 [r.timestamp.timestamp() for r in results],
                 # rely on mean to be correct? use all data for
                 # error vis
-                [float(r.mean) for r in results],
+                [float(r.mean) for r in results if r.mean is not None],
             ],
             # Rely on at least one result being in the list.
             "title": "hardware: %s, context: %s"
@@ -136,7 +136,6 @@ def show_benchmark_results(bname: str, caseid: str) -> str:
         results_by_hardware_and_context=results_by_hardware_and_context,
         infos_for_uplots_json=infos_for_uplots_json,
         case=case,
-        benchmark_result_count=len(results),
         application=Config.APPLICATION_NAME,
         title=Config.APPLICATION_NAME,  # type: ignore
     )

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -1,0 +1,145 @@
+import logging
+import json
+from collections import defaultdict
+
+from typing import Dict, List, Tuple, TypedDict
+
+
+import flask
+
+from conbench.app import app
+from conbench.entities.benchmark_result import BenchmarkResult
+from conbench.config import Config
+from conbench.job import _cache_bmrs
+
+
+log = logging.getLogger(__name__)
+
+
+@app.route("/c-benchmarks/", methods=["GET"])
+def list_benchmarks() -> str:
+    return flask.render_template(
+        "c-benchmarks.html",
+        # benchmarks_by_name=benchmarks_by_name,
+        benchmarks_by_name=_cache_bmrs["by_benchmark_name"],
+        benchmark_result_count=len(_cache_bmrs["by_id"]),
+        bmr_cache_meta=_cache_bmrs["meta"],
+        application=Config.APPLICATION_NAME,
+        title=Config.APPLICATION_NAME,  # type: ignore
+    )
+
+
+@app.route("/c-benchmarks/<bname>", methods=["GET"])
+def show_benchmark_cases(bname: str) -> str:
+    try:
+        results = _cache_bmrs["by_benchmark_name"][bname]
+    except KeyError:
+        return f"benchmark name not known: `{bname}`"
+
+    # cases = set(bmr.case for bmr in results)
+
+    results_by_case = defaultdict(list)
+    for r in results:
+        results_by_case[r.case].append(r)
+
+    hardware_count_per_case = {}
+    for case in results_by_case.keys():
+        # The indirection through `.run` here is an architecture / DB schema
+        # smell I think. This might fetch run dynamically from the DB>
+        hardware_count_per_case[case] = len(set([r.run.hardware for r in results]))
+
+    context_count_per_case = {}
+    for case, results in results_by_case.items():
+        context_count_per_case[case] = len(set([r.context for r in results]))
+
+    return flask.render_template(
+        "c-benchmark-cases.html",
+        # benchmarks_by_name=benchmarks_by_name,
+        # benchmarks_results=results,
+        benchmark_name=bname,
+        bmr_cache_meta=_cache_bmrs["meta"],
+        results_by_case=results_by_case,
+        hardware_count_per_case=hardware_count_per_case,
+        context_count_per_case=context_count_per_case,
+        # cases=cases,
+        benchmark_result_count=len(results),
+        application=Config.APPLICATION_NAME,
+        title=Config.APPLICATION_NAME,  # type: ignore
+    )
+
+
+class TypeUIPlotInfo(TypedDict):
+    title: str
+    data_for_uplot: List[List]
+
+
+@app.route("/c-benchmarks/<bname>/<caseid>", methods=["GET"])
+def show_benchmark_results(bname: str, caseid: str) -> str:
+    # First, filter by benchmark name.
+    try:
+        results_all_with_bname = _cache_bmrs["by_benchmark_name"][bname]
+    except KeyError:
+        return f"benchmark name not known: `{bname}`"
+
+    # Now, filter those that have the required case ID set.
+    matching_results = []
+    for r in results_all_with_bname:
+        if r.case.id == caseid:
+            matching_results.append(r)
+
+    log.info(
+        "results_all_with_bname: %s, results with caseid and bname: %s",
+        len(results_all_with_bname),
+        len(matching_results),
+    )
+    # Be explicit that this is now of no use.
+    del results_all_with_bname
+
+    if matching_results:
+        case = matching_results[0].case
+    else:
+        return f"no results found for benchmark `{bname}` and case `{caseid}`"
+
+    results_by_hardware_and_context: Dict[Tuple, List[BenchmarkResult]] = defaultdict(
+        list
+    )
+
+    # Build up timeseries of results (group results, don't sort them yet)
+    for result in matching_results:
+        # The indirection through `.run` here is an architecture / DB schema
+        # smell I think. This might fetch run dynamically from the DB.
+        # Store hardware name in dictionary key, for convenience.
+        h = result.run.hardware
+        hwid, hwname, ctxid = h.id, h.name, result.context.id
+        results_by_hardware_and_context[(hwid, ctxid, hwname)].append(result)
+
+    # This is going to be accessed with JavaScript.
+    infos_for_uplots = {}
+
+    for (hwid, ctxid, _), results in results_by_hardware_and_context.items():
+        infos_for_uplots[f"{hwid}_{ctxid}"] = {
+            "data_for_uplot": [
+                [r.timestamp.timestamp() for r in results],
+                # rely on mean to be correct? use all data for
+                # error vis
+                [float(r.mean) for r in results],
+            ],
+            # Rely on at least one result being in the list.
+            "title": "hardware: %s, context: %s"
+            % (results[0].ui_hardware_short, ctxid[:7]),
+        }
+
+    infos_for_uplots_json = json.dumps(infos_for_uplots, indent=2)
+    return flask.render_template(
+        "c-benchmark-results-for-case.html",
+        # benchmarks_by_name=benchmarks_by_name,
+        benchmark_results=matching_results,
+        benchmark_name=bname,
+        bmr_cache_meta=_cache_bmrs["meta"],
+        results_by_hardware_and_context=results_by_hardware_and_context,
+        infos_for_uplots_json=infos_for_uplots_json,
+        case=case,
+        benchmark_result_count=len(results),
+        application=Config.APPLICATION_NAME,
+        title=Config.APPLICATION_NAME,  # type: ignore
+    )

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -1,17 +1,14 @@
-import logging
 import json
+import logging
 from collections import defaultdict
-
 from typing import Dict, List, Tuple, TypedDict
-
 
 import flask
 
 from conbench.app import app
-from conbench.entities.benchmark_result import BenchmarkResult
 from conbench.config import Config
+from conbench.entities.benchmark_result import BenchmarkResult
 from conbench.job import _cache_bmrs
-
 
 log = logging.getLogger(__name__)
 

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -442,9 +442,12 @@ class BenchmarkResult(Base, EntityMixin):
     @property
     def ui_non_null_sample_count(self) -> str:
         """
-        If an individual iteration can report a `null`-like value, then
-        this here is the number of samples.
+        The number of actual data points (with payload, a numeric value). If an
+        individual iteration can report a `null`-like value, then this here is
+        the number of samples.
         """
+        if self.data is None:
+            return "0"
         return str(len([x for x in self.data if x is not None]))
 
     @property

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -1,6 +1,6 @@
 import math
-from datetime import datetime, timezone
 import statistics
+from datetime import datetime, timezone
 from typing import List, Optional
 
 import flask as f

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -11,7 +11,14 @@
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
 <link href="https://cdn.datatables.net/v/bs5/dt-1.13.3/r-2.4.0/datatables.min.css" rel="stylesheet">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.3/font/bootstrap-icons.css">
+
+
 <link href="{{ url_for('static', filename='app.css') }}" rel=stylesheet type=text/css>
+
+
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/uplot@1.6.24/dist/uPlot.min.css">
+
+
 {% endblock %}
 <title>{% block title %}{% if title %}{{ application }} - {{ title }}{% else %}{{ application }}{% endif %}{% endblock %}</title>
 </head>
@@ -108,6 +115,7 @@
 
 {% block scripts %}
 <script src="https://code.jquery.com/jquery-3.6.4.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/uplot@1.6.24/dist/uPlot.iife.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4" crossorigin="anonymous"></script>
 <!--
     Note(JP): I think the datatables responsive plugin (included as version
@@ -118,7 +126,6 @@
 -->
 <script src="https://cdn.datatables.net/v/bs5/dt-1.13.4/datatables.min.js"></script>
 <script src="https://cdn.datatables.net/plug-ins/1.13.3/features/conditionalPaging/dataTables.conditionalPaging.min.js"></script>
-
 <script>
 $(document).ready(function() {
     setTimeout(function() {

--- a/conbench/templates/c-benchmark-cases.html
+++ b/conbench/templates/c-benchmark-cases.html
@@ -1,0 +1,86 @@
+{% extends "app.html" %}
+{% block app_content %}
+
+
+<h3><strong>{{ benchmark_name }}</strong> / unique case permutations</h3>
+
+<p>
+    Found {{ benchmark_result_count }} result(s) for benchmark <code>{{benchmark_name}}</code>,
+    spanning {{results_by_case|length}} case(s).
+    <br>
+    Based on {{ bmr_cache_meta.n_results }} results reported in
+    total between {{bmr_cache_meta.oldest_result_time_str}} and
+    {{bmr_cache_meta.newest_result_time_str}}.
+</p>
+
+<div class="mt-5">
+    <table class="table table-hover conbench-datatable" style="width:100%; display: none">
+    <thead>
+        <tr>
+            <th scope="col">case id</th>
+            <th scope="col" style="width: 60%">case permutation</th>
+            <th scope="col" style="width: 7%"># results</th>
+            <th scope="col" style="width: 9%"># hardwares</th>
+            <th scope="col" style="width: 8%"># contexts</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for case, results in results_by_case.items() %}
+    <tr>
+        <td class="font-monospace">
+            <a href="{{ url_for('app.show_benchmark_results', bname=benchmark_name, caseid=case.id) }}">{{ case.id[:10] }}</a>
+        </td>
+        <td class="font-monospace">{{ case.text_id }}</td>
+        <td class="font-monospace">{{ results|length }}</td>
+        <td class="font-monospace">{{ hardware_count_per_case[case] }}</td>
+        <td class="font-monospace">{{ context_count_per_case[case] }}</td>
+    </tr>
+    {% endfor %}
+    </tbody>
+    </table>
+</div>
+
+{% endblock %}
+
+
+{% block scripts %}
+{{super()}}
+<script type="text/javascript">
+$(document).ready(function () {
+
+    // Enable bootstrap tooltips on this page.
+    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
+    const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+
+    $('table.conbench-datatable').each(function() {
+        $(this).DataTable({
+            // Note(JP): this enables a special, simple plugin called
+            // `conditionalPaging` which must be included, e.g. via the dist URLs
+            // published in https://cdn.datatables.net/plug-ins/1.13.3/features/.
+            // kudos to https://stackoverflow.com/a/29639664/145400
+            "conditionalPaging": true,
+            "responsive": true,
+            // the default default seems to be the first item in lengthMenu.
+            "lengthMenu": [ 5, 10, 50, 75, 100, 250, 750 ],
+            // but when pageLength is also set, then _this_ is the default.
+            "pageLength": 50,
+            // Take rather precise control of layouting elements, put bottom elements
+            // into a mult-col single row, using BS's grid system.
+            "dom": 'lfrt<"row"<"col-6"i><".col-6"p>>',
+            "order": [[0, 'desc']],
+            "columnDefs": [{ "orderable": true }],
+            initComplete: function () {
+                var api = this.api();
+                // reveal only after DOM modification is complete (reduce loading
+                // layout shift artifacts)
+                $('table.conbench-datatable').show();
+                api.columns.adjust();
+                $('.pagination').addClass('pagination-sm'); // add BS class for smaller pagination bar
+            },
+        });
+    });
+});
+
+
+</script>
+{% endblock %}

--- a/conbench/templates/c-benchmark-results-for-case.html
+++ b/conbench/templates/c-benchmark-results-for-case.html
@@ -2,14 +2,13 @@
 {% block app_content %}
 
 <div>
-<!--
-<h1 class="display-4">Results</h1>
-<h2>Results</h2>
--->
-<p class="fs-4">
-<strong>{{ benchmark_name }}</strong> <br>
-Results for <code>{{ case.text_id }}</code>
-</p>
+<h3><strong>{{ benchmark_name }}</strong> / case {{ case.id[:7] }}</h3>
+<span class="fs-4"><code>{{ case.text_id }}</code></span>
+
+<p>Based on {{ benchmark_results|length }} results reported in
+    total between {{bmr_cache_meta.oldest_result_time_str}} and
+    {{bmr_cache_meta.newest_result_time_str}}.
+ </p>
 
 <!--<h1>Results for</h1>
 <ul>
@@ -22,7 +21,7 @@ Results for <code>{{ case.text_id }}</code>
 <table class="table table-hover conbench-datatable" style="width:100%; display: none">
 <thead>
     <tr>
-        <th scope="col" style="width: 25%">time</th>
+        <th scope="col" style="width: 21%">time</th>
         <th scope="col">result</th>
         <th scope="col">hardware</th>
         <th scope="col">ctx id</th>
@@ -48,7 +47,7 @@ Results for <code>{{ case.text_id }}</code>
         <a href="{{ url_for('app.benchmark-result', benchmark_result_id=result.id) }}">{{ result.id [:9]}}</a>
     </td>
     <td class="font-monospace">{{ result.ui_hardware_short }}</td>
-    <td class="font-monospace">{{ result.context.id[:7] }}</td>
+    <td class="font-monospace">{{ result.context.id[:8] }}</td>
     <td class="font-monospace">{{ result.ui_non_null_sample_count }}</td>
     <td class="font-monospace">{{ result.ui_mean_and_uncertainty }}</td>
     <td class="font-monospace">{{ result.ui_rel_sem }}</td>
@@ -58,38 +57,36 @@ Results for <code>{{ case.text_id }}</code>
 </table>
 </div>
 
-
 <div class="mt-5">
-    <table class="table table-hover conbench-datatable foob" style="width:100%; display: none">
-    <thead>
-        <tr>
-            <th scope="col" style="width: 15%">hw/ctx</th>
-            <th scope="col" style="width: 25%">samples</th>
-            <th scope="col" style="width: 500px">evolution</th>
-        </tr>
-    </thead>
-    <tbody>
-    {% for hwctx, results in results_by_hardware_and_contexts.items() %}
-    <tr>
-        <td class="font-monospace">{{ hwctx }}</td>
-        <td class="font-monospace">
-            {{ results|length}} results
-        </td>
-        <td>
-            <div class="cb-plot-{{ hwctx }}" style="width: 500px"></div>
-        </td>
-    </tr>
-    {% endfor %}
-    </tbody>
-    </table>
-</div>
+    <h4 class="mb-3">Plots
+        <i class="bi bi-info-circle" data-bs-toggle="tooltip"
+        data-bs-title="Benchmark results, grouped by unique (hardware, context) combinations.
+        Time axis: benchmark result start time (associated commit data is not used),
+        ordinate: mean value, if multisample.
+        ">
+    </i>
+    </h4>
 
+    <!-- https://getbootstrap.com/docs/5.2/layout/grid/#row-columns -->
+    <div class="row .row-cols-auto">
+
+        {% for (hwid, ctxid, hwname), results in results_by_hardware_and_context.items() %}
+
+        <!-- with xl-6 I have tested that each plot (fixed width) has enough space -->
+        <div class="col-xl-6 mb-5">
+            <h5 class="mt-2">hardware {{hwid[:4]}} ({{hwname[:22]}}), context {{ctxid[:6]}}: {{ results|length}} results</h5>
+            <div class="cb-plot-{{hwid}}_{{ctxid}}" style="width: 550px"></div>
+        </div>
+        {% endfor %}
+    </div>
+</div>
+</div>
 
 {% endblock %}
 
 {% block scripts %}
 {{super()}}
-<script type="text/javascript">
+<script>
 
 // let data = [
 //   [1546300800, 1546387200],    // x-values (timestamps)
@@ -97,76 +94,84 @@ Results for <code>{{ case.text_id }}</code>
 //   [        90,         15],    // y-values (series 2)
 // ];
 
-
-let data_by_hwctx = {{ datas_for_plot_json|safe}};
-
+// An Object intended toi
+let plot_info_by_hwctx = {{ infos_for_uplots_json|safe }};
 
 
 $(document).ready(function () {
     let plotopts = {
         title: "",
         class: "cb-uplot",
-        width: 400,
-        height: 500,
+        width: 550,
+        height: 200,
+        cursor: {
+            show: false,
+        },
+        legend: {
+            show: false,
+        },
         series: [
             {},
             {
             sorted: 0,
             show: true,
             spanGaps: false,
-            //value: (self, rawValue) => "$" + rawValue.toFixed(5),
-            stroke: "red",
-            //width: 1,
+            stroke: 'rgb(87, 125, 134)',
+            width: 0.5,
+            // I have been taking greenish colors from this palette:
+            // https://colorhunt.co/palette/b9eddd87cbb9569daa577d86 We can
+            // think about greenifying some graphs, and reddifying others,
+            // based on their properties.
+            fill: "rgba(135, 203, 185, 0.4)",
             //fill: "rgba(255, 0, 0, 0.3)",
             //dash: [10, 5],
-            scale: "s",
+            scale: "y",
             points: {
-                fill: 'black',
-                size: 8,
+                // Without `show: true`, points do not always show.
+                show: true,
+                size: 5,
+                fill: 'rgba(87, 125, 134, 0.7)'
                 }
             }
         ],
         axes: [
             {},
             {
-            show: true,
-            label: "Population",
-            labelSize: 30,
-            labelFont: "bold 12px Arial",
-            font: "12px Arial",
-            gap: 5,
-            size: 50,
-            stroke: "red",
-            grid: {
-                show: true,
-                stroke: "#eee",
-                width: 2,
-                dash: [],
-            },
-            ticks: {
-                show: true,
-                stroke: "#eee",
-                width: 2,
-                dash: [],
-                size: 10,
-            }
+                scale: "y",
+                // give y axis labels some space
+                size: 60,
+                // This is used for y axis formatting. Trade-off:
+                // predictable width, medium precision is sufficient.
+                values: (u, splits) => splits.map((v) => v.toExponential(2)),
             }
         ],
         scales: {
-            "s": {
+
+            "y": {
+                //range: [0, 200000]
                 //auto: false,
-                range:  {
-                    min: {
-                        pad: 0.2,
-                        soft: 0,
-                        mode: 1,
-                    },
-                    max: {
-                        pad: 0.5,
-                        soft: 0,
-                        mode: 1,
-                    },
-                }
+                // range:  {
+                //     min: {
+                //         pad: 0.2,
+                //         soft: 0,
+                //         mode: 1,
+                //     },
+                //     max: {
+                //         pad: 0.5,
+                //         soft: 200000,
+                //         mode: 3,
+                //     }
+                // }
+
+                range: (u, datamin, datamax) => {
+                    // Preparing for all kinds of ranges and orders of
+                    // magnitude, always show the zero for keeping plots most
+                    // meaningful -- if the relative change is very small then
+                    // it will be rather invisible in a plot like this, which
+                    // is the goal.
+                    return [0, datamax * 1.2];
+                },
+
             }
         },
     };
@@ -175,9 +180,9 @@ $(document).ready(function () {
     //     let uplot = new uPlot(plotopts["{{ data_by_hwctx }}"], data, $(this));
     // });
     // use jquery selector, but then get raw element with [0]
-    {% for hwctx, results in results_by_hardware_and_contexts.items() %}
-
-        let uplot_{{ hwctx }} = new uPlot(plotopts, data_by_hwctx["{{ hwctx }}"], $('.cb-plot-{{ hwctx }}')[0]);
+    {% for (hwid, ctxid, _), results in results_by_hardware_and_context.items() %}
+        console.log(plot_info_by_hwctx["{{hwid}}_{{ctxid}}"]["data_for_uplot"]);
+        let uplot_{{hwid}}_{{ctxid}} = new uPlot(plotopts, plot_info_by_hwctx["{{hwid}}_{{ctxid}}"]["data_for_uplot"], $('.cb-plot-{{hwid}}_{{ctxid}}')[0]);
     {% endfor %}
 
     // Enable bootstrap tooltips on this page.
@@ -195,7 +200,7 @@ $(document).ready(function () {
             // the default default seems to be the first item in lengthMenu.
             "lengthMenu": [ 5, 10, 50, 75, 100, 250, 750 ],
             // but when pageLength is also set, then _this_ is the default.
-            "pageLength": 50,
+            "pageLength": 10,
             // Take rather precise control of layouting elements, put bottom elements
             // into a mult-col single row, using BS's grid system.
             "dom": 'lfrt<"row"<"col-6"i><".col-6"p>>',

--- a/conbench/templates/c-benchmark-results-for-case.html
+++ b/conbench/templates/c-benchmark-results-for-case.html
@@ -1,0 +1,138 @@
+{% extends "app.html" %}
+{% block app_content %}
+
+<div>
+<!--
+<h1 class="display-4">Results</h1>
+<h2>Results</h2>
+-->
+<p class="fs-4">
+<strong>{{ benchmark_name }}</strong> <br>
+Results for <code>{{ case.text_id }}</code>
+</p>
+
+<!--<h1>Results for</h1>
+<ul>
+    <li>Benchmark name: <code>{{ benchmark_name }}</code></li>
+    <li>Case: <code>{{ case.text_id }}</code></li>
+</ul>
+<p>Found {{ benchmark_result_count }} result(s).</p>
+-->
+<div class="mt-5">
+<table class="table table-hover conbench-datatable" style="width:100%; display: none">
+<thead>
+    <tr>
+        <th scope="col" style="width: 25%">time</th>
+        <th scope="col">result</th>
+        <th scope="col">hardware</th>
+        <th scope="col">ctx id</th>
+        <th scope="col" style="width: 10%"># samples</th>
+        <th scope="col" style="width: 20%">data</th>
+        <th scope="col" style="width: 10%">
+            rel err
+            <i class="bi bi-info-circle" data-bs-toggle="tooltip"
+                data-bs-title="
+                Relative standard error: standard error
+                of the mean in relationship to the mean value. Only built
+                when at least three samples are reported by this result.
+                ">
+            </i>
+        </th>
+    </tr>
+</thead>
+<tbody>
+{% for result in benchmark_results %}
+<tr>
+    <td class="font-monospace">{{ result.ui_timestamp }}</td>
+    <td class="font-monospace">
+        <a href="{{ url_for('app.benchmark-result', benchmark_result_id=result.id) }}">{{ result.id [:9]}}</a>
+    </td>
+    <td class="font-monospace">{{ result.ui_hardware_short }}</td>
+    <td class="font-monospace">{{ result.context.id[:7] }}</td>
+    <td class="font-monospace">{{ result.ui_non_null_sample_count }}</td>
+    <td class="font-monospace">{{ result.ui_mean_and_uncertainty }}</td>
+    <td class="font-monospace">{{ result.ui_rel_sem }}</td>
+</tr>
+{% endfor %}
+</tbody>
+</table>
+</div>
+
+
+<div class="mt-5">
+    <table class="table table-hover conbench-datatable" style="width:100%; display: none">
+    <thead>
+        <tr>
+            <th scope="col" style="width: 25%">hw/ctx</th>
+            <th scope="col">samples</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for hwctx, results in results_by_hardware_and_contexts.items() %}
+    <tr>
+        <td class="font-monospace">{{ hwctx }}</td>
+        <td class="font-monospace">
+            {% for res in results %}
+             {{ res.timestamp }} {{ res.data }}<br>
+            {% endfor %}
+        </td>
+    </tr>
+    {% endfor %}
+    </tbody>
+    </table>
+</div>
+
+
+
+{% endblock %}
+
+{% block scripts %}
+{{super()}}
+<script type="text/javascript">
+$(document).ready(function () {
+
+    // Enable bootstrap tooltips on this page.
+    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
+    const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+
+    $('table.conbench-datatable').each(function() {
+        $(this).DataTable({
+            // Note(JP): this enables a special, simple plugin called
+            // `conditionalPaging` which must be included, e.g. via the dist URLs
+            // published in https://cdn.datatables.net/plug-ins/1.13.3/features/.
+            // kudos to https://stackoverflow.com/a/29639664/145400
+            "conditionalPaging": true,
+            "responsive": true,
+            // the default default seems to be the first item in lengthMenu.
+            "lengthMenu": [ 5, 10, 50, 75, 100, 250, 750 ],
+            // but when pageLength is also set, then _this_ is the default.
+            "pageLength": 50,
+            // Take rather precise control of layouting elements, put bottom elements
+            // into a mult-col single row, using BS's grid system.
+            "dom": 'lfrt<"row"<"col-6"i><".col-6"p>>',
+            "order": [[0, 'desc']],
+            "columnDefs": [{ "orderable": true }],
+            initComplete: function () {
+                var api = this.api();
+                // reveal only after DOM modification is complete (reduce loading
+                // layout shift artifacts)
+                $('table.conbench-datatable').show();
+                api.columns.adjust();
+                $('.pagination').addClass('pagination-sm'); // add BS class for smaller pagination bar
+            },
+        });
+    });
+});
+</script>
+{% endblock %}
+
+
+
+
+
+
+
+
+
+
+

--- a/conbench/templates/c-benchmark-results-for-case.html
+++ b/conbench/templates/c-benchmark-results-for-case.html
@@ -60,11 +60,12 @@ Results for <code>{{ case.text_id }}</code>
 
 
 <div class="mt-5">
-    <table class="table table-hover conbench-datatable" style="width:100%; display: none">
+    <table class="table table-hover conbench-datatable foob" style="width:100%; display: none">
     <thead>
         <tr>
-            <th scope="col" style="width: 25%">hw/ctx</th>
-            <th scope="col">samples</th>
+            <th scope="col" style="width: 15%">hw/ctx</th>
+            <th scope="col" style="width: 25%">samples</th>
+            <th scope="col" style="width: 500px">evolution</th>
         </tr>
     </thead>
     <tbody>
@@ -72,9 +73,10 @@ Results for <code>{{ case.text_id }}</code>
     <tr>
         <td class="font-monospace">{{ hwctx }}</td>
         <td class="font-monospace">
-            {% for res in results %}
-             {{ res.timestamp }} {{ res.data }}<br>
-            {% endfor %}
+            {{ results|length}} results
+        </td>
+        <td>
+            <div class="cb-plot-{{ hwctx }}" style="width: 500px"></div>
         </td>
     </tr>
     {% endfor %}
@@ -83,17 +85,104 @@ Results for <code>{{ case.text_id }}</code>
 </div>
 
 
-
 {% endblock %}
 
 {% block scripts %}
 {{super()}}
 <script type="text/javascript">
+
+// let data = [
+//   [1546300800, 1546387200],    // x-values (timestamps)
+//   [        35,         71],    // y-values (series 1)
+//   [        90,         15],    // y-values (series 2)
+// ];
+
+
+let data_by_hwctx = {{ datas_for_plot_json|safe}};
+
+
+
 $(document).ready(function () {
+    let plotopts = {
+        title: "",
+        class: "cb-uplot",
+        width: 400,
+        height: 500,
+        series: [
+            {},
+            {
+            sorted: 0,
+            show: true,
+            spanGaps: false,
+            //value: (self, rawValue) => "$" + rawValue.toFixed(5),
+            stroke: "red",
+            //width: 1,
+            //fill: "rgba(255, 0, 0, 0.3)",
+            //dash: [10, 5],
+            scale: "s",
+            points: {
+                fill: 'black',
+                size: 8,
+                }
+            }
+        ],
+        axes: [
+            {},
+            {
+            show: true,
+            label: "Population",
+            labelSize: 30,
+            labelFont: "bold 12px Arial",
+            font: "12px Arial",
+            gap: 5,
+            size: 50,
+            stroke: "red",
+            grid: {
+                show: true,
+                stroke: "#eee",
+                width: 2,
+                dash: [],
+            },
+            ticks: {
+                show: true,
+                stroke: "#eee",
+                width: 2,
+                dash: [],
+                size: 10,
+            }
+            }
+        ],
+        scales: {
+            "s": {
+                //auto: false,
+                range:  {
+                    min: {
+                        pad: 0.2,
+                        soft: 0,
+                        mode: 1,
+                    },
+                    max: {
+                        pad: 0.5,
+                        soft: 0,
+                        mode: 1,
+                    },
+                }
+            }
+        },
+    };
+
+    // $('table.conbench-datatable').each(function() {
+    //     let uplot = new uPlot(plotopts["{{ data_by_hwctx }}"], data, $(this));
+    // });
+    // use jquery selector, but then get raw element with [0]
+    {% for hwctx, results in results_by_hardware_and_contexts.items() %}
+
+        let uplot_{{ hwctx }} = new uPlot(plotopts, data_by_hwctx["{{ hwctx }}"], $('.cb-plot-{{ hwctx }}')[0]);
+    {% endfor %}
 
     // Enable bootstrap tooltips on this page.
-    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
-    const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+    const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));
 
     $('table.conbench-datatable').each(function() {
         $(this).DataTable({

--- a/conbench/templates/c-benchmarks.html
+++ b/conbench/templates/c-benchmarks.html
@@ -1,0 +1,20 @@
+{% extends "app.html" %}
+{% block app_content %}
+
+
+
+
+<h4>Benchmarks (by name)</h4>
+<p>Based on {{ benchmark_result_count }} results reported in
+    total between {{bmr_cache_meta.oldest_result_time_str}} and
+    {{bmr_cache_meta.newest_result_time_str}}.
+ </p>
+
+<br>
+{% for benchmark_name, results in benchmarks_by_name.items() %}
+<a href="{{ url_for('app.show_benchmark_cases', bname=benchmark_name) }}">{{ benchmark_name }}</a>
+    ({{ results|length }} results)<br>
+{% endfor %}
+
+
+{% endblock %}


### PR DESCRIPTION
A starting point for the "list conceptual benchmarks" UI section.

Depends on the BMRT cache (#1085).

Three views so far:

- list of all known benchmark names (and associated benchmark results)
    - for each: list of all known case permutations for that benchmark name (and associated results)
        - for each: benchmark results, grouped by unique (hardware, context) combinations. A plot for each.

Each of these views already has a few ideas sprinkled in, but this is mainly to spark further ideas and discussion. I have many ideas more, but want to get a rudimentary version landed before entering more iteration.

Two ideas in this PR that fit the picture 'prototype / proof-of-concept'
- the new UI routes are experimental, not yet linked from any menu.
- the new UI routes are not covered by tests.

This serves as a foundation for discussion in the team, and I'd also (in)validate some assumptions by getting this into staging.

For building this a great help was to develop against a snapshot of the Arrow Conbench DB (see #976).

Plot: time axis: benchmark result start time (associated commit data is not used), ordinate: mean value, if multisample.

This deserves more text. Coming.

### uPlot

This introduces [uplot](https://github.com/leeoniya/uPlot). Well, for now -- I think it's very much worth giving a try for building [small multiples](https://en.wikipedia.org/wiki/Small_multiple). Had an eye on this project for a long time and was looking for a use case, and the [small multiple] is I think a perfect use case, considering that we do not want to render into a single image artifact.

The advantage of uPlot lies in interesting technical decisions.
The disadvantage of uPlot is a rather limited feature set as well as a bit of a lack of docs. The API docs are pretty good (TS type-based self documentation).

I found useful:

https://github.com/leeoniya/uPlot/blob/master/dist/uPlot.d.ts
https://leeoniya.github.io/uPlot/demos/index.html
https://github.com/leeoniya/uPlot/tree/master/docs
https://github.com/leeoniya/uPlot/issues/107
https://github.com/leeoniya/uPlot/issues/657

Alternatives briefly considered:
https://plotly.com/javascript/
https://github.com/danvk/dygraphs

-----------------
A screenshot of one of the new views (everything is very much work in progress; content was more important than design):

![Screenshot from 2023-04-11 15-19-27](https://user-images.githubusercontent.com/265630/231280419-b51ce78f-1083-4cb3-ab06-25775db28817.png)
