### PR TITLE
ui: c-benchmarks/<bname>: show 'last result' column, fix TypeError for partial multisample results

### DIFF
--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -57,7 +57,7 @@ def show_benchmark_cases(bname: str) -> str:
     context_count_per_case = {}
     for case, results in results_by_case.items():
         context_count_per_case[case] = len(set([r.context for r in results]))
-        last_run_per_case[case] = max(r.ui_time_started_at for r in results)
+        last_run_per_case[case] = max(results, key=lambda r: r.timestamp)
 
     return flask.render_template(
         "c-benchmark-cases.html",

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -39,7 +39,7 @@ def show_benchmark_cases(bname: str) -> str:
 
     # cases = set(bmr.case for bmr in results)
 
-    results_by_case = defaultdict(list)
+    results_by_case: Dict[str, List[BenchmarkResult]] = defaultdict(list)
     for r in matching_results:
         results_by_case[r.case].append(r)
 
@@ -53,9 +53,11 @@ def show_benchmark_cases(bname: str) -> str:
 
     log.info("building hardware_count_per_case took %.3f s", time.monotonic() - t0)
 
+    last_run_per_case = {}
     context_count_per_case = {}
     for case, results in results_by_case.items():
         context_count_per_case[case] = len(set([r.context for r in results]))
+        last_run_per_case[case] = max(r.ui_time_started_at for r in results)
 
     return flask.render_template(
         "c-benchmark-cases.html",
@@ -65,6 +67,7 @@ def show_benchmark_cases(bname: str) -> str:
         bmr_cache_meta=_cache_bmrs["meta"],
         results_by_case=results_by_case,
         hardware_count_per_case=hardware_count_per_case,
+        last_run_per_case=last_run_per_case,
         context_count_per_case=context_count_per_case,
         # cases=cases,
         benchmark_result_count=len(matching_results),

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -53,11 +53,11 @@ def show_benchmark_cases(bname: str) -> str:
 
     log.info("building hardware_count_per_case took %.3f s", time.monotonic() - t0)
 
-    last_run_per_case = {}
+    last_result_per_case: Dict[str, BenchmarkResult] = {}
     context_count_per_case = {}
     for case, results in results_by_case.items():
         context_count_per_case[case] = len(set([r.context for r in results]))
-        last_run_per_case[case] = max(results, key=lambda r: r.timestamp)
+        last_result_per_case[case] = max(results, key=lambda r: r.timestamp)
 
     return flask.render_template(
         "c-benchmark-cases.html",
@@ -67,7 +67,7 @@ def show_benchmark_cases(bname: str) -> str:
         bmr_cache_meta=_cache_bmrs["meta"],
         results_by_case=results_by_case,
         hardware_count_per_case=hardware_count_per_case,
-        last_run_per_case=last_run_per_case,
+        last_result_per_case=last_result_per_case,
         context_count_per_case=context_count_per_case,
         # cases=cases,
         benchmark_result_count=len(matching_results),

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -396,6 +396,10 @@ class BenchmarkResult(Base, EntityMixin):
         if samples is None:
             return "no data"
 
+        # otherwise: `TypeError: can't convert type 'NoneType' to numerator/denominator`
+        # in statistics.stdev(samples)
+        samples = [s for s in samples if s is not None]
+
         if len(samples) < 3:
             # Show each sample with five significant figures.
             return "; ".join(str(sigfig.round(s, sigfigs=5)) for s in samples)
@@ -421,6 +425,10 @@ class BenchmarkResult(Base, EntityMixin):
 
         if samples is None:
             return "no data"
+
+        # otherwise: `TypeError: can't convert type 'NoneType' to numerator/denominator`
+        # in statistics.stdev(samples)
+        samples = [s for s in samples if s is not None]
 
         if len(samples) < 3:
             return "n/a"

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -376,15 +376,6 @@ class BenchmarkResult(Base, EntityMixin):
         }
 
     @property
-    def ui_timestamp(self) -> str:
-        """
-        Build human-readable timestamp string from `timestamp` property,
-        meant for consumption in UI.
-        """
-        return self.timestamp.strftime("%Y-%m-%d %H:%M:%S UTC")
-        # tznaive_dt_to_aware_iso8601_for_api(self.timestamp)
-
-    @property
     def ui_mean_and_uncertainty(self) -> str:
         """
         Build human-readable text conveying the data point acquired here.

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -137,6 +137,10 @@ def _periodically_fetch_last_n_benchmark_results() -> None:
     first_sleep_seconds = 10
     min_delay_between_runs_seconds = 120
 
+    if Config.TESTING:
+        first_sleep_seconds = 2
+        min_delay_between_runs_seconds = 20
+
     def _run_forever():
         global _SHUTDOWN
         global _STARTED

--- a/conbench/templates/c-benchmark-cases.html
+++ b/conbench/templates/c-benchmark-cases.html
@@ -32,7 +32,7 @@
             <a href="{{ url_for('app.show_benchmark_results', bname=benchmark_name, caseid=case.id) }}">{{ case.id[:10] }}</a>
         </td>
         <td class="font-monospace">{{ case.text_id }}</td>
-        <td class="font-monospace">{{ last_run_per_case[case] }}</td>
+        <td class="font-monospace">{{ last_run_per_case[case].ui_time_started_at }}</td>
         <td class="font-monospace">{{ results|length }}</td>
         <td class="font-monospace">{{ hardware_count_per_case[case] }}</td>
         <td class="font-monospace">{{ context_count_per_case[case] }}</td>

--- a/conbench/templates/c-benchmark-cases.html
+++ b/conbench/templates/c-benchmark-cases.html
@@ -32,7 +32,7 @@
             <a href="{{ url_for('app.show_benchmark_results', bname=benchmark_name, caseid=case.id) }}">{{ case.id[:10] }}</a>
         </td>
         <td class="font-monospace">{{ case.text_id }}</td>
-        <td class="font-monospace">{{ last_run_per_case[case].ui_time_started_at }}</td>
+        <td class="font-monospace">{{ last_result_per_case[case].ui_time_started_at }}</td>
         <td class="font-monospace">{{ results|length }}</td>
         <td class="font-monospace">{{ hardware_count_per_case[case] }}</td>
         <td class="font-monospace">{{ context_count_per_case[case] }}</td>

--- a/conbench/templates/c-benchmark-cases.html
+++ b/conbench/templates/c-benchmark-cases.html
@@ -20,6 +20,7 @@
             <th scope="col">case id</th>
             <th scope="col" style="width: 60%">case permutation</th>
             <th scope="col" style="width: 7%"># results</th>
+            <th scope="col" style="width: 7%">last run</th>
             <th scope="col" style="width: 9%"># hardwares</th>
             <th scope="col" style="width: 8%"># contexts</th>
         </tr>
@@ -32,6 +33,7 @@
         </td>
         <td class="font-monospace">{{ case.text_id }}</td>
         <td class="font-monospace">{{ results|length }}</td>
+        <td class="font-monospace">{{ last_run_per_case[case] }}</td>
         <td class="font-monospace">{{ hardware_count_per_case[case] }}</td>
         <td class="font-monospace">{{ context_count_per_case[case] }}</td>
     </tr>

--- a/conbench/templates/c-benchmark-cases.html
+++ b/conbench/templates/c-benchmark-cases.html
@@ -17,12 +17,12 @@
     <table class="table table-hover conbench-datatable" style="width:100%; display: none">
     <thead>
         <tr>
-            <th scope="col">case id</th>
-            <th scope="col" style="width: 60%">case permutation</th>
-            <th scope="col" style="width: 7%"># results</th>
-            <th scope="col" style="width: 7%">last run</th>
-            <th scope="col" style="width: 9%"># hardwares</th>
-            <th scope="col" style="width: 8%"># contexts</th>
+            <th scope="col" style="width: 7%">case id</th>
+            <th scope="col" style="width: 35%">case permutation</th>
+            <th scope="col" style="width: 13%">last result</th>
+            <th scope="col" style="width: 6%"># results</th>
+            <th scope="col" style="width: 8%"># hardwares</th>
+            <th scope="col" style="width: 6%"># contexts</th>
         </tr>
     </thead>
     <tbody>
@@ -32,8 +32,8 @@
             <a href="{{ url_for('app.show_benchmark_results', bname=benchmark_name, caseid=case.id) }}">{{ case.id[:10] }}</a>
         </td>
         <td class="font-monospace">{{ case.text_id }}</td>
-        <td class="font-monospace">{{ results|length }}</td>
         <td class="font-monospace">{{ last_run_per_case[case] }}</td>
+        <td class="font-monospace">{{ results|length }}</td>
         <td class="font-monospace">{{ hardware_count_per_case[case] }}</td>
         <td class="font-monospace">{{ context_count_per_case[case] }}</td>
     </tr>

--- a/conbench/templates/c-benchmark-results-for-case.html
+++ b/conbench/templates/c-benchmark-results-for-case.html
@@ -39,7 +39,7 @@
 <tbody>
 {% for result in benchmark_results_for_table %}
 <tr>
-    <td class="font-monospace">{{ result.ui_timestamp }}</td>
+    <td class="font-monospace">{{ result.ui_time_started_at }}</td>
     <td class="font-monospace"><a href="{{ url_for('app.benchmark-result', benchmark_result_id=result.id) }}">{{ result.id [:9]}}</a></td>
     <td class="font-monospace">{{ result.ui_hardware_short }}</td>
     <td class="font-monospace">{{ result.context.id[:8] }}</td>


### PR DESCRIPTION
This addresses #1241.

This adds a 'last result' column to ` c-benchmarks/<bname>` as proposed by @alistaire47, I like that; I think its valuable information.

Also fixes a TypeError thrown by `statistics.stdev()` when getting a sequence with a `None` item. Relates to https://github.com/conbench/conbench/issues/813.