### PR TITLE
result validation: run/result commit consistency, more test coverage, misc

### DIFF
--- a/conbench/api/results.py
+++ b/conbench/api/results.py
@@ -294,6 +294,8 @@ class BenchmarkListAPI(ApiEndpoint, BenchmarkValidationMixin):
 benchmark_entity_view = BenchmarkEntityAPI.as_view("benchmark")
 benchmark_list_view = BenchmarkListAPI.as_view("benchmarks")
 
+# Phase these out, at some point.
+# https://github.com/conbench/conbench/issues/972
 rule(
     "/benchmarks/",
     view_func=benchmark_list_view,
@@ -301,6 +303,19 @@ rule(
 )
 rule(
     "/benchmarks/<benchmark_result_id>/",
+    view_func=benchmark_entity_view,
+    methods=["GET", "DELETE", "PUT"],
+)
+
+# Towards the more explicit route path naming":
+# https://github.com/conbench/conbench/issues/972
+rule(
+    "/benchmark-results/",
+    view_func=benchmark_list_view,
+    methods=["GET", "POST"],
+)
+rule(
+    "/benchmark=results/<benchmark_result_id>/",
     view_func=benchmark_entity_view,
     methods=["GET", "DELETE", "PUT"],
 )

--- a/conbench/api/results.py
+++ b/conbench/api/results.py
@@ -14,6 +14,7 @@ from ..entities.benchmark_result import (
     BenchmarkResult,
     BenchmarkResultFacadeSchema,
     BenchmarkResultSerializer,
+    BenchmarkResultValidationError,
 )
 from ..entities.case import Case
 from ._resp import json_response_for_byte_sequence, resp400
@@ -282,9 +283,10 @@ class BenchmarkListAPI(ApiEndpoint, BenchmarkValidationMixin):
         # At this point, assume that data["tags"] is a flat dictionary with
         # keys being non-empty strings, and values being non-empty strings.
 
-        # Note(JP): in the future this will also raise further validation
-        # errors that are to be exposed via a 400 response to the HTTP client
-        benchmark_result = BenchmarkResult.create(data)
+        try:
+            benchmark_result = BenchmarkResult.create(data)
+        except BenchmarkResultValidationError as exc:
+            return resp400(str(exc))
 
         return self.response_201_created(self.serializer.one.dump(benchmark_result))
 

--- a/conbench/db.py
+++ b/conbench/db.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+import sys
 
 import psycopg2
 import sqlalchemy.exc
@@ -20,10 +21,16 @@ log = logging.getLogger(__name__)
 log.info("psycopg2.__libpq_version__: %s", psycopg2.__libpq_version__)
 
 
+# Pick less log verbosity when
+logfunc = log.info
+if "pytest" in sys.modules:
+    logfunc = log.debug
+
+
 def configure_engine(url):
     global engine, session_maker, Session
 
-    log.info("create sqlalchemy DB engine")
+    logfunc("create sqlalchemy DB engine")
     engine = create_engine(
         url,
         future=True,
@@ -50,7 +57,7 @@ def configure_engine(url):
             "connect_timeout": 3,  # unit: seconds
         },
     )
-    log.info("bind engine to session")
+    logfunc("bind engine to session")
     session_maker.configure(bind=engine)
 
 
@@ -142,7 +149,7 @@ def create_all():
         else:
             raise
 
-    log.info("create_all(engine) returned. dispose()")
+    logfunc("create_all(engine) returned. dispose()")
     engine.dispose()
 
 

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -31,6 +31,10 @@ from ..entities.info import Info
 from ..entities.run import GitHubCreate, Run
 
 
+class BenchmarkResultValidationError(Exception):
+    pass
+
+
 class BenchmarkResult(Base, EntityMixin):
     __tablename__ = "benchmark_result"
     id: Mapped[str] = NotNull(s.String(50), primary_key=True, default=generate_uuid)

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -145,6 +145,10 @@ class BenchmarkResult(Base, EntityMixin):
         run = Session.scalars(select(Run).where(Run.id == userres["run_id"])).first()
 
         if run is not None:
