### PR TITLE
benchadapt: consolidate the "github-flavored commit info" acquisition and communication

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Build docs, exiting non-zero on warnings (which can be very bad)
         run: make build-docs SPHINXOPTS='-W --keep-going'
 
-  This is to confirm that commonly used developer commands still work.
+  # This is to confirm that commonly used developer commands still work.
   dev-cmds:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -32,13 +32,13 @@ jobs:
       - name: lint
         run: make lint-ci
 
-  testsuite:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-      - name: Run `make tests`
-        run: make tests
+  # testsuite:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: checkout
+  #       uses: actions/checkout@v3
+  #     - name: Run `make tests`
+  #       run: make tests
 
   check-docs:
     runs-on: ubuntu-latest
@@ -59,107 +59,107 @@ jobs:
         run: make build-docs SPHINXOPTS='-W --keep-going'
 
   # This is to confirm that commonly used developer commands still work.
-  dev-cmds:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-      - name: rebuild-expected-api-docs
-        run: |
-          pip install black
-          make rebuild-expected-api-docs
-      # Launch application as containerized stack. This terminates after
-      # health checks confirm that stack is running.
-      - name: run-app-bg
-        run: make run-app-bg
-      # Run `db-populate` twice to see that this can be repeated w/o failing.
-      - name: test `make db-populate`, twice
-        run: |
-            pip install requests # the nonly non-stdlib dependency as of now
-            export CONBENCH_BASE_URL=http://$(docker compose port app 5000) && \
-            make db-populate && make db-populate
-            docker-compose logs # view logs to see why transient errs happen
-      - name: test `make teardown-app`
-        run: make teardown-app
-      # The goal of this is to largely test `make run-app-dev`.
-      - name: test-run-app-dev
-        run: make test-run-app-dev
+  # dev-cmds:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: checkout
+  #       uses: actions/checkout@v3
+  #     - name: Set up Python
+  #       uses: actions/setup-python@v4
+  #       with:
+  #         python-version: "3.10"
+  #     - name: rebuild-expected-api-docs
+  #       run: |
+  #         pip install black
+  #         make rebuild-expected-api-docs
+  #     # Launch application as containerized stack. This terminates after
+  #     # health checks confirm that stack is running.
+  #     - name: run-app-bg
+  #       run: make run-app-bg
+  #     # Run `db-populate` twice to see that this can be repeated w/o failing.
+  #     - name: test `make db-populate`, twice
+  #       run: |
+  #           pip install requests # the nonly non-stdlib dependency as of now
+  #           export CONBENCH_BASE_URL=http://$(docker compose port app 5000) && \
+  #           make db-populate && make db-populate
+  #           docker-compose logs # view logs to see why transient errs happen
+  #     - name: test `make teardown-app`
+  #       run: make teardown-app
+  #     # The goal of this is to largely test `make run-app-dev`.
+  #     - name: test-run-app-dev
+  #       run: make test-run-app-dev
 
-  ui-screenshots:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-      - name: run-app-bg
-        run: make run-app-bg
-      - name: populate DB & take screenshots
-        run: |
-            pip install requests # the nonly non-stdlib dependency as of now
-            export CONBENCH_BASE_URL=http://$(docker compose port app 5000)
-            # Get first line of stdout, interpret as benchmark ID
-            export SOME_BENCHMARK_ID="$(make -s db-populate | head -1)"
-            echo "conbench base URL: $CONBENCH_BASE_URL"
-            echo "a valid benchmark ID: $SOME_BENCHMARK_ID"
-            cd ci
-            docker build . -t conbench-screenshot -f screenshot.Dockerfile
-            mkdir ci-artifacts
-            docker run --net=host -v $(pwd)/ci-artifacts:/artifacts conbench-screenshot \
-                python screenshot.py ${CONBENCH_BASE_URL} /artifacts frontpage
-            docker run --net=host -v $(pwd)/ci-artifacts:/artifacts conbench-screenshot \
-                python screenshot.py "${CONBENCH_BASE_URL}/benchmarks/${SOME_BENCHMARK_ID}/" \
-                  /artifacts benchmark-result-view --wait-for-canvas
-            /bin/ls -ahltr ci-artifacts/
-      - name: upload-artifacts
-        uses: actions/upload-artifact@v3
-        # Upload screenshots _especially_ when result was unexpected.
-        if: always()
-        with:
-          name: screenshots
-          path: ci/ci-artifacts/
-      - name: get container logs
-        if: always()
-        # If the browser-initiated GET requests led to e.g an Internal Server Error
-        # then we see that in the screenshot(s). For debugging that, however,
-        # it's crucial to get web application logs. Note that this shows
-        # container logs interleaved, but prefixed so that it's after all
-        # unambiguous which line came from which container.
-        run: docker compose logs --since 30m
-      - name: test `make teardown-app`
-        # Run teardown especially when previous step(s) failed, because here
-        # we get some good log output for debuggability.
-        if: always()
-        run: make teardown-app
+  # ui-screenshots:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: checkout
+  #       uses: actions/checkout@v3
+  #     - name: run-app-bg
+  #       run: make run-app-bg
+  #     - name: populate DB & take screenshots
+  #       run: |
+  #           pip install requests # the nonly non-stdlib dependency as of now
+  #           export CONBENCH_BASE_URL=http://$(docker compose port app 5000)
+  #           # Get first line of stdout, interpret as benchmark ID
+  #           export SOME_BENCHMARK_ID="$(make -s db-populate | head -1)"
+  #           echo "conbench base URL: $CONBENCH_BASE_URL"
+  #           echo "a valid benchmark ID: $SOME_BENCHMARK_ID"
+  #           cd ci
+  #           docker build . -t conbench-screenshot -f screenshot.Dockerfile
+  #           mkdir ci-artifacts
+  #           docker run --net=host -v $(pwd)/ci-artifacts:/artifacts conbench-screenshot \
+  #               python screenshot.py ${CONBENCH_BASE_URL} /artifacts frontpage
+  #           docker run --net=host -v $(pwd)/ci-artifacts:/artifacts conbench-screenshot \
+  #               python screenshot.py "${CONBENCH_BASE_URL}/benchmarks/${SOME_BENCHMARK_ID}/" \
+  #                 /artifacts benchmark-result-view --wait-for-canvas
+  #           /bin/ls -ahltr ci-artifacts/
+  #     - name: upload-artifacts
+  #       uses: actions/upload-artifact@v3
+  #       # Upload screenshots _especially_ when result was unexpected.
+  #       if: always()
+  #       with:
+  #         name: screenshots
+  #         path: ci/ci-artifacts/
+  #     - name: get container logs
+  #       if: always()
+  #       # If the browser-initiated GET requests led to e.g an Internal Server Error
+  #       # then we see that in the screenshot(s). For debugging that, however,
+  #       # it's crucial to get web application logs. Note that this shows
+  #       # container logs interleaved, but prefixed so that it's after all
+  #       # unambiguous which line came from which container.
+  #       run: docker compose logs --since 30m
+  #     - name: test `make teardown-app`
+  #       # Run teardown especially when previous step(s) failed, because here
+  #       # we get some good log output for debuggability.
+  #       if: always()
+  #       run: make teardown-app
 
