### PR TITLE
api: query all results for multiple runs: add constraint for number of run IDs

### DIFF
--- a/conbench/api/results.py
+++ b/conbench/api/results.py
@@ -174,14 +174,12 @@ class BenchmarkListAPI(ApiEndpoint, BenchmarkValidationMixin):
             )
 
         elif run_id_arg := f.request.args.get("run_id"):
-            # Note(JP): https://github.com/conbench/conbench/issues/978 Given
-            # Conbench's data model we want to limit the number of run_ids that
-            # can be provided here. Maybe to 1, maybe to 5. Querying results
-            # for 100 runs (seen in practice) is for now difficult to support.
             run_ids = run_id_arg.split(",")
             if len(run_ids) > 5:
-                log.warning(
-                    "suspicious query /api/benchmarks for many run_ids -- see conbench/conbench/issues/978"
+                return resp400(
+                    "it is currently not allowed to set more than five "
+                    "run_id values; consider making separate requests (see "
+                    "issue 978)"
                 )
 
             benchmark_results = Session.scalars(

--- a/conbench/tests/api/test_results.py
+++ b/conbench/tests/api/test_results.py
@@ -1,4 +1,5 @@
 import copy
+from uuid import uuid4
 
 import pytest
 
@@ -352,6 +353,17 @@ class TestBenchmarkList(_asserts.ListEnforcer):
         response = client.get(f"/api/benchmarks/?run_id={run_id_1},{run_id_2}")
         self.assert_200_ok(response, contains=_expected_entity(benchmark_result_1))
         self.assert_200_ok(response, contains=_expected_entity(benchmark_result_2))
+
+    def test_benchmark_results_for_run_ids_too_many(self, client):
+        self.authenticate(client)
+        comma_separated_run_ids = ",".join(uuid4().hex[-5:] for _ in range(5))
+        resp = client.get(f"/api/benchmark-results/?run_id={comma_separated_run_ids}")
+        assert resp.status_code == 200, resp.text
+
+        comma_separated_run_ids = ",".join(uuid4().hex[-5:] for _ in range(6))
+        resp = client.get(f"/api/benchmark-results/?run_id={comma_separated_run_ids}")
+        assert resp.status_code == 400, resp.text
+        assert "currently not allowed to set more than five" in resp.text
 
 
 class TestBenchmarkResultPost(_asserts.PostEnforcer):


### PR DESCRIPTION
This patch is for addressing #975.

> Maybe a middle ground is to lock this in for now: emit a Bad Request response when this number is larger than five.

