### PR TITLE
api/compare: Rename /api/compare/benchmarks to /api/compare/benchmark-results

### DIFF
--- a/conbench/api/compare.py
+++ b/conbench/api/compare.py
@@ -6,7 +6,10 @@ import flask as f
 
 from ..api import rule
 from ..api._endpoint import ApiEndpoint, maybe_login_required
-from ..entities._comparator import BenchmarkComparator, BenchmarkListComparator
+from ..entities._comparator import (
+    BenchmarkResultComparator,
+    BenchmarkResultListComparator,
+)
 from ..entities._entity import NotFound
 from ..entities.benchmark_result import BenchmarkResult
 from ..entities.commit import Commit
@@ -192,7 +195,7 @@ class CompareEntityEndpoint(ApiEndpoint, CompareMixin):
 
         baseline = _result_dict_for_compare_api(baseline_benchmark_result)
         contender = _result_dict_for_compare_api(contender_benchmark_result)
-        comparator = BenchmarkComparator(
+        comparator = BenchmarkResultComparator(
             baseline,
             contender,
             threshold,
@@ -270,7 +273,7 @@ class CompareListEndpoint(ApiEndpoint, CompareMixin):
 
         pairs = _get_pairs(baseline_items, contender_items)
 
-        comparator = BenchmarkListComparator(
+        comparator = BenchmarkResultListComparator(
             pairs,
             threshold,
             threshold_z,
@@ -280,7 +283,7 @@ class CompareListEndpoint(ApiEndpoint, CompareMixin):
         return f.jsonify(list(result))
 
 
-class CompareBenchmarksAPI(CompareEntityEndpoint):
+class CompareBenchmarkResultsAPI(CompareEntityEndpoint):
     def _get_results(self, benchmark_result_id) -> List[BenchmarkResult]:
         try:
             benchmark_result = BenchmarkResult.one(id=benchmark_result_id)
@@ -342,13 +345,15 @@ class CompareCommitsAPI(CompareListEndpoint):
         return commit
 
 
-compare_benchmarks_view = CompareBenchmarksAPI.as_view("compare-benchmarks")
+compare_benchmark_results_view = CompareBenchmarkResultsAPI.as_view(
+    "compare-benchmark-results"
+)
 compare_runs_view = CompareRunsAPI.as_view("compare-runs")
 compare_commits_view = CompareCommitsAPI.as_view("compare-commits")
 
 rule(
-    "/compare/benchmarks/<compare_ids>/",
-    view_func=compare_benchmarks_view,
+    "/compare/benchmark-results/<compare_ids>/",
+    view_func=compare_benchmark_results_view,
     methods=["GET"],
 )
 rule(

--- a/conbench/app/compare.py
+++ b/conbench/app/compare.py
@@ -271,7 +271,7 @@ class CompareRuns(Compare):
 
 
 rule(
-    "/compare/benchmark-results/<compare_ids>/",
+    "/compare/benchmarks/<compare_ids>/",
     view_func=CompareBenchmarkResults.as_view("compare-benchmark-results"),
     methods=["GET"],
 )

--- a/conbench/app/compare.py
+++ b/conbench/app/compare.py
@@ -38,7 +38,7 @@ class Compare(AppEndpoint, BenchmarkResultMixin, RunMixin, TimeSeriesPlotMixin):
         if comparisons and self.type == "run":
             baseline_run_id, contender_run_id = baseline_id, contender_id
 
-        elif comparisons and self.type == "benchmark":
+        elif comparisons and self.type == "benchmark-result":
             baseline = self.get_display_benchmark(baseline_id)
             contender = self.get_display_benchmark(contender_id)
             plot = self._get_plot(baseline, contender)
@@ -51,15 +51,15 @@ class Compare(AppEndpoint, BenchmarkResultMixin, RunMixin, TimeSeriesPlotMixin):
             baseline_run = self.get_display_run(baseline_run_id)
             contender_run = self.get_display_run(contender_run_id)
 
-        if comparisons and self.type == "benchmark":
+        if comparisons and self.type == "benchmark-result":
             plot_history = self.get_history_plot(contender, contender_run)
 
-        if comparisons and self.type != "benchmark":
+        if comparisons and self.type != "benchmark-result":
             comparisons_by_id = {c["contender_id"]: c for c in comparisons}
             if self.type == "run":
                 benchmarks, response = self._get_benchmarks(run_id=contender_id)
             if response.status_code != 200:
-                self.flash("Error getting benchmarks.")
+                self.flash("Error getting benchmark results.")
                 return self.redirect("app.index")
             for benchmark in benchmarks:
                 augment(benchmark)
@@ -244,7 +244,7 @@ class Compare(AppEndpoint, BenchmarkResultMixin, RunMixin, TimeSeriesPlotMixin):
 
         # Mutate comparison objs (dictionaries) on the fly
         for c in comparisons:
-            view = "app.compare-benchmarks"
+            view = "app.compare-benchmark-results"
             compare = f'{c["baseline_id"]}...{c["contender_id"]}'
             c["compare_benchmarks_url"] = f.url_for(view, compare_ids=compare)
 
@@ -256,11 +256,11 @@ class Compare(AppEndpoint, BenchmarkResultMixin, RunMixin, TimeSeriesPlotMixin):
         return comparisons, regressions, improvements, None
 
 
-class CompareBenchmarks(Compare):
-    type = "benchmark"
+class CompareBenchmarkResults(Compare):
+    type = "benchmark-result"
     html = "compare-entity.html"
-    title = "Compare Benchmarks"
-    api_endpoint_name = "api.compare-benchmarks"
+    title = "Compare Benchmark Results"
+    api_endpoint_name = "api.compare-benchmark-results"
 
 
 class CompareRuns(Compare):
@@ -271,8 +271,8 @@ class CompareRuns(Compare):
 
 
 rule(
-    "/compare/benchmarks/<compare_ids>/",
-    view_func=CompareBenchmarks.as_view("compare-benchmarks"),
+    "/compare/benchmark-results/<compare_ids>/",
+    view_func=CompareBenchmarkResults.as_view("compare-benchmark-results"),
     methods=["GET"],
 )
 rule(

--- a/conbench/cli.py
+++ b/conbench/cli.py
@@ -8,8 +8,8 @@ from .util import register_benchmarks
 
 register_benchmarks()
 BENCHMARKS = {}
-for benchmark_result in REGISTRY:
-    BENCHMARKS[benchmark_result.name] = benchmark_result
+for benchmark in REGISTRY:
+    BENCHMARKS[benchmark.name] = benchmark
 
 
 if not BENCHMARKS:
@@ -81,15 +81,15 @@ def _to_cli_name(name):
     return f"--{name.replace('_', '-')}"
 
 
-for name, benchmark_result in BENCHMARKS.items():
+for name, benchmark in BENCHMARKS.items():
     params = []
 
-    instance = benchmark_result()
+    instance = benchmark()
     fields, cases = instance.fields, instance.cases
-    options = getattr(benchmark_result, "options", {})
-    arguments = getattr(benchmark_result, "arguments", [])
+    options = getattr(benchmark, "options", {})
+    arguments = getattr(benchmark, "arguments", [])
     tags = [_to_cli_name(tag) for tag in fields]
-    external = getattr(benchmark_result, "external", False)
+    external = getattr(benchmark, "external", False)
 
     for k, v in instance.case_options.items():
         _choice(params, _to_cli_name(k), sorted(v))
@@ -143,7 +143,7 @@ for name, benchmark_result in BENCHMARKS.items():
     def _benchmark(
         show_result,
         show_output,
-        benchmark=benchmark_result,
+        benchmark=benchmark,
         **kwargs,
     ):
         for result, output in benchmark().run(**kwargs):
@@ -166,6 +166,6 @@ for name, benchmark_result in BENCHMARKS.items():
             name,
             params=params,
             callback=_benchmark,
-            help=_help(benchmark_result, name, cases, tags),
+            help=_help(benchmark, name, cases, tags),
         )
     )

--- a/conbench/cli.py
+++ b/conbench/cli.py
@@ -8,8 +8,8 @@ from .util import register_benchmarks
 
 register_benchmarks()
 BENCHMARKS = {}
-for benchmark in REGISTRY:
-    BENCHMARKS[benchmark.name] = benchmark
+for benchmark_result in REGISTRY:
+    BENCHMARKS[benchmark_result.name] = benchmark_result
 
 
 if not BENCHMARKS:
@@ -81,15 +81,15 @@ def _to_cli_name(name):
     return f"--{name.replace('_', '-')}"
 
 
-for name, benchmark in BENCHMARKS.items():
+for name, benchmark_result in BENCHMARKS.items():
     params = []
 
-    instance = benchmark()
+    instance = benchmark_result()
     fields, cases = instance.fields, instance.cases
-    options = getattr(benchmark, "options", {})
-    arguments = getattr(benchmark, "arguments", [])
+    options = getattr(benchmark_result, "options", {})
+    arguments = getattr(benchmark_result, "arguments", [])
     tags = [_to_cli_name(tag) for tag in fields]
-    external = getattr(benchmark, "external", False)
+    external = getattr(benchmark_result, "external", False)
 
     for k, v in instance.case_options.items():
         _choice(params, _to_cli_name(k), sorted(v))
@@ -143,7 +143,7 @@ for name, benchmark in BENCHMARKS.items():
     def _benchmark(
         show_result,
         show_output,
-        benchmark=benchmark,
+        benchmark=benchmark_result,
         **kwargs,
     ):
         for result, output in benchmark().run(**kwargs):
@@ -166,6 +166,6 @@ for name, benchmark in BENCHMARKS.items():
             name,
             params=params,
             callback=_benchmark,
-            help=_help(benchmark, name, cases, tags),
+            help=_help(benchmark_result, name, cases, tags),
         )
     )

--- a/conbench/entities/_comparator.py
+++ b/conbench/entities/_comparator.py
@@ -64,7 +64,7 @@ class BenchmarkResult:
         self.z_score = float(z_score) if z_score is not None else None
 
 
-class BenchmarkComparator:
+class BenchmarkResultComparator:
     def __init__(self, baseline, contender, threshold=None, threshold_z=None):
         self.baseline = BenchmarkResult(**baseline) if baseline else None
         self.contender = BenchmarkResult(**contender) if contender else None
@@ -243,7 +243,7 @@ class BenchmarkComparator:
         }
 
 
-class BenchmarkListComparator:
+class BenchmarkResultListComparator:
     def __init__(self, pairs, threshold=None, threshold_z=None):
         self.pairs = pairs
         self.threshold = float(threshold) if threshold is not None else CHANGE
@@ -252,7 +252,7 @@ class BenchmarkListComparator:
     def formatted(self):
         for pair in self.pairs.values():
             baseline, contender = pair.get("baseline"), pair.get("contender")
-            yield BenchmarkComparator(
+            yield BenchmarkResultComparator(
                 baseline,
                 contender,
                 self.threshold,
@@ -262,7 +262,7 @@ class BenchmarkListComparator:
     def compare(self):
         for pair in self.pairs.values():
             baseline, contender = pair.get("baseline"), pair.get("contender")
-            yield BenchmarkComparator(
+            yield BenchmarkResultComparator(
                 baseline,
                 contender,
                 self.threshold,

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -1465,7 +1465,7 @@
                 "tags": ["Commits"],
             }
         },
-        "/api/compare/benchmarks/{compare_ids}/": {
+        "/api/compare/benchmark-results/{compare_ids}/": {
             "get": {
                 "description": "Compare benchmark results.",
                 "parameters": [

--- a/conbench/tests/api/test_compare.py
+++ b/conbench/tests/api/test_compare.py
@@ -173,8 +173,8 @@ class TestGetPairs:
         assert pairs["case 1-context 2"]["contender"] is None
 
 
-class TestCompareBenchmarksGet(_asserts.GetEnforcer):
-    url = "/api/compare/benchmarks/{}/"
+class TestCompareBenchmarkResultsGet(_asserts.GetEnforcer):
+    url = "/api/compare/benchmark-results/{}/"
     public = True
 
     def _create(self, name=None, verbose=False):
@@ -230,7 +230,7 @@ class TestCompareBenchmarksGet(_asserts.GetEnforcer):
         new_entities, compare = self._create(name, verbose=True)
         query_string = {"threshold_z": threshold_z} if threshold_z else None
         response = client.get(
-            f"/api/compare/benchmarks/{compare.id}/", query_string=query_string
+            f"/api/compare/benchmark-results/{compare.id}/", query_string=query_string
         )
 
         benchmark_result_ids = [e.id for e in new_entities]
@@ -275,7 +275,7 @@ class TestCompareBenchmarksGet(_asserts.GetEnforcer):
         new_entities, compare = self._create_with_error(
             name, baseline_error=error, verbose=True
         )
-        response = client.get(f"/api/compare/benchmarks/{compare.id}/")
+        response = client.get(f"/api/compare/benchmark-results/{compare.id}/")
 
         benchmark_result_ids = [e.id for e in new_entities]
         batch_ids = [e.batch_id for e in new_entities]
@@ -312,7 +312,7 @@ class TestCompareBenchmarksGet(_asserts.GetEnforcer):
 
     def test_compare_unknown_compare_ids(self, client):
         self.authenticate(client)
-        response = client.get("/api/compare/benchmarks/foo...bar/")
+        response = client.get("/api/compare/benchmark-results/foo...bar/")
         self.assert_404_not_found(response)
 
     @pytest.mark.parametrize(
@@ -334,7 +334,7 @@ class TestCompareBenchmarksGet(_asserts.GetEnforcer):
         contender_result = benchmark_results[7]  # on a PR branch
         baseline_result = benchmark_results[baseline_result_id]
         response = client.get(
-            f"/api/compare/benchmarks/{baseline_result.id}...{contender_result.id}/"
+            f"/api/compare/benchmark-results/{baseline_result.id}...{contender_result.id}/"
         )
         assert response.status_code == 200, response.status_code
         assert response.json["contender_z_score"] == expected_z_score

--- a/conbench/tests/app/test_compare.py
+++ b/conbench/tests/app/test_compare.py
@@ -16,7 +16,7 @@ def _emsg_needle(thing, thingid):
 
 
 class TestCompareBenchmarkResults(_asserts.GetEnforcer):
-    url = "/compare/benchmark-results/{}/"
+    url = "/compare/benchmarks/{}/"
     title = "Compare Benchmark Results"
     redirect_on_unknown = False
 
@@ -28,15 +28,13 @@ class TestCompareBenchmarkResults(_asserts.GetEnforcer):
         self.authenticate(client)
 
         response = client.get(
-            "/compare/benchmark-results/unknown...unknown2/", follow_redirects=True
+            "/compare/benchmarks/unknown...unknown2/", follow_redirects=True
         )
         self.assert_page(response, "Compare Benchmark Results")
 
         assert "cannot perform comparison:" in response.text, response.text
 
-        response = client.get(
-            "/compare/benchmark-results/foo...bar/", follow_redirects=True
-        )
+        response = client.get("/compare/benchmarks/foo...bar/", follow_redirects=True)
         self.assert_page(response, "Compare Benchmark Results")
         assert "cannot perform comparison:" in response.text
 

--- a/conbench/tests/app/test_compare.py
+++ b/conbench/tests/app/test_compare.py
@@ -15,9 +15,9 @@ def _emsg_needle(thing, thingid):
     return f"cannot perform comparison: no benchmark results found for {thing} ID: &#39;{thingid}&#39;"
 
 
-class TestCompareBenchmark(_asserts.GetEnforcer):
-    url = "/compare/benchmarks/{}/"
-    title = "Compare Benchmarks"
+class TestCompareBenchmarkResults(_asserts.GetEnforcer):
+    url = "/compare/benchmark-results/{}/"
+    title = "Compare Benchmark Results"
     redirect_on_unknown = False
 
     def _create(self, client):
@@ -28,14 +28,16 @@ class TestCompareBenchmark(_asserts.GetEnforcer):
         self.authenticate(client)
 
         response = client.get(
-            "/compare/benchmarks/unknown...unknown2/", follow_redirects=True
+            "/compare/benchmark-results/unknown...unknown2/", follow_redirects=True
         )
-        self.assert_page(response, "Compare Benchmarks")
+        self.assert_page(response, "Compare Benchmark Results")
 
         assert "cannot perform comparison:" in response.text, response.text
 
-        response = client.get("/compare/benchmarks/foo...bar/", follow_redirects=True)
-        self.assert_page(response, "Compare Benchmarks")
+        response = client.get(
+            "/compare/benchmark-results/foo...bar/", follow_redirects=True
+        )
+        self.assert_page(response, "Compare Benchmark Results")
         assert "cannot perform comparison:" in response.text
 
 

--- a/conbench/tests/entities/test_comparator.py
+++ b/conbench/tests/entities/test_comparator.py
@@ -1,4 +1,7 @@
-from ...entities._comparator import BenchmarkComparator, BenchmarkListComparator
+from ...entities._comparator import (
+    BenchmarkResultComparator,
+    BenchmarkResultListComparator,
+)
 
 
 def test_compare_no_change():
@@ -29,8 +32,8 @@ def test_compare_no_change():
         "z_score": "0.0",
     }
 
-    result = BenchmarkComparator(baseline, contender).compare()
-    formatted = BenchmarkComparator(baseline, contender).formatted()
+    result = BenchmarkResultComparator(baseline, contender).compare()
+    formatted = BenchmarkResultComparator(baseline, contender).formatted()
 
     assert result == {
         "batch": "arrow-compute-scalar-cast-benchmark",
@@ -120,8 +123,8 @@ def test_compare_regression():
         "z_score": "-6.0",
     }
 
-    result = BenchmarkComparator(baseline, contender).compare()
-    formatted = BenchmarkComparator(baseline, contender).formatted()
+    result = BenchmarkResultComparator(baseline, contender).compare()
+    formatted = BenchmarkResultComparator(baseline, contender).formatted()
 
     assert result == {
         "batch": "arrow-compute-scalar-cast-benchmark",
@@ -211,8 +214,8 @@ def test_compare_regression_less_is_better():
         "z_score": "-6.0",
     }
 
-    result = BenchmarkComparator(baseline, contender).compare()
-    formatted = BenchmarkComparator(baseline, contender).formatted()
+    result = BenchmarkResultComparator(baseline, contender).compare()
+    formatted = BenchmarkResultComparator(baseline, contender).formatted()
 
     assert result == {
         "batch": "arrow-compute-scalar-cast-benchmark",
@@ -302,8 +305,8 @@ def test_compare_regression_but_under_threshold():
         "z_score": "-5.0",
     }
 
-    result = BenchmarkComparator(baseline, contender).compare()
-    formatted = BenchmarkComparator(baseline, contender).formatted()
+    result = BenchmarkResultComparator(baseline, contender).compare()
+    formatted = BenchmarkResultComparator(baseline, contender).formatted()
 
     assert result == {
         "batch": "arrow-compute-scalar-cast-benchmark",
@@ -394,8 +397,10 @@ def test_compare_regression_custom_threshold_and_threshold_z():
     }
 
     threshold, threshold_z = 4, 1
-    result = BenchmarkComparator(baseline, contender, threshold, threshold_z).compare()
-    formatted = BenchmarkComparator(
+    result = BenchmarkResultComparator(
+        baseline, contender, threshold, threshold_z
+    ).compare()
+    formatted = BenchmarkResultComparator(
         baseline, contender, threshold, threshold_z
     ).formatted()
 
@@ -487,8 +492,8 @@ def test_compare_improvement():
         "z_score": "6.0",
     }
 
-    result = BenchmarkComparator(baseline, contender).compare()
-    formatted = BenchmarkComparator(baseline, contender).formatted()
+    result = BenchmarkResultComparator(baseline, contender).compare()
+    formatted = BenchmarkResultComparator(baseline, contender).formatted()
 
     assert result == {
         "batch": "arrow-compute-scalar-cast-benchmark",
@@ -578,8 +583,8 @@ def test_compare_improvement_less_is_better():
         "z_score": "6.0",
     }
 
-    result = BenchmarkComparator(baseline, contender).compare()
-    formatted = BenchmarkComparator(baseline, contender).formatted()
+    result = BenchmarkResultComparator(baseline, contender).compare()
+    formatted = BenchmarkResultComparator(baseline, contender).formatted()
 
     assert result == {
         "batch": "arrow-compute-scalar-cast-benchmark",
@@ -670,8 +675,10 @@ def test_compare_improvement_but_under_threshold():
     }
 
     threshold, threshold_z = 4, 1
-    result = BenchmarkComparator(baseline, contender, threshold, threshold_z).compare()
-    formatted = BenchmarkComparator(
+    result = BenchmarkResultComparator(
+        baseline, contender, threshold, threshold_z
+    ).compare()
+    formatted = BenchmarkResultComparator(
         baseline, contender, threshold, threshold_z
     ).formatted()
 
@@ -763,8 +770,8 @@ def test_compare_improvement_custom_threshold_and_threshold_z():
         "z_score": "5.0",
     }
 
-    result = BenchmarkComparator(baseline, contender).compare()
-    formatted = BenchmarkComparator(baseline, contender).formatted()
+    result = BenchmarkResultComparator(baseline, contender).compare()
+    formatted = BenchmarkResultComparator(baseline, contender).formatted()
 
     assert result == {
         "batch": "arrow-compute-scalar-cast-benchmark",
@@ -886,8 +893,8 @@ def test_compare_list():
         },
     }
 
-    result = BenchmarkListComparator(pairs).compare()
-    formatted = BenchmarkListComparator(pairs).formatted()
+    result = BenchmarkResultListComparator(pairs).compare()
+    formatted = BenchmarkResultListComparator(pairs).formatted()
 
     assert list(result) == [
         {
@@ -1058,8 +1065,8 @@ def test_compare_list_missing_contender():
         },
     }
 
-    result = BenchmarkListComparator(pairs).compare()
-    formatted = BenchmarkListComparator(pairs).formatted()
+    result = BenchmarkResultListComparator(pairs).compare()
+    formatted = BenchmarkResultListComparator(pairs).formatted()
 
     assert list(result) == [
         {
@@ -1231,8 +1238,8 @@ def test_compare_list_empty_contender():
         },
     }
 
-    result = BenchmarkListComparator(pairs).compare()
-    formatted = BenchmarkListComparator(pairs).formatted()
+    result = BenchmarkResultListComparator(pairs).compare()
+    formatted = BenchmarkResultListComparator(pairs).formatted()
 
     assert list(result) == [
         {
@@ -1403,8 +1410,8 @@ def test_compare_list_missing_baseline():
         },
     }
 
-    result = BenchmarkListComparator(pairs).compare()
-    formatted = BenchmarkListComparator(pairs).formatted()
+    result = BenchmarkResultListComparator(pairs).compare()
+    formatted = BenchmarkResultListComparator(pairs).formatted()
 
     assert list(result) == [
         {
@@ -1576,8 +1583,8 @@ def test_compare_list_empty_baseline():
         },
     }
 
-    result = BenchmarkListComparator(pairs).compare()
-    formatted = BenchmarkListComparator(pairs).formatted()
+    result = BenchmarkResultListComparator(pairs).compare()
+    formatted = BenchmarkResultListComparator(pairs).formatted()
 
     assert list(result) == [
         {
@@ -1713,8 +1720,8 @@ def test_compare_list_empty_pair():
         },
     }
 
-    result = BenchmarkListComparator(pairs).compare()
-    formatted = BenchmarkListComparator(pairs).formatted()
+    result = BenchmarkResultListComparator(pairs).compare()
+    formatted = BenchmarkResultListComparator(pairs).formatted()
 
     assert list(result) == [
         {


### PR DESCRIPTION
Closes #1090 with lots of `benchmarks` -> `benchmark-results`.

~I went further than the story intended on the app side when on a roll trying to unbreak things; I don't know if we're relying on the stability of those URLs anywhere, so unless anybody can confidently say "no", I need to roll back that change before merging.~

Edit: done; left the internal changes.