### PR TITLE
repo_url_to_display_name(url): prepare for `None` arg

### DIFF
--- a/conbench/app/index.py
+++ b/conbench/app/index.py
@@ -80,9 +80,9 @@ class Index(AppEndpoint, RunMixin):
         # A quick/pragmatic decision for now, not set in stone: get a stable
         # sort order of repositories the way they are listed on that page;
         # do this by sorting alphabetically.
-        reponame_runs_map = dict(sorted(reponame_runs_map.items()))
+        reponame_runs_map_sorted = dict(sorted(reponame_runs_map.items()))
 
-        return self.page(reponame_runs_map)
+        return self.page(reponame_runs_map_sorted)
 
 
 def repo_url_to_display_name(url: Optional[str]) -> str:

--- a/conbench/app/index.py
+++ b/conbench/app/index.py
@@ -43,7 +43,7 @@ class Index(AppEndpoint, RunMixin):
         )
 
     @authorize_or_terminate
-    def get(self):
+    def get(self) -> str | flask.Response:
         resp = _cloud_lb_health_check_shortcut()
         if resp is not None:
             return resp

--- a/conbench/app/index.py
+++ b/conbench/app/index.py
@@ -85,7 +85,12 @@ class Index(AppEndpoint, RunMixin):
         return self.page(reponame_runs_map)
 
 
-def repo_url_to_display_name(url: str) -> str:
+def repo_url_to_display_name(url: Optional[str]) -> str:
+    if url is None:
+        # For those cases where the repository information stored with a
+        # Commit object in the DB is not a URL
+        return "no repository specified"
+
     try:
         result = urlparse(url)
     except ValueError as exc:
@@ -97,6 +102,7 @@ def repo_url_to_display_name(url: str) -> str:
 
     # See https://github.com/conbench/conbench/issues/1095
     if isinstance(p, bytes):
+        # Note: this case can be hit when `url` is None! Interesting.
         log.info("repo_url_to_display_name led to bytes obj: url: %s", url)
         p = p.decode("utf-8")
 

--- a/conbench/entities/commit.py
+++ b/conbench/entities/commit.py
@@ -53,8 +53,10 @@ class Commit(Base, EntityMixin):
     parent: Mapped[Optional[str]] = Nullable(s.String(50))
 
     # This is meant to be the URL to the repository without trailing slash.
-    # Should be renamed to repo_url
+    # Should be renamed to repo_url. Seemingly this can be an empty string,
+    # too. We should transition to a state where this is known to be a URL.
     repository: Mapped[str] = NotNull(s.String(300))
+
     message: Mapped[str] = NotNull(s.String(250))
     author_name: Mapped[str] = NotNull(s.String(100))
     author_login: Mapped[Optional[str]] = Nullable(s.String(50))
@@ -79,11 +81,11 @@ class Commit(Base, EntityMixin):
     @property
     def repo_url(self) -> Optional[str]:
         """
-        Return a URL string or None. The returned string is guaranteed to start
-        with 'http' and is guanrateed to not have a trailing slash.
+        Return a URL (string) or None. The returned string is guaranteed to
+        start with 'http' and is guaranteed to not have a trailing slash.
 
-        The `None` case is here because I think the database may contain emtpy
-        strings.
+        The `None` case is here because I think the database may contain other
+        (non-URL) value types; and we need to phase those out.
         """
         u = self.repository
         if u.startswith("http"):

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -58,7 +58,7 @@ _shutdown = False
 
 # Fetching one million items from a sample DB takes ~1 minute on my machine
 # (the `results = Session.scalars(....all())` call takes that long.
-def _fetch_and_cache_most_recent_results(n=0.2 * 10**6) -> None:
+def _fetch_and_cache_most_recent_results(n=0.07 * 10**6) -> None:
     log.debug(
         "BMRT cache: keys in cache: %s",
         len(_cache_bmrs["by_id"]),


### PR DESCRIPTION
Follow-up after #1098.

mypy didn't complain because the call site was not yet checked.