### PR TITLE
metrics: remove multiproc support, add GAUGE_BMRT_CACHE_LAST_UPDATE_SECONDS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,17 +53,6 @@ RUN pwd && /bin/ls -1 .
 # importlib.metadata.PackageNotFoundError: No package metadata was found for conbench
 RUN pip install .
 
-
-# Make it so that this directory exists in the container file system. That's
-# the value of the PROMETHEUS_MULTIPROC_DIR env var. The prometheus-client
-# Python library needs this to be set to a path pointing to a directory. I have
-# tried setting this up within the CPython process (early during import) but
-# that wasn't early enough. Note that when mounting the host's /tmp to the
-# container's /tmp the host is expected to have /tmp/_conbench-promcl-coord-dir
-# in its file system.
-RUN mkdir -p /tmp/_conbench-promcl-coord-dir
-
-
 # Bake build information into container image. This invalidates the layer
 # cache for every commit and therefore it is important to do this as late as
 # possible in this Dockerfile.

--- a/ci/minikube/conbench-config-for-minikube.yml
+++ b/ci/minikube/conbench-config-for-minikube.yml
@@ -17,8 +17,3 @@ data:
   DISTRIBUTION_COMMITS: "100"
   # value does not seem to matter, hard-coded in gunicorn cmd
   FLASK_APP: foobarrofl
-  # For
-  # https://github.com/prometheus/client_python#multiprocess-mode-eg-gunicorn
-  # timing of setting this matters:
-  # https://github.com/rycus86/prometheus_flask_exporter/issues/131
-  PROMETHEUS_MULTIPROC_DIR: /tmp/_conbench-promcl-coord-dir

--- a/conbench-config.yml
+++ b/conbench-config.yml
@@ -13,5 +13,3 @@ data:
   DB_PORT: "{{DB_PORT}}"
   FLASK_APP: "{{FLASK_APP}}"
   DISTRIBUTION_COMMITS: "{{DISTRIBUTION_COMMITS}}"
-  # Hardcoding this for now. We can always make it configurable in the future.
-  PROMETHEUS_MULTIPROC_DIR: /tmp/_conbench-promcl-coord-dir

--- a/conbench/gunicorn-conf.py
+++ b/conbench/gunicorn-conf.py
@@ -2,7 +2,6 @@ import os
 import signal
 import sys
 
-
 """
 Gunicorn configuration that applies in testing and prod environments.
 

--- a/conbench/gunicorn-conf.py
+++ b/conbench/gunicorn-conf.py
@@ -2,55 +2,12 @@ import os
 import signal
 import sys
 
+
 """
-Relevant docs:
+Gunicorn configuration that applies in testing and prod environments.
 
