### PR TITLE
UI: c-bench: require authentication proof

### DIFF
--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -7,6 +7,7 @@ import flask
 import orjson
 
 from conbench.app import app
+from conbench.app._endpoint import authorize_or_terminate
 from conbench.config import Config
 from conbench.entities.benchmark_result import BenchmarkResult
 from conbench.job import _cache_bmrs
@@ -15,6 +16,7 @@ log = logging.getLogger(__name__)
 
 
 @app.route("/c-benchmarks/", methods=["GET"])  # type: ignore
+@authorize_or_terminate
 def list_benchmarks() -> str:
     return flask.render_template(
         "c-benchmarks.html",
@@ -28,6 +30,7 @@ def list_benchmarks() -> str:
 
 
 @app.route("/c-benchmarks/<bname>", methods=["GET"])  # type: ignore
+@authorize_or_terminate
 def show_benchmark_cases(bname: str) -> str:
     try:
         matching_results = _cache_bmrs["by_benchmark_name"][bname]
@@ -76,6 +79,7 @@ class TypeUIPlotInfo(TypedDict):
 
 
 @app.route("/c-benchmarks/<bname>/<caseid>", methods=["GET"])  # type: ignore
+@authorize_or_terminate
 def show_benchmark_results(bname: str, caseid: str) -> str:
     # First, filter by benchmark name.
     try:

--- a/conbench/tests/app/test_index.py
+++ b/conbench/tests/app/test_index.py
@@ -1,5 +1,3 @@
-import pytest
-
 from ...tests.api import _fixtures
 from ...tests.app import _asserts
 

--- a/conbench/tests/app/test_index.py
+++ b/conbench/tests/app/test_index.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ...tests.api import _fixtures
 from ...tests.app import _asserts
 
@@ -25,3 +27,13 @@ class TestIndex(_asserts.ListEnforcer):
         response = client.get("/index/")
         self.assert_index_page(response)
         assert run_id.encode() in response.data
+
+
+class TestCBenchmarks(_asserts.AppEndpointTest):
+    url = "/c-benchmarks"
+
+    def test_public_data_off(self, client, monkeypatch):
+        monkeypatch.setenv("BENCHMARKS_DATA_PUBLIC", "off")
+        self.logout(client)
+        response = client.get(self.url, follow_redirects=True)
+        assert b"Sign In" in response.data, response.data


### PR DESCRIPTION
conceptual benchmark list poc: enable authorizer

This should be the default for all endpoints, i.e. we should mark this in the inverse fashion.