+            # TODO: specification -- if userres.get("github") is None and if
+            # the Run has associated commit information -- then consider this
+            # as a conflict or not? what about branch name and PR number?
+
             # The property should not be called "github", this confuses me each
             # time I deal with that.
             if userres.get("github") is not None:
@@ -152,9 +156,18 @@ class BenchmarkResult(Base, EntityMixin):
                 chresult = userres["github"]["commit"]
                 if chrun != chresult:
                     raise BenchmarkResultValidationError(
-                        f"result refers to commit hash {chresult}, but Run {run.id} "
-                        f"refers to commit hash {chrun}."
+                        f"Result refers to commit hash '{chresult}', but Run '{run.id}' "
+                        f"refers to commit hash '{chrun}'"
                     )
+
+                # Cannot do this yet, this is too complicated as of None/empty
+                # string confusion repo_url_run = run.commit.repo_url
+                # repo_url_result = userres["github"]["repository"] if
+                # repo_url_run != repo_url_result: raise
+                #     BenchmarkResultValidationError( f"Result refers to
+                #         repository URL '{repo_url_result}', but Run
+                #         '{run.id}' " f"refers to repository URL
+                #     '{repo_url_run}'" )
 
         # Temporary: keep name `data` -- it's unfortunate that we have the name
         # `data` here while also having key(s) in the dict(s) that are called

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -8,11 +8,12 @@ import marshmallow
 import numpy as np
 import sigfig
 import sqlalchemy as s
-from sqlalchemy import CheckConstraint as check
+from sqlalchemy import select, CheckConstraint as check
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import Mapped, relationship
 
 import conbench.util
+from conbench.db import Session
 
 from ..entities._comparator import z_improvement, z_regression
 from ..entities._entity import (
@@ -141,7 +142,8 @@ class BenchmarkResult(Base, EntityMixin):
                     "`error` property required when `stats` property not present"
                 )
 
-        run = Run.first(id=userres["run_id"])
+        run = Session.scalars(select(Run).where(Run.id == userres["run_id"])).first()
+
         if run is not None:
             # The property should not be called "github", this confuses me each
             # time I deal with that.

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -8,7 +8,8 @@ import marshmallow
 import numpy as np
 import sigfig
 import sqlalchemy as s
-from sqlalchemy import select, CheckConstraint as check
+from sqlalchemy import CheckConstraint as check
+from sqlalchemy import select
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import Mapped, relationship
 

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -136,12 +136,6 @@ class BenchmarkResult(Base, EntityMixin):
                 "(the name of the conceptual benchmark)"
             )
 
-        if "stats" not in userres:
-            if "error" not in userres:
-                raise BenchmarkResultValidationError(
-                    "`error` property required when `stats` property not present"
-                )
-
         run = Session.scalars(select(Run).where(Run.id == userres["run_id"])).first()
 
         if run is not None:

--- a/conbench/tests/api/_fixtures.py
+++ b/conbench/tests/api/_fixtures.py
@@ -44,7 +44,7 @@ MACHINE_INFO = {
     "gpu_product_names": ["Tesla T4", "GeForce GTX 1060 3GB"],
 }
 
