### PR TITLE
BMRT cache job: start from within gunicorn hook, add tests, improve signal handling, minor cleanup

### DIFF
--- a/conbench/api/index.py
+++ b/conbench/api/index.py
@@ -36,7 +36,6 @@ def docs():
     # dictionary may be different for each application startup. Sort keys
     # alphabetically to get a stable outcome.
     for schemaname in sorted(spec.components.schemas.keys()):
-        print(schemaname)
         mdchunks.append(
             f"## {schemaname}\n"
             f'<SchemaDefinition schemaRef="#/components/schemas/{schemaname}" />\n'

--- a/conbench/api/results.py
+++ b/conbench/api/results.py
@@ -5,8 +5,6 @@ import flask_login
 import orjson
 from sqlalchemy import select
 
-import conbench.job
-
 from ..api import rule
 from ..api._docs import spec
 from ..api._endpoint import ApiEndpoint, maybe_login_required
@@ -19,8 +17,6 @@ from ..entities.benchmark_result import (
 )
 from ..entities.case import Case
 from ._resp import json_response_for_byte_sequence, resp400
-
-conbench.job.start_jobs()
 
 log = logging.getLogger(__name__)
 

--- a/conbench/gunicorn-conf.py
+++ b/conbench/gunicorn-conf.py
@@ -46,9 +46,9 @@ timeout = 120
 
 
 def post_worker_init(worker):
-    # Starting the BMRT cache / job machinery in this hook mean that it is not
+    # Starting the BMRT cache job machinery in this hook means that it is not
     # automatically started as a side-effect by creating / importing the
-    # WSGI/Flask application object
+    # WSGI/Flask application object.
     import conbench
 
     worker.log.info("gunicorn post_worker_init hook: conbench.job.start_jobs()")

--- a/conbench/gunicorn-conf.py
+++ b/conbench/gunicorn-conf.py
@@ -45,6 +45,16 @@ threads = 10
 timeout = 120
 
 
+def post_worker_init(worker):
+    # Starting the BMRT cache / job machinery in this hook mean that it is not
+    # automatically started as a side-effect by creating / importing the
+    # WSGI/Flask application object
+    import conbench
+
+    worker.log.info("gunicorn post_worker_init hook: conbench.job.start_jobs()")
+    conbench.job.start_jobs()
+
+
 def worker_int(worker):
     # Motivation to use this hook was to build a simple/robust mechanism for
     # graceful shutdown of the _run_forever function in the BMRT cache.

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -207,7 +207,11 @@ def shutdown_handler(sig, frame):
 # ourselves a SIGTERM sinal. Don't worry, I don't generally hurt myself.
 signal.signal(signal.SIGTERM, shutdown_handler)
 
-# For interactive sessions
+# For interactive sessions (such as when running make run-app-dev)
 signal.signal(signal.SIGINT, shutdown_handler)
 
+# There is no clear purpose for this yet; I wonder which mechanism docker
+# compose really uses to signal its containers a graceful shutdown -- so far I
+# need to send SIGINT twice, and I think then it immediately sends SIGKILL to
+# containerized processes.
 signal.signal(signal.SIGQUIT, shutdown_handler)

--- a/conbench/tests/app/test_conceptual_benchmark_views.py
+++ b/conbench/tests/app/test_conceptual_benchmark_views.py
@@ -1,0 +1,22 @@
+import pytest
+
+from ...tests.app import _asserts
+
+
+def assert_response_is_login_age(resp):
+    assert resp.status_code == 200, (resp.status_code, resp.text)
+    assert "<h4>Sign in</h4>" in resp.text, resp.text
+    assert '<label for="password">Password</label>' in resp.text, resp.text
+
+
+class TestCBenchmarks(_asserts.AppEndpointTest):
+    url = "/c-benchmarks"
+
+    @pytest.mark.parametrize(
+        "relpath",
+        ["/c-benchmarks", "/c-benchmarks/bname", "/c-benchmarks/bname/caseid"],
+    )
+    def test_access_control(self, client, monkeypatch, relpath):
+        monkeypatch.setenv("BENCHMARKS_DATA_PUBLIC", "off")
+        self.logout(client)
+        assert_response_is_login_age(client.get(relpath, follow_redirects=True))

--- a/conbench/tests/app/test_conceptual_benchmark_views.py
+++ b/conbench/tests/app/test_conceptual_benchmark_views.py
@@ -3,7 +3,7 @@ import pytest
 from ...tests.app import _asserts
 
 
-def assert_response_is_login_age(resp):
+def assert_response_is_login_page(resp):
     assert resp.status_code == 200, (resp.status_code, resp.text)
     assert "<h4>Sign in</h4>" in resp.text, resp.text
     assert '<label for="password">Password</label>' in resp.text, resp.text
@@ -19,4 +19,4 @@ class TestCBenchmarks(_asserts.AppEndpointTest):
     def test_access_control(self, client, monkeypatch, relpath):
         monkeypatch.setenv("BENCHMARKS_DATA_PUBLIC", "off")
         self.logout(client)
-        assert_response_is_login_age(client.get(relpath, follow_redirects=True))
+        assert_response_is_login_page(client.get(relpath, follow_redirects=True))

--- a/conbench/tests/app/test_index.py
+++ b/conbench/tests/app/test_index.py
@@ -25,13 +25,3 @@ class TestIndex(_asserts.ListEnforcer):
         response = client.get("/index/")
         self.assert_index_page(response)
         assert run_id.encode() in response.data
-
-
-class TestCBenchmarks(_asserts.AppEndpointTest):
-    url = "/c-benchmarks"
-
-    def test_public_data_off(self, client, monkeypatch):
-        monkeypatch.setenv("BENCHMARKS_DATA_PUBLIC", "off")
-        self.logout(client)
-        response = client.get(self.url, follow_redirects=True)
-        assert b"Sign In" in response.data, response.data


### PR DESCRIPTION
Add a new test module for the "conceptual benchmark list" views.

Initiate the BMRT cache populuation logic in a gunicorn worker process hook (_after_ having initialized the WSGI app).

That means that simply importing the application object or initializing the Flask app itself does not have the side effect of running this job.

This makes it so that running the test suite with the pytest test runner does not initiate the job.

With that, we can remove the `if Config.TESTING:` bandaid again. The result is that the job starts when running `make run-app-dev` locally (desired outcome). I think we now could also remove the `CREATE_ALL_TABLES`-based check, but it's OK to stay for a little longer.

This patch also invokes the original signal handler for SIGINT which on CPython is to raise KeyboardInterrupt.