### PR TITLE
Dashboard: refine panels, queries, add new panel for BMRT cache update time

### DIFF
--- a/k8s/kube-prometheus/conbench-grafana-dashboard.json
+++ b/k8s/kube-prometheus/conbench-grafana-dashboard.json
@@ -160,7 +160,7 @@
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -214,7 +214,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(http_request_total{namespace=~\"$namespace\",container=\"conbench\"}[$timewindow]))",
+          "expr": "sum(rate(http_request_total{namespace=~\"$namespace\"}[$timewindow]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -348,13 +348,13 @@
               "viz": false
             },
             "lineInterpolation": "linear",
-            "lineWidth": 2,
+            "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "log": 10,
               "type": "symlog"
             },
-            "showPoints": "auto",
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -383,7 +383,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 11,
         "w": 12,
         "x": 12,
         "y": 6
@@ -408,8 +408,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (status) (rate(http_request_total{namespace=~\"$namespace\",container=\"conbench\",status!=\"200\"}[$timewindow]))",
-          "legendFormat": "__auto",
+          "expr": "sum by (status) (rate(http_request_total{namespace=~\"$namespace\",status!=\"200\"}[$timewindow]))",
+          "legendFormat": "{{status}}",
           "range": true,
           "refId": "A"
         }
@@ -517,94 +517,6 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "path / and response status code 200",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "scaleDistribution": {
-              "type": "linear"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 12
-      },
-      "id": 13,
-      "options": {
-        "calculate": false,
-        "calculation": {
-          "xBuckets": {
-            "mode": "size"
-          },
-          "yBuckets": {
-            "mode": "size"
-          }
-        },
-        "cellGap": 1,
-        "color": {
-          "exponent": 0.5,
-          "fill": "dark-orange",
-          "mode": "scheme",
-          "reverse": false,
-          "scale": "exponential",
-          "scheme": "Spectral",
-          "steps": 99
-        },
-        "exemplars": {
-          "color": "rgba(255,0,255,0.7)"
-        },
-        "filterValues": {
-          "le": 1e-9
-        },
-        "legend": {
-          "show": true
-        },
-        "rowsFrame": {
-          "layout": "auto"
-        },
-        "tooltip": {
-          "show": true,
-          "yHistogram": false
-        },
-        "yAxis": {
-          "axisPlacement": "left",
-          "reverse": false,
-          "unit": "s"
-        }
-      },
-      "pluginVersion": "9.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum by (le) (rate(http_request_duration_seconds_bucket{namespace=~\"$namespace\",method=\"GET\",http_handler_name=\"app.index\",status=\"200\"}[$timewindow]))",
-          "format": "heatmap",
-          "legendFormat": "{{le}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "UI landing page: response generation duration, event rate [1/s]. Observation period: $timewindow",
-      "type": "heatmap"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
       "description": "The rate of GitHub HTTP API responses received with status code 403. Some of these errors may have been retried.",
       "fieldConfig": {
         "defaults": {
@@ -700,7 +612,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "",
+      "description": "path / and response status code 200",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -717,12 +629,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 12,
         "x": 12,
-        "y": 19
+        "y": 17
       },
-      "id": 6,
+      "id": 13,
       "options": {
         "calculate": false,
         "calculation": {
@@ -773,14 +685,14 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (le) (rate(http_request_duration_seconds_bucket{namespace=~\"$namespace\",method!=\"GET\",http_handler_name=~\"api.*\"}[$timewindow]))",
+          "expr": "sum by (le) (rate(http_request_duration_seconds_bucket{namespace=~\"$namespace\",method=\"GET\",http_handler_name=\"app.index\",status=\"200\"}[$timewindow]))",
           "format": "heatmap",
           "legendFormat": "{{le}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "/api non-GET requests: Flask HTTP response generation duration, event rate [1/s]. Observation period: $timewindow",
+      "title": "UI landing page: response generation duration, event rate [1/s]. Observation period: $timewindow",
       "type": "heatmap"
     },
     {
@@ -888,7 +800,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "This shows data only for those requests to /api/*\nRequests to /api/ping are excluded.\nRedirect responses are excluded.\n",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -908,9 +820,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 27
+        "y": 24
       },
-      "id": 5,
+      "id": 6,
       "options": {
         "calculate": false,
         "calculation": {
@@ -961,14 +873,14 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (le) (rate(http_request_duration_seconds_bucket{namespace=~\"$namespace\",method=\"GET\",http_handler_name=~\"api.*\",http_handler_name!=\"api.ping\",status!~\"3..\"}[$timewindow]))",
+          "expr": "sum by (le) (rate(http_request_duration_seconds_bucket{namespace=~\"$namespace\",method!=\"GET\",http_handler_name=~\"api.*\"}[$timewindow]))",
           "format": "heatmap",
           "legendFormat": "{{le}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "/api GET requests: response generation duration, event rate [1/s]. Observation period: $timewindow",
+      "title": "/api non-GET requests: Flask HTTP response generation duration, event rate [1/s]. Observation period: $timewindow",
       "type": "heatmap"
     },
     {
@@ -1068,10 +980,98 @@
       ],
       "title": "BMRT cache, duration of last update (seconds)",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "This shows data only for those requests to /api/*\nRequests to /api/ping are excluded.\nRedirect responses are excluded.\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 5,
+      "options": {
+        "calculate": false,
+        "calculation": {
+          "xBuckets": {
+            "mode": "size"
+          },
+          "yBuckets": {
+            "mode": "size"
+          }
+        },
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 99
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "show": true,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "pluginVersion": "9.5.0-cloud.4.a016665c",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (le) (rate(http_request_duration_seconds_bucket{namespace=~\"$namespace\",method=\"GET\",http_handler_name=~\"api.*\",http_handler_name!=\"api.ping\",status!~\"3..\"}[$timewindow]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "/api GET requests: response generation duration, event rate [1/s]. Observation period: $timewindow",
+      "type": "heatmap"
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 37,
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [
     "conbench"
@@ -1166,7 +1166,7 @@
     ]
   },
   "time": {
-    "from": "now-2d",
+    "from": "now-24h",
     "to": "now"
   },
   "timepicker": {},

--- a/k8s/kube-prometheus/conbench-grafana-dashboard.json
+++ b/k8s/kube-prometheus/conbench-grafana-dashboard.json
@@ -970,6 +970,104 @@
       ],
       "title": "/api GET requests: response generation duration, event rate [1/s]. Observation period: $timewindow",
       "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "This is a gauge. Last update wins.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "series",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "min": -1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "conbench_bmrt_cache_last_update_seconds{namespace=~\"$namespace\"}",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "BMRT cache, duration of last update (seconds)",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",

--- a/k8s/kube-prometheus/conbench-grafana-dashboard.json
+++ b/k8s/kube-prometheus/conbench-grafana-dashboard.json
@@ -214,7 +214,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(http_request_total{namespace=~\"$namespace\"}[$timewindow]))",
+          "expr": "sum(rate(http_request_total{namespace=~\"$namespace\",container=\"conbench\"}[$timewindow]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -408,13 +408,13 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (status) (rate(http_request_total{namespace=~\"$namespace\"}[$timewindow]))",
+          "expr": "sum by (status) (rate(http_request_total{namespace=~\"$namespace\",container=\"conbench\",status!=\"200\"}[$timewindow]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Flask response generation rate by status code [1/s], $timewindow mean",
+      "title": "webapp response generation rate by status code, non-200 [1/s], $timewindow mean",
       "type": "timeseries"
     },
     {
@@ -422,11 +422,12 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Based on a counter that is incremented right before attempting to make an HTTP request, i.e. this rate includes failed requests.",
+      "description": "The rate of failed HTTP requests, either after retrying or upon first attempt.",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "fixedColor": "semi-dark-red",
+            "mode": "fixed"
           },
           "custom": {
             "axisCenteredZero": false,
@@ -502,13 +503,13 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (instance)(rate(conbench_github_httpapi_requests_total{namespace=~\"$namespace\"}[$timewindow]))",
-          "legendFormat": "",
+          "expr": "sum(rate(conbench_github_httpapi_requests_failed_total{namespace=~\"$namespace\"}[$timewindow]))",
+          "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "GitHub HTTP API request rate [1/s], $timewindow mean",
+      "title": "GitHub HTTP API request error rate [1/s], $timewindow mean",
       "type": "timeseries"
     },
     {
@@ -604,11 +605,12 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "The rate of failed HTTP requests, either after retrying or upon first attempt.",
+      "description": "The rate of GitHub HTTP API responses received with status code 403. Some of these errors may have been retried.",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "fixedColor": "semi-dark-red",
+            "mode": "fixed"
           },
           "custom": {
             "axisCenteredZero": false,
@@ -684,13 +686,13 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (instance)(rate(conbench_github_httpapi_requests_failed_total{namespace=~\"$namespace\"}[$timewindow]))",
+          "expr": "sum(rate(conbench_github_httpapi_403responses_total[$timewindow]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "GitHub HTTP API request error rate [1/s], $timewindow mean",
+      "title": "GitHub HTTP API 403 error rate [1/s], $timewindow mean",
       "type": "timeseries"
     },
     {
@@ -903,10 +905,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 11,
+        "h": 8,
         "w": 12,
         "x": 12,
-        "y": 32
+        "y": 27
       },
       "id": 5,
       "options": {

--- a/k8s/kube-prometheus/conbench-grafana-dashboard.json
+++ b/k8s/kube-prometheus/conbench-grafana-dashboard.json
@@ -96,7 +96,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 3,
         "w": 12,
         "x": 0,
         "y": 0
@@ -200,7 +200,7 @@
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": false
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -229,6 +229,97 @@
         }
       ],
       "title": "Flask response generation rate [1/s], $timewindow mean",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Based on a counter that is incremented right before attempting to make an HTTP request, i.e. this rate includes failed requests.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "series",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "hertz"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 3
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(conbench_github_httpapi_requests_total{namespace=~\"$namespace\"}[$timewindow]))",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GitHub HTTP API request rate [1/s], $timewindow mean",
       "type": "timeseries"
     },
     {
@@ -292,7 +383,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 6,
         "w": 12,
         "x": 12,
         "y": 6
@@ -352,11 +443,10 @@
               "viz": false
             },
             "lineInterpolation": "linear",
-            "lineWidth": 3,
+            "lineWidth": 2,
             "pointSize": 5,
             "scaleDistribution": {
-              "log": 2,
-              "type": "symlog"
+              "type": "linear"
             },
             "showPoints": "auto",
             "spanNulls": false,
@@ -387,12 +477,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 6,
         "w": 12,
         "x": 0,
-        "y": 7
+        "y": 11
       },
-      "id": 9,
+      "id": 11,
       "options": {
         "legend": {
           "calcs": [],
@@ -443,10 +533,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 12,
         "x": 12,
-        "y": 13
+        "y": 12
       },
       "id": 13,
       "options": {
@@ -569,12 +659,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 6,
         "w": 12,
         "x": 0,
-        "y": 15
+        "y": 17
       },
-      "id": 11,
+      "id": 12,
       "options": {
         "legend": {
           "calcs": [],
@@ -625,10 +715,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 11,
+        "h": 8,
         "w": 12,
         "x": 12,
-        "y": 21
+        "y": 19
       },
       "id": 6,
       "options": {
@@ -696,101 +786,6 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "The rate of GitHub HTTP API responses received with status code 403. Some of these errors may have been retried.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "semi-dark-red",
-            "mode": "fixed"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "series",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 3,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "hertz"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 23
-      },
-      "id": 12,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum by (instance)(rate(conbench_github_httpapi_403responses_total[$timewindow]))",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "GitHub HTTP API 403 error rate [1/s], $timewindow mean",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
       "description": "This is a gauge. Last update wins. -1 means: not seen an HTTP response yet carrying the x-ratelimit-remaining header. Each process reports this. Processes might die.",
       "fieldConfig": {
         "defaults": {
@@ -802,6 +797,7 @@
             "axisColorMode": "series",
             "axisLabel": "",
             "axisPlacement": "auto",
+            "axisSoftMax": 6000,
             "axisSoftMin": -1,
             "barAlignment": 0,
             "drawStyle": "line",
@@ -849,10 +845,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 11,
+        "h": 9,
         "w": 12,
         "x": 0,
-        "y": 31
+        "y": 23
       },
       "id": 10,
       "options": {
@@ -877,7 +873,7 @@
           },
           "editorMode": "code",
           "expr": "conbench_github_httpapi_quota_remaining{namespace=~\"$namespace\"} > 0",
-          "legendFormat": "pid:{{pid}}, {{instance}}",
+          "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"
         }
@@ -1037,8 +1033,8 @@
       {
         "current": {
           "selected": true,
-          "text": ".*",
-          "value": ".*"
+          "text": "staging",
+          "value": "staging"
         },
         "hide": 0,
         "includeAll": false,
@@ -1047,7 +1043,7 @@
         "name": "namespace",
         "options": [
           {
-            "selected": false,
+            "selected": true,
             "text": "staging",
             "value": "staging"
           },
@@ -1057,7 +1053,7 @@
             "value": "default"
           },
           {
-            "selected": true,
+            "selected": false,
             "text": ".*",
             "value": ".*"
           }
@@ -1070,7 +1066,7 @@
     ]
   },
   "time": {
-    "from": "now-24h",
+    "from": "now-2d",
     "to": "now"
   },
   "timepicker": {},


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/265630/231996471-56d4bbac-5e70-47b3-8037-374f32abf71a.png)

I've made adjustments so that this dashboard works in two different Grafana instances (kube-prometheys, GC) and tested it against three different Conbench deployments (arrow, cb, cb-staging).