-  db-migrations:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-      - name: Start PostgreSQL DB
-        run: docker compose run --detach db
-      # Run `alembic upgrade head` via docker compose. This runs in the web
-      # application container image. Running this via docker compose makes it
-      # so that it is within the virtual network that the DB is also in,
-      # reachable via DNS name `db`. Set CREATE_ALL_TABLES=false to defuse some
-      # webapp bootstrap code (not needed here, because these Python modules
-      # run in the context of alembic, not in the context of the actual web
-      # application bootstrapping itself).
-      - name: Test database migrations
-        run: make set-build-info && docker compose run -e CREATE_ALL_TABLES app alembic upgrade head
-        env:
-          CREATE_ALL_TABLES: false
-      # a better way to test this would be to change source code to
-      # generate a non-noop migration.
-      - name: Test make alembic-new-migration
-        run: |
-          make alembic-new-migration
-          cat migrations/versions/*dummy_migr_name*
-        env:
-           ALEMBIC_MIGRATION_NAME: dummy_migr_name
+  # db-migrations:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: checkout
+  #       uses: actions/checkout@v3
+  #     - name: Start PostgreSQL DB
+  #       run: docker compose run --detach db
+  #     # Run `alembic upgrade head` via docker compose. This runs in the web
+  #     # application container image. Running this via docker compose makes it
+  #     # so that it is within the virtual network that the DB is also in,
+  #     # reachable via DNS name `db`. Set CREATE_ALL_TABLES=false to defuse some
+  #     # webapp bootstrap code (not needed here, because these Python modules
+  #     # run in the context of alembic, not in the context of the actual web
+  #     # application bootstrapping itself).
+  #     - name: Test database migrations
+  #       run: make set-build-info && docker compose run -e CREATE_ALL_TABLES app alembic upgrade head
+  #       env:
+  #         CREATE_ALL_TABLES: false
+  #     # a better way to test this would be to change source code to
+  #     # generate a non-noop migration.
+  #     - name: Test make alembic-new-migration
+  #       run: |
+  #         make alembic-new-migration
+  #         cat migrations/versions/*dummy_migr_name*
+  #       env:
+  #          ALEMBIC_MIGRATION_NAME: dummy_migr_name
 
   libraries:
     runs-on: ubuntu-latest
@@ -198,19 +198,19 @@ jobs:
         run: |
           pytest -vv benchconnect
 
-  cb-on-minikube:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-      - name: start minikube
-        id: minikube
-        uses: medyagh/setup-minikube@e1ee887a96c50e34066a4bf9f172eb94ae69d454
-        with:
-          kubernetes-version: v1.23.16
-          # By convention, both locally and in CI we call this mk-conbench.
-          start-args: '--profile mk-conbench --extra-config=kubelet.cgroup-driver=systemd'
-          cpus: max
-          memory: max
-      - name: ci/minikube/test-conbench-on-mk.sh
-        run: export CONBENCH_REPO_ROOT_DIR=$(pwd) && bash ci/minikube/test-conbench-on-mk.sh
+  # cb-on-minikube:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: checkout
+  #       uses: actions/checkout@v3
+  #     - name: start minikube
+  #       id: minikube
+  #       uses: medyagh/setup-minikube@e1ee887a96c50e34066a4bf9f172eb94ae69d454
+  #       with:
+  #         kubernetes-version: v1.23.16
+  #         # By convention, both locally and in CI we call this mk-conbench.
+  #         start-args: '--profile mk-conbench --extra-config=kubelet.cgroup-driver=systemd'
+  #         cpus: max
+  #         memory: max
+  #     - name: ci/minikube/test-conbench-on-mk.sh
+  #       run: export CONBENCH_REPO_ROOT_DIR=$(pwd) && bash ci/minikube/test-conbench-on-mk.sh

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -32,13 +32,13 @@ jobs:
       - name: lint
         run: make lint-ci
 
-  # testsuite:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: checkout
-  #       uses: actions/checkout@v3
-  #     - name: Run `make tests`
-  #       run: make tests
+  testsuite:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: Run `make tests`
+        run: make tests
 
   check-docs:
     runs-on: ubuntu-latest
@@ -58,108 +58,108 @@ jobs:
       - name: Build docs, exiting non-zero on warnings (which can be very bad)
         run: make build-docs SPHINXOPTS='-W --keep-going'
 
-  # This is to confirm that commonly used developer commands still work.
-  # dev-cmds:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: checkout
-  #       uses: actions/checkout@v3
-  #     - name: Set up Python
-  #       uses: actions/setup-python@v4
-  #       with:
-  #         python-version: "3.10"
-  #     - name: rebuild-expected-api-docs
-  #       run: |
-  #         pip install black
-  #         make rebuild-expected-api-docs
-  #     # Launch application as containerized stack. This terminates after
-  #     # health checks confirm that stack is running.
-  #     - name: run-app-bg
-  #       run: make run-app-bg
-  #     # Run `db-populate` twice to see that this can be repeated w/o failing.
-  #     - name: test `make db-populate`, twice
-  #       run: |
-  #           pip install requests # the nonly non-stdlib dependency as of now
-  #           export CONBENCH_BASE_URL=http://$(docker compose port app 5000) && \
-  #           make db-populate && make db-populate
-  #           docker-compose logs # view logs to see why transient errs happen
-  #     - name: test `make teardown-app`
-  #       run: make teardown-app
-  #     # The goal of this is to largely test `make run-app-dev`.
-  #     - name: test-run-app-dev
-  #       run: make test-run-app-dev
+  This is to confirm that commonly used developer commands still work.
+  dev-cmds:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: rebuild-expected-api-docs
+        run: |
+          pip install black
+          make rebuild-expected-api-docs
+      # Launch application as containerized stack. This terminates after
+      # health checks confirm that stack is running.
+      - name: run-app-bg
+        run: make run-app-bg
+      # Run `db-populate` twice to see that this can be repeated w/o failing.
+      - name: test `make db-populate`, twice
+        run: |
+            pip install requests # the nonly non-stdlib dependency as of now
+            export CONBENCH_BASE_URL=http://$(docker compose port app 5000) && \
+            make db-populate && make db-populate
+            docker-compose logs # view logs to see why transient errs happen
+      - name: test `make teardown-app`
+        run: make teardown-app
+      # The goal of this is to largely test `make run-app-dev`.
+      - name: test-run-app-dev
+        run: make test-run-app-dev
 
-  # ui-screenshots:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: checkout
-  #       uses: actions/checkout@v3
-  #     - name: run-app-bg
-  #       run: make run-app-bg
-  #     - name: populate DB & take screenshots
-  #       run: |
-  #           pip install requests # the nonly non-stdlib dependency as of now
-  #           export CONBENCH_BASE_URL=http://$(docker compose port app 5000)
-  #           # Get first line of stdout, interpret as benchmark ID
-  #           export SOME_BENCHMARK_ID="$(make -s db-populate | head -1)"
-  #           echo "conbench base URL: $CONBENCH_BASE_URL"
-  #           echo "a valid benchmark ID: $SOME_BENCHMARK_ID"
-  #           cd ci
-  #           docker build . -t conbench-screenshot -f screenshot.Dockerfile
-  #           mkdir ci-artifacts
-  #           docker run --net=host -v $(pwd)/ci-artifacts:/artifacts conbench-screenshot \
-  #               python screenshot.py ${CONBENCH_BASE_URL} /artifacts frontpage
-  #           docker run --net=host -v $(pwd)/ci-artifacts:/artifacts conbench-screenshot \
-  #               python screenshot.py "${CONBENCH_BASE_URL}/benchmarks/${SOME_BENCHMARK_ID}/" \
-  #                 /artifacts benchmark-result-view --wait-for-canvas
-  #           /bin/ls -ahltr ci-artifacts/
-  #     - name: upload-artifacts
-  #       uses: actions/upload-artifact@v3
-  #       # Upload screenshots _especially_ when result was unexpected.
-  #       if: always()
-  #       with:
-  #         name: screenshots
-  #         path: ci/ci-artifacts/
-  #     - name: get container logs
-  #       if: always()
-  #       # If the browser-initiated GET requests led to e.g an Internal Server Error
-  #       # then we see that in the screenshot(s). For debugging that, however,
-  #       # it's crucial to get web application logs. Note that this shows
-  #       # container logs interleaved, but prefixed so that it's after all
-  #       # unambiguous which line came from which container.
-  #       run: docker compose logs --since 30m
-  #     - name: test `make teardown-app`
-  #       # Run teardown especially when previous step(s) failed, because here
-  #       # we get some good log output for debuggability.
-  #       if: always()
-  #       run: make teardown-app
+  ui-screenshots:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: run-app-bg
+        run: make run-app-bg
+      - name: populate DB & take screenshots
+        run: |
+            pip install requests # the nonly non-stdlib dependency as of now
+            export CONBENCH_BASE_URL=http://$(docker compose port app 5000)
+            # Get first line of stdout, interpret as benchmark ID
+            export SOME_BENCHMARK_ID="$(make -s db-populate | head -1)"
+            echo "conbench base URL: $CONBENCH_BASE_URL"
+            echo "a valid benchmark ID: $SOME_BENCHMARK_ID"
+            cd ci
+            docker build . -t conbench-screenshot -f screenshot.Dockerfile
+            mkdir ci-artifacts
+            docker run --net=host -v $(pwd)/ci-artifacts:/artifacts conbench-screenshot \
+                python screenshot.py ${CONBENCH_BASE_URL} /artifacts frontpage
+            docker run --net=host -v $(pwd)/ci-artifacts:/artifacts conbench-screenshot \
+                python screenshot.py "${CONBENCH_BASE_URL}/benchmarks/${SOME_BENCHMARK_ID}/" \
+                  /artifacts benchmark-result-view --wait-for-canvas
+            /bin/ls -ahltr ci-artifacts/
+      - name: upload-artifacts
+        uses: actions/upload-artifact@v3
+        # Upload screenshots _especially_ when result was unexpected.
+        if: always()
+        with:
+          name: screenshots
+          path: ci/ci-artifacts/
+      - name: get container logs
+        if: always()
+        # If the browser-initiated GET requests led to e.g an Internal Server Error
+        # then we see that in the screenshot(s). For debugging that, however,
+        # it's crucial to get web application logs. Note that this shows
+        # container logs interleaved, but prefixed so that it's after all
+        # unambiguous which line came from which container.
+        run: docker compose logs --since 30m
+      - name: test `make teardown-app`
+        # Run teardown especially when previous step(s) failed, because here
+        # we get some good log output for debuggability.
+        if: always()
+        run: make teardown-app
 
-  # db-migrations:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: checkout
-  #       uses: actions/checkout@v3
-  #     - name: Start PostgreSQL DB
-  #       run: docker compose run --detach db
-  #     # Run `alembic upgrade head` via docker compose. This runs in the web
-  #     # application container image. Running this via docker compose makes it
-  #     # so that it is within the virtual network that the DB is also in,
-  #     # reachable via DNS name `db`. Set CREATE_ALL_TABLES=false to defuse some
-  #     # webapp bootstrap code (not needed here, because these Python modules
-  #     # run in the context of alembic, not in the context of the actual web
-  #     # application bootstrapping itself).
-  #     - name: Test database migrations
-  #       run: make set-build-info && docker compose run -e CREATE_ALL_TABLES app alembic upgrade head
-  #       env:
-  #         CREATE_ALL_TABLES: false
-  #     # a better way to test this would be to change source code to
-  #     # generate a non-noop migration.
-  #     - name: Test make alembic-new-migration
-  #       run: |
-  #         make alembic-new-migration
-  #         cat migrations/versions/*dummy_migr_name*
-  #       env:
-  #          ALEMBIC_MIGRATION_NAME: dummy_migr_name
+  db-migrations:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: Start PostgreSQL DB
+        run: docker compose run --detach db
+      # Run `alembic upgrade head` via docker compose. This runs in the web
+      # application container image. Running this via docker compose makes it
+      # so that it is within the virtual network that the DB is also in,
+      # reachable via DNS name `db`. Set CREATE_ALL_TABLES=false to defuse some
+      # webapp bootstrap code (not needed here, because these Python modules
+      # run in the context of alembic, not in the context of the actual web
+      # application bootstrapping itself).
+      - name: Test database migrations
+        run: make set-build-info && docker compose run -e CREATE_ALL_TABLES app alembic upgrade head
+        env:
+          CREATE_ALL_TABLES: false
+      # a better way to test this would be to change source code to
+      # generate a non-noop migration.
+      - name: Test make alembic-new-migration
+        run: |
+          make alembic-new-migration
+          cat migrations/versions/*dummy_migr_name*
+        env:
+           ALEMBIC_MIGRATION_NAME: dummy_migr_name
 
   libraries:
     runs-on: ubuntu-latest
@@ -198,19 +198,19 @@ jobs:
         run: |
           pytest -vv benchconnect
 
-  # cb-on-minikube:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: checkout
-  #       uses: actions/checkout@v3
-  #     - name: start minikube
-  #       id: minikube
-  #       uses: medyagh/setup-minikube@e1ee887a96c50e34066a4bf9f172eb94ae69d454
-  #       with:
-  #         kubernetes-version: v1.23.16
-  #         # By convention, both locally and in CI we call this mk-conbench.
-  #         start-args: '--profile mk-conbench --extra-config=kubelet.cgroup-driver=systemd'
-  #         cpus: max
-  #         memory: max
-  #     - name: ci/minikube/test-conbench-on-mk.sh
-  #       run: export CONBENCH_REPO_ROOT_DIR=$(pwd) && bash ci/minikube/test-conbench-on-mk.sh
+  cb-on-minikube:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: start minikube
+        id: minikube
+        uses: medyagh/setup-minikube@e1ee887a96c50e34066a4bf9f172eb94ae69d454
+        with:
+          kubernetes-version: v1.23.16
+          # By convention, both locally and in CI we call this mk-conbench.
+          start-args: '--profile mk-conbench --extra-config=kubelet.cgroup-driver=systemd'
+          cpus: max
+          memory: max
+      - name: ci/minikube/test-conbench-on-mk.sh
+        run: export CONBENCH_REPO_ROOT_DIR=$(pwd) && bash ci/minikube/test-conbench-on-mk.sh

--- a/benchadapt/python/benchadapt/_machine_info.py
+++ b/benchadapt/python/benchadapt/_machine_info.py
@@ -97,7 +97,7 @@ def github_info():
     return gh_info
 
 
-def detect_github_info():
+def detect_commit_info_from_local_git():
     """Attempts to inspect a locally cloned repository for git information that can be
     posted to the "github" key when creating a run.
 
@@ -109,7 +109,7 @@ def detect_github_info():
     commit = _exec_command(["git", "rev-parse", "HEAD"])
     if not commit:
         warnings.warn(
-            "error in github_info(): probably not in a git repo; returning {}",
+            "error in detect_commit_info_from_local_git(): probably not in a git repo; returning {}",
             GitParseWarning,
         )
         return {}
@@ -119,7 +119,7 @@ def detect_github_info():
         remote = "origin"
         branch = "<DETATCHED BRANCH>"
         warnings.warn(
-            f"error in github_info(): detached HEAD; returning {branch=}",
+            f"error in detect_commit_info_from_local_git(): detached HEAD; returning {branch=}",
             GitParseWarning,
         )
 
@@ -130,7 +130,7 @@ def detect_github_info():
             remote = "origin"
             branch = _exec_command(["git", "branch", "--show-current"])
             warnings.warn(
-                f"error in github_info(): untracked branch; returning {branch=}",
+                f"error in detect_commit_info_from_local_git(): untracked branch; returning {branch=}",
                 GitParseWarning,
             )
         else:

--- a/benchadapt/python/benchadapt/_machine_info.py
+++ b/benchadapt/python/benchadapt/_machine_info.py
@@ -1,9 +1,7 @@
 import logging
 import os
 import platform
-import re
 import subprocess
-import warnings
 from typing import Dict, Optional
 
 

--- a/benchadapt/python/benchadapt/_machine_info.py
+++ b/benchadapt/python/benchadapt/_machine_info.py
@@ -118,7 +118,7 @@ def gh_commit_info_from_env() -> Dict[str, str]:
     return result
 
 
-def detect_commit_info_from_local_git():
+def detect_commit_info_from_local_git_or_raise():
     """Attempts to inspect a locally cloned repository for git information that can be
     posted to the "github" key when creating a run.
 

--- a/benchadapt/python/benchadapt/_machine_info.py
+++ b/benchadapt/python/benchadapt/_machine_info.py
@@ -161,11 +161,11 @@ def detect_commit_info_from_local_git():
     remote_url = _exec_command(["git", "remote", "get-url", remote])
     fork = re.search("(?<=.com[/:])([^/]*?)(?=/)", remote_url).group(0)
 
+    # Assumed to be all str values of non-zero length.
     return {
         "commit": commit,
         "repository": remote_url.rsplit(".git")[0],
         "branch": f"{fork}:{branch}",
-        "pr_number": None,
     }
 
 

--- a/benchadapt/python/benchadapt/_machine_info.py
+++ b/benchadapt/python/benchadapt/_machine_info.py
@@ -79,7 +79,7 @@ class GitParseWarning(RuntimeWarning):
     pass
 
 
-def github_info():
+def gh_commit_info_from_env() -> Dict[str, str]:
     """Get github metadata from environment variables"""
     repo = os.environ.get("CONBENCH_PROJECT_REPOSITORY")
     pr_number = os.environ.get("CONBENCH_PROJECT_PR_NUMBER") or os.environ.get(

--- a/benchadapt/python/benchadapt/_machine_info.py
+++ b/benchadapt/python/benchadapt/_machine_info.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import platform
 import re
@@ -9,6 +10,8 @@ from typing import Optional
 def _sysctl(stat):
     return ["sysctl", "-n", stat]
 
+
+log = logging.getLogger(__name__)
 
 MUST_BE_INTS = [
     "cpu_core_count",
@@ -364,4 +367,15 @@ def _has_missing(info, mapping):
 
 def _exec_command(command):
     result = subprocess.run(command, capture_output=True)
+
+    # Some of these failures are expected, i.e. the command not executing isn't
+    # supposed to be fatal to this program here. However, it makes sense to log
+    # information about how exactly the child process invocation failed.
+    if result.returncode != 0:
+        log.info(
+            "child process returned with code %s, stderr prefix:\n %s",
+            result.returncode,
+            result.stderr.decode("utf-8").strip()[:500],
+        )
+
     return result.stdout.decode("utf-8").strip()

--- a/benchadapt/python/benchadapt/_machine_info.py
+++ b/benchadapt/python/benchadapt/_machine_info.py
@@ -92,7 +92,7 @@ def gh_commit_info_from_env() -> Dict[str, str]:
     """
 
     varmap = {
-        "CONBENCH_PROJECT_REPOSITORY": "repo",
+        "CONBENCH_PROJECT_REPOSITORY": "repository",
         "CONBENCH_PROJECT_COMMIT": "commit",
         "BENCHMARKABLE_PR_NUMBER": "pr_number",
         "CONBENCH_PROJECT_PR_NUMBER": "pr_number",  # later entry takes precedence

--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -288,6 +288,11 @@ def validate_or_remove_github_commit_key(res_dict: Dict, strict=False):
         del res_dict["github"]
         return
 
+    # Note(JP): this is basically non-strict schema validation with the
+    # following behavior: "ok, it looks like you wanted to send commit
+    # information, but you didn't do it properly, and now I pretend as if
+    # you really didn't want to do that, but I emit a bit of a warning".
+    # We should make this stricter in the future.
     for checkkey in ("repository", "commit"):
         if checkkey not in res_dict["github"]:
             _warn_or_raise()

--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -67,7 +67,7 @@ class BenchmarkResult:
 
         A dictionary containing GitHub-flavored commit information.
 
-        Allowed values: `None`, no value, a dictionary.
+        Allowed values: `None`, no value, a special dictionary.
 
         Not passing an argument upon dataclass construction results in inspection
         of the environment variables ``CONBENCH_PROJECT_REPOSITORY``,
@@ -82,20 +82,21 @@ class BenchmarkResult:
         that this benchmark result will not be considered for time series
         analysis along a commit tree.
 
-        If passed a dictionary, it should have the following keys:
-        - required: ``repository`` (string, in the format ``https://github.com/<org>/<repo>``)
-        - required: ``commit`` (string, the full commit hash)
-        - recommended: ``pr_number`` (stringified integer) or ``branch`` (string)
+        If passed a dictionary, it must have at least the following two keys:
+        - ``repository`` (string, in the format ``https://github.com/<org>/<repo>``)
+        - ``commit`` (string, the full commit hash)
 
-        If the benchmark was run gainst the default branch, you may leave
-        out ``pr_number`` and ``branch``.
+        If the benchmark was run against the default branch, do not specify
+        additional keys.
 
-        If it was run on a GitHub pull request branch, you should provide the
+        If it was run on a GitHub pull request branch, you should provide
         ``pr_number``.
 
         If it was run on a non-default branch and a non-PR commit, you may
         supply the branch name via the ``branch`` set to a value of the format
         ``org:branch``.
+
+        For more details, consult the Conbench HTTP API specification.
 
     Notes
     -----

--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -135,7 +135,9 @@ class BenchmarkResult:
     machine_info: Dict[str, Any] = field(default_factory=_machine_info.machine_info)
     cluster_info: Dict[str, Any] = None
     context: Dict[str, Any] = field(default_factory=dict)
-    github: Dict[str, Any] = field(default_factory=_machine_info.github_info)
+    github: Dict[str, Any] = field(
+        default_factory=_machine_info.gh_commit_info_from_env
+    )
 
     def __post_init__(self) -> None:
         self._maybe_set_run_name()

--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -227,7 +227,7 @@ def validate_or_remove_github_commit_key(res_dict: Dict, strict=False):
 
     def _warn_or_raise():
         msg = (
-            "Result not publishable! `github.repository` and `github.commit` "
+            "Entity not publishable! `github.repository` and `github.commit` "
             "must be populated. You may pass github metadata via "
             "CONBENCH_PROJECT_REPOSITORY, CONBENCH_PROJECT_COMMIT, "
             "and CONBENCH_PR_NUMBER environment variables. "

--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -135,7 +135,7 @@ class BenchmarkResult:
     machine_info: Dict[str, Any] = field(default_factory=_machine_info.machine_info)
     cluster_info: Dict[str, Any] = None
     context: Dict[str, Any] = field(default_factory=dict)
-    github: Dict[str, Any] = field(
+    github: Dict[str, str] = field(
         default_factory=_machine_info.gh_commit_info_from_env
     )
 

--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -263,11 +263,14 @@ def validate_or_remove_github_commit_key(res_dict: Dict, strict=False):
 
     def _warn_or_raise():
         msg = (
-            "Entity not publishable! `github.repository` and `github.commit` "
-            "must be populated. You may pass github metadata via "
-            "CONBENCH_PROJECT_REPOSITORY, CONBENCH_PROJECT_COMMIT, "
-            "and CONBENCH_PR_NUMBER environment variables. "
-            f"\ngithub: {res_dict['github']}"
+            "This dictionary does not contain commit information. "
+            "This might be intended (for a so-called pre-merge benchmark "
+            "result). If it is not intended then you might be accidentally "
+            "missing out on those Conbench capabilities that associate "
+            "benchmark results with code changes. For automatically "
+            "adding commit information, set the CONBENCH_PROJECT_* family "
+            "of environment variables before dataclass instantiation (see API "
+            "docs for details)."
         )
         if strict:
             raise ValueError(msg)

--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -220,7 +220,7 @@ def validate_or_remove_github_commit_key(res_dict: Dict, strict=False):
     property be compliant with the Conbench HTTP API.
 
     Not providing the `github` key in result dictionary tells Conbench that
-    this result is commit context-less (recording it in Conbench might be
+    this result is commit-context-less (recording it in Conbench might be
     useful for debugging and testing purposes, but generally we should make
     clear that this implies missing out on critical features/purpose).
     """

--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -176,8 +176,10 @@ class BenchmarkResult:
         `None: <commit hash>`. Since `run_reason` and commit are required by the API,
         this should in most situations produce a reasonably useful `run_name`.
         """
-        if not self.run_name and self.github.get("commit"):
-            self.run_name = f"{self.run_reason}: {self.github['commit']}"
+        if not self.run_name:
+            if isinstance(self.github, dict):
+                if self.github.get("commit"):
+                    self.run_name = f"{self.run_reason}: {self.github['commit']}"
 
     @property
     def _github_property(self):

--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -173,10 +173,20 @@ class BenchmarkResult:
             self.machine_info = None
         self._cluster_info_cache = value
 
-    def to_publishable_dict(self):
-        """Returns a dict suitable for sending to conbench"""
+    def to_publishable_dict(self) -> Dict:
+        """
+        Return a dictionary representing the benchmark result.
+
+        After JSON-serialization, that dictionary is expected to validate
+        against the JSON schema that the Conbench API expects on the endpoint
+        for benchmark result submission.
+        """
+
         res_dict = asdict(self)
 
+        # We should discuss why we don't exit with an error here (publish this
+        # although it's not publishable? who consumes the warning? should the
+        # warning be re-worded to be more user-friendly?)
         if bool(res_dict.get("machine_info")) != bool(not res_dict["cluster_info"]):
             warnings.warn(
                 "Result not publishable! `machine_info` xor `cluster_info` must be specified"

--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -2,7 +2,7 @@ import datetime
 import uuid
 import warnings
 from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, Optional, Union, Literal
+from typing import Any, Dict, Literal, Optional, Union
 
 from . import _machine_info
 

--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -193,7 +193,7 @@ class BenchmarkResult:
             value = _machine_info.detect_commit_info_from_local_git_or_raise()
         else:
             # Better: schema validation
-            if not value is None and not isinstance(value, dict):
+            if value is not None and not isinstance(value, dict):
                 raise Exception(f"unexpected value for `github` property: {value}")
 
         self._github_cache = value

--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -186,9 +186,16 @@ class BenchmarkResult:
         return self._github_cache
 
     @_github_property.setter
-    def _github_property(self, value: Optional[dict]):
-        if value is None:
-            value = _machine_info.detect_commit_info_from_local_git()
+    def _github_property(
+        self, value: Union[Optional[Dict[str, str]], Literal["inspect_git_in_cwd"]]
+    ):
+        if value == "inspect_git_in_cwd":
+            value = _machine_info.detect_commit_info_from_local_git_or_raise()
+        else:
+            # Better: schema validation
+            if not value is None and not isinstance(value, dict):
+                raise Exception(f"unexpected value for `github` property: {value}")
+
         self._github_cache = value
         self._maybe_set_run_name()
 

--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -252,13 +252,16 @@ class BenchmarkResult:
 
 def validate_or_remove_github_commit_key(res_dict: Dict, strict=False):
     """
-    Mutate BenchmarkResult dictionary in-place to make its `github` key
-    property be compliant with the Conbench HTTP API.
+    Mutate BenchmarkResult dictionary (result of asdict(self)) in-place to make
+    its `github` key property be compliant with the Conbench HTTP API:
+    - Remove it when it's set to `None` (silently)
+    - Remove it when it doesn't look good (but also emit a warning)
 
-    Not providing the `github` key in result dictionary tells Conbench that
+    Not providing the `github` key in the result dictionary tells Conbench that
     this result is commit-context-less (recording it in Conbench might be
-    useful for debugging and testing purposes, but generally we should make
-    clear that this implies missing out on critical features/purpose).
+    useful for e.g. the special pre-merge capability, as well as for debugging
+    and testing purposes, but generally we should make clear that this might
+    imply to accidentally miss out on features/value).
     """
 
     def _warn_or_raise():

--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -157,7 +157,7 @@ class BenchmarkResult:
     @_github_property.setter
     def _github_property(self, value: Optional[dict]):
         if value is None:
-            value = _machine_info.detect_github_info()
+            value = _machine_info.detect_commit_info_from_local_git()
         self._github_cache = value
         self._maybe_set_run_name()
 

--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -258,21 +258,15 @@ def validate_or_remove_github_commit_key(res_dict: Dict, strict=False):
     imply to accidentally miss out on features/value).
     """
 
-    def _warn_or_raise():
-        msg = (
-            "This dictionary does not contain commit information. "
-            "This might be intended (for a so-called pre-merge benchmark "
-            "result). If it is not intended then you might be accidentally "
-            "missing out on those Conbench capabilities that associate "
-            "benchmark results with code changes. For automatically "
-            "adding commit information, set the CONBENCH_PROJECT_* family "
-            "of environment variables before dataclass instantiation (see API "
-            "docs for details)."
-        )
-        if strict:
-            raise ValueError(msg)
-
-        warnings.warn(msg)
+    errmsg = (
+        "This dictionary does not contain commit hash / repository information. "
+        "If that is intended (for a so-called pre-merge benchmark "
+        "result), explicitly set `github=None` upon data class "
+        "instantiation. For automatically "
+        "adding commit information, set the CONBENCH_PROJECT_* family "
+        "of environment variables before dataclass instantiation (see API "
+        "docs for details)."
+    )
 
     if res_dict["github"] is None:
         # Tis means: "no commit information present", and this was desired by
@@ -282,18 +276,9 @@ def validate_or_remove_github_commit_key(res_dict: Dict, strict=False):
         del res_dict["github"]
         return
 
-    # Note(JP): this is basically non-strict schema validation with the
-    # following behavior: "ok, it looks like you wanted to send commit
-    # information, but you didn't do it properly, and now I pretend as if
-    # you really didn't want to do that, but I emit a bit of a warning".
-    # We should make this stricter in the future.
     for checkkey in ("repository", "commit"):
         if checkkey not in res_dict["github"]:
-            _warn_or_raise()
-            # Normalize this state into the recommended, single way to say "no
-            # commit info": remove the key from the BenchmarkResult dict..
-            del res_dict["github"]
-            break
+            raise ValueError(errmsg)
 
 
 # Ugly, but per https://stackoverflow.com/a/61480946 lets us keep defaults and order

--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -274,13 +274,12 @@ def validate_or_remove_github_commit_key(res_dict: Dict, strict=False):
 
         warnings.warn(msg)
 
-    # For now, the decision is to send the result out, signaling to the
-    # Conbench API that this result has no repo/commit context. Maybe we should
-    # have the client tooling error out instead?
-    if "github" not in res_dict:
-        # API-wise, that's a valid state, signaling "no commit information
-        # present"
-        _warn_or_raise()
+    if res_dict["github"] is None:
+        # Tis means: "no commit information present", and this was desired by
+        # the user (i.e., be quiet and do as demanded by user). Normalize this
+        # state into the the one way to tell the Conbench HTTP API "no commit
+        # info": remove the key from the BenchmarkResult dict.
+        del res_dict["github"]
         return
 
     for checkkey in ("repository", "commit"):

--- a/benchadapt/python/benchadapt/run.py
+++ b/benchadapt/python/benchadapt/run.py
@@ -136,7 +136,7 @@ class BenchmarkRun:
                 "Run not publishable! `machine_info` xor `cluster_info` must be specified"
             )
 
-        validate_or_remove_github_commit_key(res_dict)
+        validate_or_remove_github_commit_key(res_dict, strict=True)
 
         for attr in [
             "name",

--- a/benchadapt/python/benchadapt/run.py
+++ b/benchadapt/python/benchadapt/run.py
@@ -103,9 +103,7 @@ class BenchmarkRun:
         return self._github_cache
 
     @_github_property.setter
-    def _github_property(
-        self, value: Union[Optional[Dict[str, str]], Literal["inspect_git_in_cwd"]]
-    ):
+    def _github_property(self, value: Optional[Dict[str, str]]):
         # Better: schema validation
         if value is not None and not isinstance(value, dict):
             raise Exception(f"unexpected value for `github` property: {value}")

--- a/benchadapt/python/benchadapt/run.py
+++ b/benchadapt/python/benchadapt/run.py
@@ -1,7 +1,7 @@
 import uuid
 import warnings
 from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, Literal, Optional, Union
+from typing import Any, Dict, Optional
 
 from . import _machine_info
 from .result import validate_or_remove_github_commit_key

--- a/benchadapt/python/benchadapt/run.py
+++ b/benchadapt/python/benchadapt/run.py
@@ -110,7 +110,7 @@ class BenchmarkRun:
     @_github_property.setter
     def _github_property(self, value: Optional[dict]):
         if value is None:
-            value = _machine_info.detect_github_info()
+            value = _machine_info.detect_commit_info_from_local_git()
         self._github_cache = value
         self._maybe_set_name()
 

--- a/benchadapt/python/benchadapt/run.py
+++ b/benchadapt/python/benchadapt/run.py
@@ -85,7 +85,9 @@ class BenchmarkRun:
     info: Dict[str, Any] = field(default_factory=dict)
     machine_info: Dict[str, Any] = field(default_factory=_machine_info.machine_info)
     cluster_info: Dict[str, Any] = None
-    github: Dict[str, Any] = field(default_factory=_machine_info.github_info)
+    github: Dict[str, Any] = field(
+        default_factory=_machine_info.gh_commit_info_from_env
+    )
     finished_timestamp: str = None
     error_type: str = None
     error_info: Dict[str, Any] = None

--- a/benchadapt/python/benchadapt/run.py
+++ b/benchadapt/python/benchadapt/run.py
@@ -1,7 +1,7 @@
 import uuid
 import warnings
 from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, Optional, Union, Literal
+from typing import Any, Dict, Literal, Optional, Union
 
 from . import _machine_info
 from .result import validate_or_remove_github_commit_key

--- a/benchadapt/python/benchadapt/run.py
+++ b/benchadapt/python/benchadapt/run.py
@@ -110,7 +110,7 @@ class BenchmarkRun:
             value = _machine_info.detect_commit_info_from_local_git_or_raise()
         else:
             # Better: schema validation
-            if not value is None and not isinstance(value, dict):
+            if value is not None and not isinstance(value, dict):
                 raise Exception(f"unexpected value for `github` property: {value}")
 
         self._github_cache = value

--- a/benchadapt/python/benchadapt/run.py
+++ b/benchadapt/python/benchadapt/run.py
@@ -76,7 +76,7 @@ class BenchmarkRun:
     info: Dict[str, Any] = field(default_factory=dict)
     machine_info: Dict[str, Any] = field(default_factory=_machine_info.machine_info)
     cluster_info: Dict[str, Any] = None
-    github: Union[Optional[Dict[str, str]], Literal["inspect_git_in_cwd"]] = field(
+    github: Optional[Dict[str, str]] = field(
         default_factory=_machine_info.gh_commit_info_from_env
     )
     finished_timestamp: str = None
@@ -106,12 +106,9 @@ class BenchmarkRun:
     def _github_property(
         self, value: Union[Optional[Dict[str, str]], Literal["inspect_git_in_cwd"]]
     ):
-        if value == "inspect_git_in_cwd":
-            value = _machine_info.detect_commit_info_from_local_git_or_raise()
-        else:
-            # Better: schema validation
-            if value is not None and not isinstance(value, dict):
-                raise Exception(f"unexpected value for `github` property: {value}")
+        # Better: schema validation
+        if value is not None and not isinstance(value, dict):
+            raise Exception(f"unexpected value for `github` property: {value}")
 
         self._github_cache = value
         self._maybe_set_name()

--- a/benchadapt/python/benchadapt/run.py
+++ b/benchadapt/python/benchadapt/run.py
@@ -4,6 +4,7 @@ from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, Optional
 
 from . import _machine_info
+from .result import validate_or_remove_github_commit_key
 
 
 @dataclass
@@ -135,15 +136,7 @@ class BenchmarkRun:
                 "Run not publishable! `machine_info` xor `cluster_info` must be specified"
             )
 
-        if not (
-            res_dict["github"].get("repository") and res_dict["github"].get("commit")
-        ):
-            raise ValueError(
-                "Run not publishable! `github.repository` and `github.commit` must be populated. "
-                "You may pass github metadata via CONBENCH_PROJECT_REPOSITORY, CONBENCH_PROJECT_COMMIT, "
-                "and CONBENCH_PR_NUMBER environment variables. "
-                f"\ngithub: {res_dict['github']}"
-            )
+        validate_or_remove_github_commit_key(res_dict)
 
         for attr in [
             "name",

--- a/benchadapt/python/tests/test_result.py
+++ b/benchadapt/python/tests/test_result.py
@@ -105,7 +105,11 @@ class TestBenchmarkResult:
 
         res = BenchmarkResult(run_reason=res_json["run_reason"])
 
-        assert res.github == {"commit": None, "repository": None, "pr_number": None}
+        # This indicates that "no commit/repo context is provided for this
+        # result". And we really need to work on re-naming this key towards
+        # "commit_info" or so.
+        assert "github" not in res
+
         assert res.run_name is None
         res.github = res_json["github"]
         assert (

--- a/benchadapt/python/tests/test_result.py
+++ b/benchadapt/python/tests/test_result.py
@@ -104,11 +104,7 @@ class TestBenchmarkResult:
         monkeypatch.delenv("CONBENCH_PROJECT_COMMIT", raising=False)
 
         res = BenchmarkResult(run_reason=res_json["run_reason"])
-
-        # This indicates that "no commit/repo context is provided for this
-        # result". And we really need to work on re-naming this key towards
-        # "commit_info" or so.
-        assert "github" not in res
+        assert res.github == {}
 
         assert res.run_name is None
         res.github = res_json["github"]

--- a/benchadapt/python/tests/test_result.py
+++ b/benchadapt/python/tests/test_result.py
@@ -94,7 +94,7 @@ class TestBenchmarkResult:
 
         with pytest.warns(
             UserWarning,
-            match="Result not publishable! `github.repository` and `github.commit` must be populated",
+            match="Entity not publishable! `github.repository` and `github.commit` must be populated",
         ):
             BenchmarkResult().to_publishable_dict()
 

--- a/benchadapt/python/tests/test_result.py
+++ b/benchadapt/python/tests/test_result.py
@@ -92,10 +92,9 @@ class TestBenchmarkResult:
         monkeypatch.delenv("CONBENCH_PROJECT_PR_NUMBER")
         monkeypatch.delenv("CONBENCH_PROJECT_COMMIT")
 
-        # Unintended, emit warning, but proceed.
-        with pytest.warns(
-            UserWarning,
-            match="dictionary does not contain commit information",
+        with pytest.raises(
+            ValueError,
+            match="dictionary does not contain commit hash / repository information",
         ):
             d = BenchmarkResult().to_publishable_dict()
             assert "github" not in d

--- a/benchadapt/python/tests/test_result.py
+++ b/benchadapt/python/tests/test_result.py
@@ -125,8 +125,3 @@ class TestBenchmarkResult:
         result = BenchmarkResult(github=res_json["github"])
         assert result.machine_info["name"] == machine_info_name
         assert result.machine_info["name"] != res_json["machine_info"]["name"]
-
-    def test_commit_info_from_local_git(self):
-        run = BenchmarkResult(github="inspect_git_in_cwd")
-        d = run.to_publishable_dict()
-        assert d["github"]["repository"] == "https://github.com/conbench/conbench"

--- a/benchadapt/python/tests/test_run.py
+++ b/benchadapt/python/tests/test_run.py
@@ -106,8 +106,3 @@ class TestBenchmarkRun:
         run = BenchmarkRun(github=None)
         d = run.to_publishable_dict()
         assert "github" not in d
-
-    def test_commit_info_from_local_git(self):
-        run = BenchmarkRun(github="inspect_git_in_cwd")
-        d = run.to_publishable_dict()
-        assert d["github"]["repository"] == "https://github.com/conbench/conbench"

--- a/benchadapt/python/tests/test_run.py
+++ b/benchadapt/python/tests/test_run.py
@@ -68,7 +68,7 @@ class TestBenchmarkRun:
 
         with pytest.raises(
             ValueError,
-            match="dictionary does not contain commit information",
+            match="dictionary does not contain commit hash / repository information",
         ):
             BenchmarkRun().to_publishable_dict()
 
@@ -98,7 +98,7 @@ class TestBenchmarkRun:
         run = BenchmarkRun()
         with pytest.raises(
             ValueError,
-            match="dictionary does not contain commit information",
+            match="dictionary does not contain commit hash / repository information",
         ):
             run.to_publishable_dict()
 

--- a/benchadapt/python/tests/test_run.py
+++ b/benchadapt/python/tests/test_run.py
@@ -87,11 +87,7 @@ class TestBenchmarkRun:
         monkeypatch.delenv("CONBENCH_PROJECT_COMMIT", raising=False)
 
         run = BenchmarkRun(reason=run_json["reason"])
-
-        # This indicates that "no commit/repo context is provided for this
-        # result". And we really need to work on re-naming this key towards
-        # "commit_info" or so.
-        assert "github" not in run
+        assert run.github == {}
 
         assert run.name is None
         run.github = run_json["github"]

--- a/benchadapt/python/tests/test_run.py
+++ b/benchadapt/python/tests/test_run.py
@@ -88,7 +88,11 @@ class TestBenchmarkRun:
 
         run = BenchmarkRun(reason=run_json["reason"])
 
-        assert run.github == {"commit": None, "repository": None, "pr_number": None}
+        # This indicates that "no commit/repo context is provided for this
+        # result". And we really need to work on re-naming this key towards
+        # "commit_info" or so.
+        assert "github" not in run
+
         assert run.name is None
         run.github = run_json["github"]
         assert run.name == f"{run_json['reason']}: {run_json['github']['commit']}"

--- a/benchadapt/python/tests/test_run.py
+++ b/benchadapt/python/tests/test_run.py
@@ -68,7 +68,7 @@ class TestBenchmarkRun:
 
         with pytest.raises(
             ValueError,
-            match="Run not publishable! `github.repository` and `github.commit` must be populated",
+            match="Entity not publishable! `github.repository` and `github.commit` must be populated",
         ):
             BenchmarkRun().to_publishable_dict()
 

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -564,19 +564,41 @@ class SchemaGitHubCreate(marshmallow.Schema):
         required=False,
         allow_none=True,
         metadata={
-            "description": "[recommended] The number of the GitHub pull request that "
-            "is running this benchmark, or `null` if it's a run on the default branch"
+            "description": conbench.util.dedent_rejoin(
+                """
+                If set, this needs to be an integer or a stringified integer.
+
+                This is the recommended way to indicate that this benchmark
+                result has been obtained for a specific pull request branch.
+                Conbench will use this pull request number to (try to) obtain
+                branch information via the GitHub HTTP API.
+
+                Set this to `null` or leave this out to indicate that this
+                benchmark result has been obtained for the default branch.
+                """
+            )
         },
     )
     branch = marshmallow.fields.String(
-        # I think this means that all of these pass validation:
-        # empty string, non-empty-string, null
+        # All of these pass schema validation: empty string, non-empty-string,
+        # null
         required=False,
         allow_none=True,
         metadata={
-            "description": "[not recommended] Instead of supplying `pr_number` you may "
-            "supply this, the branch name in the form `org:branch`. Only do so if you "
-            "know exactly what you're doing."
+            "description": conbench.util.dedent_rejoin(
+                """
+                This is an alternative way to indicate that this benchmark
+                result has been obtained for a commit that is not on the
+                default branch. Do not use this for GitHub pull requests (use
+                the `pr_number` argument for that, see above).
+
+                If set, this needs to be a string of the form `org:branch`.
+
+                Warning: currently, if `branch` and `pr_number` are both
+                provided, there is no error and `branch` takes precedence. Only
+                use this when you know what you are doing.
+                """
+            )
         },
     )
 

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -1423,7 +1423,7 @@
             "SchemaGitHubCreate": {
                 "properties": {
                     "branch": {
-                        "description": "[not recommended] Instead of supplying `pr_number` you may supply this, the branch name in the form `org:branch`. Only do so if you know exactly what you're doing.",
+                        "description": "This is an alternative way to indicate that this benchmark result has been obtained for a commit that is not on the default branch. Do not use this for GitHub pull requests (use the `pr_number` argument for that, see above).  If set, this needs to be a string of the form `org:branch`.  Warning: currently, if `branch` and `pr_number` are both provided, there is no error and `branch` takes precedence. Only use this when you know what you are doing.",
                         "nullable": True,
                         "type": "string",
                     },
@@ -1432,7 +1432,7 @@
                         "type": "string",
                     },
                     "pr_number": {
-                        "description": "[recommended] The number of the GitHub pull request that is running this benchmark, or `null` if it's a run on the default branch",
+                        "description": "If set, this needs to be an integer or a stringified integer.  This is the recommended way to indicate that this benchmark result has been obtained for a specific pull request branch. Conbench will use this pull request number to (try to) obtain branch information via the GitHub HTTP API.  Set this to `null` or leave this out to indicate that this benchmark result has been obtained for the default branch.",
                         "nullable": True,
                         "type": "integer",
                     },


### PR DESCRIPTION
Motivated by
https://github.com/conbench/conbench/pull/1134#discussion_r1171073366
https://github.com/conbench/conbench/pull/1134#pullrequestreview-1390569743

> how can that client library provide "no commit information" when posting a result or run? I'm going to need that functionality soon.

> OK, so there we need to hook in and use the 'new' way of communicating "not commit info". OK, I am on that.

Did a few more chores while being in this code base. Clearer types. Clearer naming. More debug info. See commit messages!