-VALID_PAYLOAD = {
+VALID_RESULT_PAYLOAD = {
     "run_id": "2a5709d179f349cba69ed242be3e6321",
     "run_name": "commit: 02addad336ba19a654f9c857ede546331be7b631",
     "run_reason": "commit",
@@ -116,22 +116,22 @@ VALID_PAYLOAD = {
     },
 }
 
-VALID_PAYLOAD_WITH_ERROR = dict(
+VALID_RESULT_PAYLOAD_WITH_ERROR = dict(
     run_id="ya5709d179f349cba69ed242be3e6323",
     error={"stack_trace": "some trace", "command": "ls"},
     **{
         key: value
-        for key, value in VALID_PAYLOAD.items()
+        for key, value in VALID_RESULT_PAYLOAD.items()
         if key not in ("stats", "run_id")
     },
 )
 
-VALID_PAYLOAD_WITH_ITERATION_ERROR = dict(
+VALID_RESULT_PAYLOAD_WITH_ITERATION_ERROR = dict(
     run_id="ya5709d179f349cba69ed242be3e6323",
     error={"stack_trace": "some trace", "command": "ls"},
     **{
         key: value
-        for key, value in VALID_PAYLOAD.items()
+        for key, value in VALID_RESULT_PAYLOAD.items()
         if key not in ("stats", "run_id")
     },
     stats={
@@ -165,12 +165,12 @@ VALID_PAYLOAD_WITH_ITERATION_ERROR = dict(
     },
 )
 
-VALID_PAYLOAD_FOR_CLUSTER = dict(
+VALID_RESULT_PAYLOAD_FOR_CLUSTER = dict(
     run_id="3a5709d179f349cba69ed242be3e6323",
     cluster_info=CLUSTER_INFO,
     **{
         key: value
-        for key, value in VALID_PAYLOAD.items()
+        for key, value in VALID_RESULT_PAYLOAD.items()
         if key not in ("machine_info", "run_id")
     },
 )
@@ -228,7 +228,7 @@ def benchmark_result(
 ):
     """Create BenchmarkResult and write to database."""
 
-    data = copy.deepcopy(VALID_PAYLOAD)
+    data = copy.deepcopy(VALID_RESULT_PAYLOAD)
     data["run_name"] = f"commit: {_uuid()}"
     data["run_reason"] = reason if reason else "commit"
     data["run_id"] = run_id if run_id else _uuid()

--- a/conbench/tests/api/test_results.py
+++ b/conbench/tests/api/test_results.py
@@ -708,6 +708,7 @@ class TestBenchmarkResultPost(_asserts.PostEnforcer):
         self.assert_400_bad_request(response, message)
 
     def _assert_none_commit(self, response):
+        assert response.status_code == 201, (response.status_code, response.text)
         new_id = response.json["id"]
         benchmark_result = BenchmarkResult.one(id=new_id)
         assert benchmark_result.run.commit.sha == ""

--- a/conbench/tests/api/test_results.py
+++ b/conbench/tests/api/test_results.py
@@ -354,12 +354,14 @@ class TestBenchmarkList(_asserts.ListEnforcer):
         self.assert_200_ok(response, contains=_expected_entity(benchmark_result_2))
 
 
-class TestBenchmarkPost(_asserts.PostEnforcer):
+class TestBenchmarkResultPost(_asserts.PostEnforcer):
     url = "/api/benchmarks/"
-    valid_payload = _fixtures.VALID_PAYLOAD
-    valid_payload_for_cluster = _fixtures.VALID_PAYLOAD_FOR_CLUSTER
-    valid_payload_with_error = _fixtures.VALID_PAYLOAD_WITH_ERROR
-    valid_payload_with_iteration_error = _fixtures.VALID_PAYLOAD_WITH_ITERATION_ERROR
+    valid_payload = _fixtures.VALID_RESULT_PAYLOAD
+    valid_payload_for_cluster = _fixtures.VALID_RESULT_PAYLOAD_FOR_CLUSTER
+    valid_payload_with_error = _fixtures.VALID_RESULT_PAYLOAD_WITH_ERROR
+    valid_payload_with_iteration_error = (
+        _fixtures.VALID_RESULT_PAYLOAD_WITH_ITERATION_ERROR
+    )
     required_fields = [
         "batch_id",
         "context",
@@ -929,7 +931,7 @@ class TestBenchmarkPost(_asserts.PostEnforcer):
 
     def test_create_benchmark_context_missing(self, client):
         self.authenticate(client)
-        payload = _fixtures.VALID_PAYLOAD.copy()
+        payload = _fixtures.VALID_RESULT_PAYLOAD.copy()
         del payload["context"]
         resp = client.post(self.url, json=payload)
         assert resp.status_code == 400, f"unexpected response: {resp.text}"
@@ -937,13 +939,12 @@ class TestBenchmarkPost(_asserts.PostEnforcer):
 
     def test_create_benchmark_name_missing(self, client):
         self.authenticate(client)
-        payload = copy.deepcopy(_fixtures.VALID_PAYLOAD)
+        payload = copy.deepcopy(_fixtures.VALID_RESULT_PAYLOAD)
         del payload["tags"]["name"]
-        with pytest.raises(KeyError):
-            client.post(self.url, json=payload)
-            # TODO: https://github.com/conbench/conbench/issues/935
-            # This here just quickly checks that there is a failure at all,
-            # that 'name' is required.
+        # https://github.com/conbench/conbench/issues/935
+        resp = client.post(self.url, json=payload)
+        assert resp.status_code == 400, resp.text
+        assert "`name` property must be present in `tags" in resp.text
 
     @pytest.mark.parametrize(
         "tagdict",
@@ -958,7 +959,7 @@ class TestBenchmarkPost(_asserts.PostEnforcer):
     )
     def test_create_benchmark_bad_tags(self, client, tagdict):
         self.authenticate(client)
-        payload = copy.deepcopy(_fixtures.VALID_PAYLOAD)
+        payload = copy.deepcopy(_fixtures.VALID_RESULT_PAYLOAD)
         payload["tags"] = tagdict.copy()
         resp = client.post(self.url, json=payload)
         assert resp.status_code == 400
@@ -988,7 +989,7 @@ class TestBenchmarkPost(_asserts.PostEnforcer):
     )
     def test_create_benchmark_good_tags(self, client, tagdict):
         self.authenticate(client)
-        payload = copy.deepcopy(_fixtures.VALID_PAYLOAD)
+        payload = copy.deepcopy(_fixtures.VALID_RESULT_PAYLOAD)
         payload["tags"] = tagdict.copy()
         resp = client.post(self.url, json=payload)
         assert resp.status_code == 201
@@ -1005,7 +1006,7 @@ class TestBenchmarkPost(_asserts.PostEnforcer):
         this scenario.
         """
         self.authenticate(client)
-        payload = _fixtures.VALID_PAYLOAD.copy()
+        payload = _fixtures.VALID_RESULT_PAYLOAD.copy()
         payload["run_id"] = _uuid()
         payload["batch_id"] = _uuid()
 

--- a/conbench/tests/api/test_results.py
+++ b/conbench/tests/api/test_results.py
@@ -1093,3 +1093,20 @@ class TestBenchmarkResultPost(_asserts.PostEnforcer):
         assert (
             f"Run '{run['id']}' refers to commit hash '{run_commit_hash}'" in resp.text
         )
+
+    def test_create_result_missing_stats_and_error(self, client):
+        self.authenticate(client)
+        result = _fixtures.VALID_RESULT_PAYLOAD.copy()
+        del result["stats"]
+        try:
+            del result["error"]
+        except KeyError:
+            # if it wasn't set before, that's good, too.
+            pass
+
+        resp = client.post("/api/benchmark-results/", json=result)
+        assert resp.status_code == 400, resp.text
+
+        # This is currently the error message emitted by marshmallow
+        # schema validation.
+        assert "Either stats or error field is required" in resp.text

--- a/conbench/tests/api/test_results.py
+++ b/conbench/tests/api/test_results.py
@@ -1073,8 +1073,8 @@ class TestBenchmarkResultPost(_asserts.PostEnforcer):
     def test_create_result_mismatch_run_commit_hash(self, client):
         self.authenticate(client)
 
-        run = _fixtures.VALID_RUN_PAYLOAD.copy()
-        result = _fixtures.VALID_RESULT_PAYLOAD.copy()
+        run = copy.deepcopy(_fixtures.VALID_RUN_PAYLOAD)
+        result = copy.deepcopy(_fixtures.VALID_RESULT_PAYLOAD)
 
         resp = client.post("/api/runs/", json=run)
         assert resp.status_code == 201, resp.text

--- a/conbench/tests/app/_asserts.py
+++ b/conbench/tests/app/_asserts.py
@@ -79,7 +79,7 @@ class AppEndpointTest:
 
     def create_benchmark(self, client):
         self.authenticate(client)
-        response = client.post("/api/benchmarks/", json=_fixtures.VALID_PAYLOAD)
+        response = client.post("/api/benchmarks/", json=_fixtures.VALID_RESULT_PAYLOAD)
         assert response.status_code == 201, response.text
         benchmark_result_id = response.json["id"]
         self.logout(client)

--- a/conbench/tests/app/test_batches.py
+++ b/conbench/tests/app/test_batches.py
@@ -9,4 +9,4 @@ class TestBatch(_asserts.GetEnforcer):
 
     def _create(self, client):
         self.create_benchmark(client)
-        return _fixtures.VALID_PAYLOAD["batch_id"]
+        return _fixtures.VALID_RESULT_PAYLOAD["batch_id"]

--- a/conbench/tests/app/test_compare.py
+++ b/conbench/tests/app/test_compare.py
@@ -46,7 +46,7 @@ class TestCompareRuns(_asserts.GetEnforcer):
 
     def _create(self, client):
         self.create_benchmark(client)
-        run_id = _fixtures.VALID_PAYLOAD["run_id"]
+        run_id = _fixtures.VALID_RESULT_PAYLOAD["run_id"]
         return f"{run_id}...{run_id}"
 
     def test_flash_messages(self, client):

--- a/conbench/tests/app/test_hardware.py
+++ b/conbench/tests/app/test_hardware.py
@@ -9,7 +9,7 @@ class TestHardwares(_asserts.AppEndpointTest):
         self.authenticate(client)
         response = client.get("/hardware/")
         self.assert_page(response, "Hardware")
-        machine_name = _fixtures.VALID_PAYLOAD["machine_info"]["name"]
+        machine_name = _fixtures.VALID_RESULT_PAYLOAD["machine_info"]["name"]
         assert f"<div>{machine_name}</div>".encode() in response.data
 
     def test_hardware_list_unauthenticated(self, client):
@@ -20,7 +20,7 @@ class TestHardwares(_asserts.AppEndpointTest):
 class TestHardware(_asserts.AppEndpointTest):
     def test_hardware_get_authenticated(self, client):
         self.create_benchmark(client)
-        run_id = _fixtures.VALID_PAYLOAD["run_id"]
+        run_id = _fixtures.VALID_RESULT_PAYLOAD["run_id"]
         response = client.get(f"/api/runs/{run_id}/")
         hardware_id = response.json["hardware"]["id"]
 
@@ -30,7 +30,7 @@ class TestHardware(_asserts.AppEndpointTest):
 
     def test_hardware_get_unauthenticated(self, client):
         self.create_benchmark(client)
-        run_id = _fixtures.VALID_PAYLOAD["run_id"]
+        run_id = _fixtures.VALID_RESULT_PAYLOAD["run_id"]
         response = client.get(f"/api/runs/{run_id}/")
         hardware_id = response.json["hardware"]["id"]
 

--- a/conbench/tests/app/test_index.py
+++ b/conbench/tests/app/test_index.py
@@ -8,7 +8,7 @@ class TestIndex(_asserts.ListEnforcer):
 
     def _create(self, client):
         self.create_benchmark(client)
-        return _fixtures.VALID_PAYLOAD["run_id"]
+        return _fixtures.VALID_RESULT_PAYLOAD["run_id"]
 
     def test_unknown_route(self, client):
         response = client.get("/foo/")

--- a/conbench/tests/app/test_runs.py
+++ b/conbench/tests/app/test_runs.py
@@ -11,13 +11,13 @@ class TestRunGet(_asserts.GetEnforcer):
 
     def _create(self, client):
         self.create_benchmark(client)
-        return _fixtures.VALID_PAYLOAD["run_id"]
+        return _fixtures.VALID_RESULT_PAYLOAD["run_id"]
 
 
 class TestRunDelete(_asserts.DeleteEnforcer):
     def test_authenticated(self, client):
         self.create_benchmark(client)
-        run_id = _fixtures.VALID_PAYLOAD["run_id"]
+        run_id = _fixtures.VALID_RESULT_PAYLOAD["run_id"]
         self.authenticate(client)
         response = client.get(f"/runs/{run_id}/")
         self.assert_page(response, "Run")
@@ -34,7 +34,7 @@ class TestRunDelete(_asserts.DeleteEnforcer):
 
     def test_unauthenticated(self, client):
         self.create_benchmark(client)
-        run_id = _fixtures.VALID_PAYLOAD["run_id"]
+        run_id = _fixtures.VALID_RESULT_PAYLOAD["run_id"]
         self.logout(client)
         data = {"delete": ["Delete"]}
         response = client.post(f"/runs/{run_id}/", data=data, follow_redirects=True)
@@ -42,7 +42,7 @@ class TestRunDelete(_asserts.DeleteEnforcer):
 
     def test_no_csrf_token(self, client):
         self.create_benchmark(client)
-        run_id = _fixtures.VALID_PAYLOAD["run_id"]
+        run_id = _fixtures.VALID_RESULT_PAYLOAD["run_id"]
         self.authenticate(client)
         data = {"delete": ["Delete"]}
         response = client.post(f"/runs/{run_id}/", data=data, follow_redirects=True)

--- a/conbench/tests/benchmark/test_runner.py
+++ b/conbench/tests/benchmark/test_runner.py
@@ -25,9 +25,9 @@ assert os.path.exists(".git"), (
 
 pytestmark = pytest.mark.filterwarnings("ignore::conbench.machine_info.GitParseWarning")
 
-EXAMPLE = copy.deepcopy(_fixtures.VALID_PAYLOAD)
-EXAMPLE_WITH_CLUSTER_INFO = copy.deepcopy(_fixtures.VALID_PAYLOAD_FOR_CLUSTER)
-EXAMPLE_WITH_ERROR = copy.deepcopy(_fixtures.VALID_PAYLOAD_WITH_ERROR)
+EXAMPLE = copy.deepcopy(_fixtures.VALID_RESULT_PAYLOAD)
+EXAMPLE_WITH_CLUSTER_INFO = copy.deepcopy(_fixtures.VALID_RESULT_PAYLOAD_FOR_CLUSTER)
+EXAMPLE_WITH_ERROR = copy.deepcopy(_fixtures.VALID_RESULT_PAYLOAD_WITH_ERROR)
 for example in [EXAMPLE, EXAMPLE_WITH_CLUSTER_INFO, EXAMPLE_WITH_ERROR]:
     example.pop("run_name")
     example.pop("run_reason")


### PR DESCRIPTION
Main motivation of this PR was to address #932.

Three new result validation criteria:
- benchmark result commit hash matches run commit hash (test added)
- benchmark name set (test adjusted)
- error / stats: at least one is req (test added here)


Other changes:
- add HTTP route `api/benchmark-results/<bmrid>`, for #972.
- new SQLAlchemy query idiom with type inference
- better response validation
- reduce log verbosity during pytest session
- more renaming for sanity: "valid payload" -> "valid result payload"


Some details are broken out of #1119.