-- https://github.com/rycus86/prometheus_flask_exporter#wsgi
-- https://github.com/prometheus/client_python#multiprocess-mode-eg-gunicorn
-
-prometheus_flask_exporter provides a useful quickstart, exposing relevant
-metrics around HTTP request handlers. It is however potentially a little too
-opinionated. I have not yet looked into adding custom metrics (like a custom
-gauge, or counter).
-
-I'd also like to add that the 'multiprocess complication' is not great to have
-in the system. I think that generally these limitations are fine:
-https://github.com/prometheus/client_python#multiprocess-mode-eg-gunicorn
-
-But the added complexity compared to a more canonical setup is maybe hurtful in
-the future.
-
-Yet, I believe this is a great starting point. Within the 'multiprocess
-complication' there is a choice to make: expose the /metrics HTTP endpoint in
-the same HTTP server that handles regular HTTP requests, or spawn a separate
-HTTP server for that? The latter has the advantage of separation of concerns
-(metrics can still be obtained in case of a dead-locked main HTTP server).
-Maybe the access log is a relevant criterion, too. I'd love to see an access
-log showing the requests to the /metrics endpoint.
+https://docs.gunicorn.org/en/stable/settings.html#config-file
 """
-
-# What's outcommented is a method that can be used when running a separate
-# gunicorn HTTP server for serving the metrics endpoing.
-#
-# from prometheus_flask_exporter.multiprocess import GunicornPrometheusMetrics
-# def when_ready(server):
-#     GunicornPrometheusMetrics.start_http_server_when_ready(8000, "0.0.0.0")
-#     print(
-#         'done with: GunicornPrometheusMetrics.start_http_server_when_ready(8000, "0.0.0.0")'
-#     )
-# def child_exit(server, worker):
-#     GunicornPrometheusMetrics.mark_process_dead_on_child_exit(worker.pid)
-#
-
-from prometheus_flask_exporter.multiprocess import GunicornInternalPrometheusMetrics
-
-
-def child_exit(server, worker):
-    GunicornInternalPrometheusMetrics.mark_process_dead_on_child_exit(worker.pid)
-
-
-# Canonical gunicorn config below this line.
-# https://docs.gunicorn.org/en/stable/settings.html#config-file
 
 
 bind = ["0.0.0.0:5000"]

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -8,8 +8,8 @@ from typing import Dict, List, TypedDict
 
 from sqlalchemy import select
 
-from conbench.config import Config
 import conbench.metrics
+from conbench.config import Config
 from conbench.db import Session
 from conbench.entities.benchmark_result import BenchmarkResult
 from conbench.hacks import get_case_kvpair_strings

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -9,6 +9,7 @@ from typing import Dict, List, TypedDict
 from sqlalchemy import select
 
 from conbench.config import Config
+import conbench.metrics
 from conbench.db import Session
 from conbench.entities.benchmark_result import BenchmarkResult
 from conbench.hacks import get_case_kvpair_strings
@@ -103,6 +104,8 @@ def _fetch_and_cache_most_recent_results(n=0.2 * 10**6) -> None:
     )
 
     t2 = time.monotonic()
+
+    conbench.metrics.GAUGE_BMRT_CACHE_LAST_UPDATE_SECONDS.set(t2 - t0)
 
     log.info(
         (

--- a/conbench/metrics.py
+++ b/conbench/metrics.py
@@ -22,8 +22,6 @@ import time
 
 import flask
 import prometheus_client
-from prometheus_flask_exporter import NO_PREFIX
-from prometheus_flask_exporter.multiprocess import GunicornInternalPrometheusMetrics
 
 log = logging.getLogger(__name__)
 
@@ -59,9 +57,6 @@ GAUGE_GITHUB_HTTP_API_QUOTA_REMAINING = prometheus_client.Gauge(
     "conbench_github_httpapi_quota_remaining",
     "A gauge that shows the last-observed x-ratelimit-remaining response "
     "header value.",
-    # multiprocess mode gauges are tricky!
-    # https://github.com/prometheus/client_python#multiprocess-mode-eg-gunicorn
-    multiprocess_mode="liveall",
 )
 
 gauge_gh_api_rem_set = {"set": False}
@@ -95,11 +90,7 @@ def decorate_flask_app_with_metrics(app) -> None:
     if epn:
         default_labels["envpodname"] = epn
 
-    # Use `GunicornPrometheusMetrics` when spawning a separate HTTP server for
-    # the metrics scrape endpoint. This needs PROMETHEUS_MULTIPROC_DIR to be
-    # set to a path to a directory.
-    _inspect_prom_multiproc_dir()
-    GunicornInternalPrometheusMetrics(
+    PrometheusMetrics(
         app=app,
         # See https://github.com/conbench/conbench/issues/1006
         # We will have to maybe iterate on those endpoint names,
@@ -188,23 +179,6 @@ def _periodically_set_q_rem() -> None:
     threading.Thread(target=func).start()
 
     # This function immediately returns after having spawned the thread.
-
-
-def _inspect_prom_multiproc_dir():
-    """
-    Log information about the environment variable PROMETHEUS_MULTIPROC_DIR
-    and about the path it points to. This is helpful for debugging bad state.
-    """
-    path = os.environ.get("PROMETHEUS_MULTIPROC_DIR")
-    log.info("env PROMETHEUS_MULTIPROC_DIR: `%s`", path)
-
-    if not path:
-        return
-
-    try:
-        log.info("os.path.isdir('%s'): %s", path, os.path.isdir(path))
-    except OSError as exc:
-        log.info("os.path.isdir('%s') failed: %s", path, exc)
 
 
 _periodically_set_q_rem()

--- a/conbench/metrics.py
+++ b/conbench/metrics.py
@@ -22,6 +22,7 @@ import time
 
 import flask
 import prometheus_client
+from prometheus_flask_exporter import NO_PREFIX, PrometheusMetrics
 
 log = logging.getLogger(__name__)
 
@@ -57,6 +58,11 @@ GAUGE_GITHUB_HTTP_API_QUOTA_REMAINING = prometheus_client.Gauge(
     "conbench_github_httpapi_quota_remaining",
     "A gauge that shows the last-observed x-ratelimit-remaining response "
     "header value.",
+)
+
+GAUGE_BMRT_CACHE_LAST_UPDATE_SECONDS = prometheus_client.Gauge(
+    "conbench_bmrt_cache_last_update_seconds",
+    "The time the last iteration of fetch_and_cache_most_recent_results() took",
 )
 
 gauge_gh_api_rem_set = {"set": False}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,6 @@ services:
       CONBENCH_OIDC_ISSUER_URL: http://dex:5556/dex-for-conbench
       CONBENCH_INTENDED_BASE_URL: http://127.0.0.1:5000/
       GITHUB_API_TOKEN: $GITHUB_API_TOKEN
-      PROMETHEUS_MULTIPROC_DIR: "/tmp/_conbench-promcl-coord-dir"
     healthcheck:
       test: "curl -sfS http://0.0.0.0:5000/api/ping/"
       interval: 5s


### PR DESCRIPTION
This is a nice simplification after enabled by https://github.com/conbench/conbench/pull/1065.

The new metric is a valuable thing to observe (I also think this is a great example for how easy it is to add a custom application metric given the new building blocks we have for that).