### PR TITLE
benchalerts: use a closer JWT expiration time

### DIFF
--- a/benchalerts/benchalerts/integrations/github.py
+++ b/benchalerts/benchalerts/integrations/github.py
@@ -66,8 +66,13 @@ class GitHubAppClient(BaseClient):
         payload = {
             "iss": app_id,
             "iat": datetime.datetime.utcnow() - datetime.timedelta(minutes=1),
-            "exp": datetime.datetime.utcnow() + datetime.timedelta(minutes=10),
+            # Expiration time must be no more than 10 minutes, but using exactly 10
+            # minutes may be flaky due to system clock disagreements (see
+            # https://github.com/conbench/conbench/issues/1101). We only need this token
+            # briefly anyway.
+            "exp": datetime.datetime.utcnow() + datetime.timedelta(minutes=3),
         }
+        log.debug("Payload to encode for JWT: %s", str(payload))
         encoded_jwt = jwt.encode(payload=payload, key=private_key, algorithm="RS256")
         return encoded_jwt
 

--- a/benchalerts/benchalerts/integrations/github.py
+++ b/benchalerts/benchalerts/integrations/github.py
@@ -66,10 +66,11 @@ class GitHubAppClient(BaseClient):
         payload = {
             "iss": app_id,
             "iat": datetime.datetime.utcnow() - datetime.timedelta(minutes=1),
-            # Expiration time must be no more than 10 minutes, but using exactly 10
-            # minutes may be flaky due to system clock disagreements (see
-            # https://github.com/conbench/conbench/issues/1101). We only need this token
-            # briefly anyway.
+            # https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app#about-json-web-tokens-jwts
+            # According to the authenticator (GitHub) the JWT lifetime must be no more
+            # than 10 minutes, but using exactly 10 minutes may be flaky due to system
+            # clock disagreement (see https://github.com/conbench/conbench/issues/1101).
+            # We only need this token briefly anyway.
             "exp": datetime.datetime.utcnow() + datetime.timedelta(minutes=3),
         }
         log.debug("Payload to encode for JWT: %s", str(payload))


### PR DESCRIPTION
To address #1101. This PR lowers the time before the `benchalerts` GitHub App JWT expires, to reduce the likelihood of that issue happening.

We cannot test this change explicitly, but we'll be able to tell if it worked by monitoring our integration tests to ensure this issue doesn't come up again.