### PR TITLE
benchclients: Log failed requests

### DIFF
--- a/benchclients/python/benchclients/base.py
+++ b/benchclients/python/benchclients/base.py
@@ -43,9 +43,12 @@ class BaseClient(abc.ABC):
     def get(self, path: str, params: Optional[dict] = None) -> dict:
         """Make a GET request"""
         url = self.base_url + path
-        log.debug(f"GET {url} {params=}")
+
+        req_string = f"GET {url} {params=}"
+        log.debug(req_string)
+
         res = self.session.get(url=url, params=params, timeout=self.timeout_s)
-        self._maybe_raise(res=res)
+        self._maybe_raise(req_string=req_string, res=res)
 
         return res.json()
 
@@ -54,10 +57,11 @@ class BaseClient(abc.ABC):
         json = json or {}
         url = self.base_url + path
 
-        log.debug(f"POST {url} {dumps(json)}")
+        req_string = f"POST {url} {dumps(json)}"
+        log.debug(req_string)
 
         res = self.session.post(url=url, json=json, timeout=self.timeout_s)
-        self._maybe_raise(res=res)
+        self._maybe_raise(req_string=req_string, res=res)
 
         if res.content:
             return res.json()
@@ -65,15 +69,18 @@ class BaseClient(abc.ABC):
     def put(self, path: str, json: dict) -> Optional[dict]:
         """Make a PUT request"""
         url = self.base_url + path
-        log.debug(f"PUT {url} {dumps(json)}")
+
+        req_string = f"PUT {url} {dumps(json)}"
+        log.debug(req_string)
+
         res = self.session.put(url=url, json=json, timeout=self.timeout_s)
-        self._maybe_raise(res=res)
+        self._maybe_raise(req_string=req_string, res=res)
 
         if res.content:
             return res.json()
 
     @staticmethod
-    def _maybe_raise(res: requests.Response):
+    def _maybe_raise(req_string: str, res: requests.Response):
         try:
             res.raise_for_status()
         except requests.HTTPError as e:
@@ -81,5 +88,6 @@ class BaseClient(abc.ABC):
                 res_content = e.response.content.decode()
             except AttributeError:
                 res_content = e.response.content
+            log.error(f"Failed request: {req_string}")
             log.error(f"Response content: {res_content}")
             raise

--- a/benchclients/python/tests/unit_tests/test_conbench.py
+++ b/benchclients/python/tests/unit_tests/test_conbench.py
@@ -35,6 +35,8 @@ class TestConbenchClient:
         with pytest.raises(requests.HTTPError, match="404"):
             self.cb.get(path)
 
+        assert f"Failed request: GET {self.cb.base_url}{path}" in caplog.text
+
         if path == "/error_with_content":
             assert 'Response content: {"code":' in caplog.text
         else:


### PR DESCRIPTION
Closes #807, which I saw and then lost track of, but which I noticed again today.

Logs exactly the same request string as in `DEBUG` mode as `ERROR` when things blow up.