### PR TITLE
_entity.py: change query idiom (use type info), introduce robust get_or_create() functions

### DIFF
--- a/conbench/entities/_entity.py
+++ b/conbench/entities/_entity.py
@@ -106,7 +106,7 @@ class EntityMixin:
             raise NotFound()
 
     @classmethod
-    def first(cls, **kwargs):
+    def first(cls, **kwargs) -> cls:
         return Session.scalars(select(cls).filter_by(**kwargs)).first()
 
     @classmethod

--- a/conbench/entities/_entity.py
+++ b/conbench/entities/_entity.py
@@ -106,7 +106,7 @@ class EntityMixin:
             raise NotFound()
 
     @classmethod
-    def first(cls, **kwargs) -> cls:
+    def first(cls, **kwargs):
         return Session.scalars(select(cls).filter_by(**kwargs)).first()
 
     @classmethod

--- a/conbench/entities/_entity.py
+++ b/conbench/entities/_entity.py
@@ -3,7 +3,7 @@ import uuid
 from typing import List
 
 import flask as f
-from sqlalchemy import distinct
+from sqlalchemy import distinct, select
 from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 from sqlalchemy.orm import declarative_base, mapped_column
 from sqlalchemy.orm.exc import NoResultFound
@@ -107,7 +107,7 @@ class EntityMixin:
 
     @classmethod
     def first(cls, **kwargs):
-        return Session.query(cls).filter_by(**kwargs).first()
+        return Session.scalars(select(cls).filter_by(**kwargs)).first()
 
     @classmethod
     def delete_all(cls):

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -26,10 +26,10 @@ from ..entities._entity import (
     generate_uuid,
     to_float,
 )
-from ..entities.case import Case
-from ..entities.context import Context
+from ..entities.case import Case, get_case_or_create
+from ..entities.context import Context, get_context_or_create
 from ..entities.hardware import ClusterSchema, MachineSchema
-from ..entities.info import Info
+from ..entities.info import Info, get_info_or_create
 from ..entities.run import GitHubCreate, Run
 
 
@@ -269,26 +269,9 @@ class BenchmarkResult(Base, EntityMixin):
         # Also note: this pulls the `name=xx` key/value pair out of tags.
         name = tags.pop("name")
 
-        # create if not exists
-        c = {"name": name, "tags": tags}
-        case = Case.first(**c)
-        if not case:
-            # Note(JP): there is a race condition here, expect this to collide
-            case = Case.create(c)
-
-        # create if not exists
-        if "context" not in data:
-            data["context"] = {}
-        context = Context.first(tags=data["context"])
-        if not context:
-            context = Context.create({"tags": data["context"]})
-
-        # create if not exists
-        if "info" not in data:
-            data["info"] = {}
-        info = Info.first(tags=data["info"])
-        if not info:
-            info = Info.create({"tags": data["info"]})
+        case = get_case_or_create({"name": name, "tags": tags})
+        context = get_context_or_create({"tags": data["context"]})
+        info = get_info_or_create({"tags": data["info"]})
 
         # Create a corresponding `run` entity in the database if it doesn't
         # exist yet. Use the user-given `id` (string) as primary key. If the

--- a/conbench/entities/case.py
+++ b/conbench/entities/case.py
@@ -13,4 +13,23 @@ class Case(Base, EntityMixin):
     tags: Mapped[dict] = NotNull(postgresql.JSONB)
 
 
+def get_case_or_create(case_dict) -> Case:
+    """
+    Try to create case, but expect conflict (work with unique constraint on
+    name/tags).
+
+    Return (newly created, or previously existing) Case object, or raise an
+    exception.
+    """
+    try:
+        return Case.create(case_dict)
+    except s.exc.IntegrityError as exc:
+        if "unique constraint" in str(exc):
+            # It is known that it exists, otherwise conflict is not precise.
+            c = Case.first(**case_dict)
+            assert c is not None
+            return c
+        raise
+
+
 s.Index("case_index", Case.name, Case.tags, unique=True)

--- a/conbench/entities/case.py
+++ b/conbench/entities/case.py
@@ -2,6 +2,8 @@ import sqlalchemy as s
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import Mapped
 
+from conbench.db import Session
+
 from ..entities._entity import Base, EntityMixin, NotNull, generate_uuid
 
 
@@ -24,12 +26,13 @@ def get_case_or_create(case_dict) -> Case:
     try:
         return Case.create(case_dict)
     except s.exc.IntegrityError as exc:
-        if "unique constraint" in str(exc):
-            # It is known that it exists, otherwise conflict is not precise.
-            c = Case.first(**case_dict)
-            assert c is not None
-            return c
-        raise
+        if "violates unique constraint" not in str(exc):
+            raise
+
+    Session.rollback()
+    c = Case.first(**case_dict)
+    assert c is not None
+    return c
 
 
 s.Index("case_index", Case.name, Case.tags, unique=True)

--- a/conbench/entities/context.py
+++ b/conbench/entities/context.py
@@ -4,6 +4,7 @@ from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import Mapped
 
 from conbench.db import Session
+
 from ..entities._entity import (
     Base,
     EntityMixin,

--- a/conbench/entities/context.py
+++ b/conbench/entities/context.py
@@ -18,6 +18,24 @@ class Context(Base, EntityMixin):
     tags: Mapped[dict] = NotNull(postgresql.JSONB)
 
 
+def get_context_or_create(ctx_dict) -> Context:
+    """
+    Try to create, but expect conflict (work with unique constraint on
+    name/tags).
+
+    Return (newly created, or previously existing) object, or raise an
+    exception.
+    """
+    try:
+        return Context.create(ctx_dict)
+    except s.exc.IntegrityError as exc:
+        if "unique constraint" in str(exc):
+            c = Context.first(**ctx_dict)
+            assert c is not None
+            return c
+        raise
+
+
 s.Index("context_index", Context.tags, unique=True)
 
 

--- a/conbench/entities/info.py
+++ b/conbench/entities/info.py
@@ -18,6 +18,24 @@ class Info(Base, EntityMixin):
     tags: Mapped[dict] = NotNull(postgresql.JSONB)
 
 
+def get_info_or_create(ctx_dict) -> Info:
+    """
+    Try to create, but expect conflict (work with unique constraint on
+    name/tags).
+
+    Return (newly created, or previously existing) object, or raise an
+    exception.
+    """
+    try:
+        return Info.create(ctx_dict)
+    except s.exc.IntegrityError as exc:
+        if "unique constraint" in str(exc):
+            i = Info.first(**ctx_dict)
+            assert i is not None
+            return i
+        raise
+
+
 s.Index("info_index", Info.tags, unique=True)
 
 


### PR DESCRIPTION
Main ideas broken out of #1119. 

This patch replaces check-then-create sequences (prone to race condition) with their more robust and correct EAFP-based counterparts: try to create, but expect conflict. Upon conflict, fetch the thing.

Also, change the `first()` method in _entity.py to use a newer SQLAlchemy idiom; with that, the IDE knows the type of the returned object of this method.

We can of course look into implementing the `get_X_or_create()` family of functions in a parent class; and we should. But this is a tiny bit of an effort to do right, with nice type annotations. Can/will do later.