### PR TITLE
BenchmarkResult validation: consolidate some code paths, add validation units of work

### DIFF
--- a/conbench/api/results.py
+++ b/conbench/api/results.py
@@ -231,60 +231,6 @@ class BenchmarkListAPI(ApiEndpoint, BenchmarkValidationMixin):
         # can use) based on the schema that we validate against.
         data = self.validate_benchmark(self.schema.create)
 
-        # Note(JP): this next block inspects and mutates `tags`, with the goal
-        # that all keys are non-empty strings, and all values are non-empty
-        # strings. See
-        # https://github.com/conbench/conbench/pull/948#discussion_r1149090197
-        # for background. Summary of current desired behavior: primitive value
-        # types are accepted (string, boolean, float, int; non-string values
-        # are converted to string before DB insertion). Other value types
-        # (array -> list, object -> dict) lead to request rejection.
-        tags = data["tags"]
-        # Iterate over a copy of key/value pairs.
-        for key, value in list(tags.items()):
-            # In JSON, a key is always of type string. We rely on this, codify
-            # this invariant.
-            assert isinstance(key, str)
-
-            # An empty string is a valid JSON key. Do not allow this.
-            if len(key) == 0:
-                return resp400("tags: zero-length string as key is not allowed")
-
-            # For now, be liberal in what we accept. Do not consider empty
-            # string or None values for the case permutation (do not store
-            # those in the DB, drop these key/value pairs). This is documented
-            # in the API spec. Maybe in the future we want to reject such
-            # requests with a Bad Request response.
-            if value == "" or value is None:
-                log.warning("drop tag key/value pair: `%s`, `%s`", key, value)
-                # Remove current key/value pair, proceed with next key. This
-                # mutates the dictionary `data["tags"]`; for keeping this a
-                # sane operation the loop iterates over a copy of key/value
-                # pairs.
-                del tags[key]
-                continue
-
-            # Note(JP): this code path should go away after we adjust our
-            # client tooling to not send numeric values anymore.
-            if isinstance(value, (int, float, bool)):
-                # I think we first want to adjust some client tooling before
-                # enabling this log line:
-                # log.warning("stringify case parameter value: `%s`, `%s`", key, value)
-                # Replace value, proceed with next key.
-                tags[key] = str(value)
-                continue
-
-            # This should be logically equivalent with the value being either
-            # of type dict or of type list.
-            if not isinstance(value, str):
-                # Emit Bad Request response..
-                return resp400(
-                    "tags: bad value type for key `{key}`, JSON object and array is not allowed`"
-                )
-
-        # At this point, assume that data["tags"] is a flat dictionary with
-        # keys being non-empty strings, and values being non-empty strings.
-
         try:
             benchmark_result = BenchmarkResult.create(data)
         except BenchmarkResultValidationError as exc:

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -160,7 +160,11 @@ class BenchmarkResult(Base, EntityMixin):
         # This is going to be the structure based on which we will do
         # DB insertion.
         benchmark_result_data = {}
-        benchmark_result_data["error"] = result_error_for_db
+        # Only insert `error` key if there is an error object. In JSON, error:
+        # null still means that the benchmark is errored (at least some
+        # business logic treat it as such.)
+        if result_error_for_db is not None:
+            benchmark_result_data["error"] = result_error_for_db
 
         # Temporary: keep name `data` -- it's unfortunate that we have the name
         # `data` here while also having key(s) in the dict(s) that are called

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -238,7 +238,10 @@ class BenchmarkResult(Base, EntityMixin):
         # Also note: this pulls the `name=xx` key/value pair out of tags.
         name = tags.pop("name")
 
-        case = get_case_or_create({"name": name, "tags": tags})
+        # See https://github.com/conbench/conbench/issues/935,
+        # name is guaranteed to be set.
+        benchmark_name = tags.pop("name")
+        case = get_case_or_create({"name": benchmark_name, "tags": tags})
         context = get_context_or_create({"tags": data["context"]})
         info = get_info_or_create({"tags": data["info"]})
 

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -148,7 +148,7 @@ class BenchmarkResult(Base, EntityMixin):
         # Now, check for a more subtle error condition, based on the per-
         # iteration samples. Rely on `stats` key to exist (see checks above).
         if "stats" in userres and do_iteration_samples_look_like_error(
-            userres["stats"]
+            userres["stats"]["data"]
         ):
             if "error" not in userres:
                 # User did not set `error`, but the number sequence indicates
@@ -180,7 +180,8 @@ class BenchmarkResult(Base, EntityMixin):
             # deserializaiton/validation against the `BenchmarkResultCreate`
             # schema below. This needs better naming. Most importantly, we
             # should make use of typing information derived from the schema.
