### PR TITLE
k8s: increase mem request for Conbench webapp container

### DIFF
--- a/k8s/conbench-deployment.templ.yml
+++ b/k8s/conbench-deployment.templ.yml
@@ -78,10 +78,11 @@ spec:
               name: conbench-secret
         resources:
           requests:
-            # Note(JP): these are so small to allow for deployment rollover
-            # on a too-busy k8s cluster (resource contention).
-            memory: '500Mi'
-            cpu: 0.2
+            # Note(JP): these are so small to allow for deployment rollover on
+            # a too-busy k8s cluster (resource contention). Update: with
+            # somewhat more real mem resources on vd-2 we can bump this again.
+            memory: '2500Mi'
+            cpu: 0.5
         # TODO(JP): define liveness probe (for k8s to restart upon e.g.
         # deadlock). Readiness is really about when to serve traffic.
         readinessProbe:


### PR DESCRIPTION
BMRT cache usage is a little big right now (but only for populated databases). But generally we should start informing the k8s scheduler about more or less realistic memory requirements, this makes sense in particular in view of vd-2 having seen new resources.

I expect this change to break the minikube CI workflow, let's see.

In general, first we need to make sure we run Conbench in environment(s) that we are happy with (resource footprint-wise) and that we have full control over; before we invest into setting meaningful resource requests. Because having too little resources (and unpredictable resources) _plus_ setting big requests means: placement errors. And all what we get from placement errors these days is a loss in developer productivity.