-            benchmark_result_data = data["stats"].copy()
+            # Merge this on top of the above-defined benchmark_result_data.
+            benchmark_result_data = benchmark_result_data | data["stats"].copy()
 
             # Note(JP): I think we may want to emit a Bad Request response when
             # benchmark_result_data['data'] does not contain any non-null
@@ -303,7 +304,6 @@ class BenchmarkResult(Base, EntityMixin):
         benchmark_result_data["info_id"] = info.id
         benchmark_result_data["context_id"] = context.id
         benchmark_result = BenchmarkResult(**benchmark_result_data)
-
         benchmark_result.save()
 
         return benchmark_result

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -130,12 +130,6 @@ class BenchmarkResult(Base, EntityMixin):
         Raises BenchmarkResultValidationError, exc message is expected to be
         emitted to the HTTP client in a Bad Request response.
         """
-        # See: https://github.com/conbench/conbench/issues/935
-        if "name" not in userres["tags"]:
-            raise BenchmarkResultValidationError(
-                "`name` property must be present in `tags` "
-                "(the name of the conceptual benchmark)"
-            )
 
         validate_and_augment_result_tags(userres)
 

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -176,23 +176,16 @@ class BenchmarkResult(Base, EntityMixin):
         # keys being non-empty strings, and values being non-empty strings.
         tags = data["tags"]
         has_error = "error" in data
-        has_stats = "stats" in data
 
-        if has_stats:
+        if "stats" in data:
             # Note(JP): this is the result of marshmallow
-            # deserializaiton/validation against the `BenchmarkResultCreate`
+            # deserialization/validation against the `BenchmarkResultCreate`
             # schema below. This needs better naming. Most importantly, we
             # should make use of typing information derived from the schema.
+
             # Merge this on top of the above-defined benchmark_result_data.
             benchmark_result_data = benchmark_result_data | data["stats"].copy()
 
-            # Note(JP): I think we may want to emit a Bad Request response when
-            # benchmark_result_data['data'] does not contain any non-null
-            # value. An empty list would then also be rejected right away. `if
-            # benchmark_result_data.get("data")` is probably supposed to catch
-            # the case where an empty list was provided.
-
-            # calculate any missing stats if data available
             if benchmark_result_data.get("data"):
                 # Note(JP): looks like `benchmark_result_data["data"]` is a
                 # list of either `None` or `Decimal` objects (currently

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -147,16 +147,15 @@ class BenchmarkResult(Base, EntityMixin):
 
         # Now, check for a more subtle error condition, based on the per-
         # iteration samples. Rely on `stats` key to exist (see checks above).
-        if "stats" in userres and do_iteration_samples_look_like_error(
+        elif "stats" in userres and do_iteration_samples_look_like_error(
             userres["stats"]["data"]
         ):
-            if "error" not in userres:
-                # User did not set `error`, but the number sequence indicates
-                # that this result is to be considered 'errored'. Set a generic
-                # error message.
-                result_error_for_db = {
-                    "status": "Partial result: not all iterations completed"
-                }
+            # User did not set `error`, but the number sequence indicates
+            # that this result is to be considered 'errored'. Set a generic
+            # error message.
+            result_error_for_db = {
+                "status": "Partial result: not all iterations completed"
+            }
 
         # This is going to be the structure based on which we will do
         # DB insertion.

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -257,11 +257,6 @@ class BenchmarkResult(Base, EntityMixin):
                 "status": "Partial result: not all iterations completed"
             }
 
-        # Note(JP): this implicitly introduces a requirement for `name` to be
-        # set: https://github.com/conbench/conbench/issues/935
-        # Also note: this pulls the `name=xx` key/value pair out of tags.
-        name = tags.pop("name")
-
         # See https://github.com/conbench/conbench/issues/935,
         # name is guaranteed to be set.
         benchmark_name = tags.pop("name")

--- a/conbench/tests/api/test_results.py
+++ b/conbench/tests/api/test_results.py
@@ -562,6 +562,7 @@ class TestBenchmarkResultPost(_asserts.PostEnforcer):
 
         new_id = response.json["id"]
         benchmark_result = BenchmarkResult.one(id=new_id)
+
         location = "http://localhost/api/benchmarks/%s/" % new_id
         stats = self.valid_payload_with_iteration_error["stats"]
         stats["data"] = [float(x) if x is not None else None for x in stats["data"]]


### PR DESCRIPTION
Ideas split out from #1119.

The BenchmarkResult.create() method is more or less unmaintainable. Before we add new logic, we need to make the code easier to read and reason about.

Here, we add three new units of work, and I hope their name reflects quite well what they are doing:

- `validate_run_result_consistency()`
- `validate_and_augment_result_tags()`
- `do_iteration_samples_look_like_error()`

This patch also 
- renames `name` -> `benchmark_name`
- clarifies when a benchmark result is considered "errored"