### PR TITLE
db insert: use uuid7 primary key to track insert order

### DIFF
--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -25,7 +25,7 @@ from ..entities._entity import (
     EntitySerializer,
     NotNull,
     Nullable,
-    generate_uuid,
+    genprimkey,
     to_float,
 )
 from ..entities.case import Case, get_case_or_create
@@ -44,7 +44,7 @@ class BenchmarkResultValidationError(Exception):
 
 class BenchmarkResult(Base, EntityMixin):
     __tablename__ = "benchmark_result"
-    id: Mapped[str] = NotNull(s.String(50), primary_key=True, default=generate_uuid)
+    id: Mapped[str] = NotNull(s.String(50), primary_key=True, default=genprimkey)
     case_id: Mapped[str] = NotNull(s.String(50), s.ForeignKey("case.id"))
     info_id: Mapped[str] = NotNull(s.String(50), s.ForeignKey("info.id"))
     context_id: Mapped[str] = NotNull(s.String(50), s.ForeignKey("context.id"))

--- a/conbench/entities/case.py
+++ b/conbench/entities/case.py
@@ -4,12 +4,12 @@ from sqlalchemy.orm import Mapped
 
 from conbench.db import Session
 
-from ..entities._entity import Base, EntityMixin, NotNull, generate_uuid
+from ..entities._entity import Base, EntityMixin, NotNull, genprimkey
 
 
 class Case(Base, EntityMixin):
     __tablename__ = "case"
-    id: Mapped[str] = NotNull(s.String(50), primary_key=True, default=generate_uuid)
+    id: Mapped[str] = NotNull(s.String(50), primary_key=True, default=genprimkey)
     # The name of the conceptual benchmark (store on BenchmarkResult directly)?
     name: Mapped[str] = NotNull(s.Text)
     tags: Mapped[dict] = NotNull(postgresql.JSONB)

--- a/conbench/entities/commit.py
+++ b/conbench/entities/commit.py
@@ -22,7 +22,7 @@ from ..entities._entity import (
     EntitySerializer,
     NotNull,
     Nullable,
-    generate_uuid,
+    genprimkey,
 )
 
 log = logging.getLogger(__name__)
@@ -52,7 +52,7 @@ class TypeCommitInfoGitHub(TypedDict):
 
 class Commit(Base, EntityMixin):
     __tablename__ = "commit"
-    id: Mapped[str] = NotNull(s.String(50), primary_key=True, default=generate_uuid)
+    id: Mapped[str] = NotNull(s.String(50), primary_key=True, default=genprimkey)
     sha: Mapped[str] = NotNull(s.String(50))
     branch: Mapped[Optional[str]] = Nullable(s.String(510))
     fork_point_sha: Mapped[Optional[str]] = Nullable(s.String(50))

--- a/conbench/entities/context.py
+++ b/conbench/entities/context.py
@@ -5,20 +5,14 @@ from sqlalchemy.orm import Mapped
 
 from conbench.db import Session
 
-from ..entities._entity import (
-    Base,
-    EntityMixin,
-    EntitySerializer,
-    NotNull,
-    generate_uuid,
-)
+from ..entities._entity import Base, EntityMixin, EntitySerializer, NotNull, genprimkey
 
 
 # Maybe EntityMixin should be a generic class
 # https://mypy.readthedocs.io/en/latest/generics.html#defining-subclasses-of-generic-classes
 class Context(Base, EntityMixin):
     __tablename__ = "context"
-    id: Mapped[str] = NotNull(s.String(50), primary_key=True, default=generate_uuid)
+    id: Mapped[str] = NotNull(s.String(50), primary_key=True, default=genprimkey)
     tags: Mapped[dict] = NotNull(postgresql.JSONB)
 
 

--- a/conbench/entities/hardware.py
+++ b/conbench/entities/hardware.py
@@ -14,13 +14,13 @@ from ..entities._entity import (
     EntitySerializer,
     NotNull,
     Nullable,
-    generate_uuid,
+    genprimkey,
 )
 
 
 class Hardware(Base, EntityMixin):
     __tablename__ = "hardware"
-    id: Mapped[str] = NotNull(s.String(50), primary_key=True, default=generate_uuid)
+    id: Mapped[str] = NotNull(s.String(50), primary_key=True, default=genprimkey)
     name: Mapped[str] = NotNull(s.Text)
     type: Mapped[str] = NotNull(s.String(50))
     hash: Mapped[str] = NotNull(s.String(1000))

--- a/conbench/entities/info.py
+++ b/conbench/entities/info.py
@@ -5,18 +5,12 @@ from sqlalchemy.orm import Mapped
 
 from conbench.db import Session
 
-from ..entities._entity import (
-    Base,
-    EntityMixin,
-    EntitySerializer,
-    NotNull,
-    generate_uuid,
-)
+from ..entities._entity import Base, EntityMixin, EntitySerializer, NotNull, genprimkey
 
 
 class Info(Base, EntityMixin):
     __tablename__ = "info"
-    id: Mapped[str] = NotNull(s.String(50), primary_key=True, default=generate_uuid)
+    id: Mapped[str] = NotNull(s.String(50), primary_key=True, default=genprimkey)
     tags: Mapped[dict] = NotNull(postgresql.JSONB)
 
 

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -43,6 +43,7 @@ log = logging.getLogger(__name__)
 
 class Run(Base, EntityMixin):
     __tablename__ = "run"
+    # TODO: use default uuid7 primary key
     id: Mapped[str] = NotNull(s.String(50), primary_key=True)
     name: Mapped[Optional[str]] = Nullable(s.String(250))
     reason: Mapped[Optional[str]] = Nullable(s.String(250))

--- a/conbench/entities/user.py
+++ b/conbench/entities/user.py
@@ -5,13 +5,7 @@ import sqlalchemy as s
 import werkzeug.security
 from sqlalchemy.orm import Mapped
 
-from ..entities._entity import (
-    Base,
-    EntityMixin,
-    EntitySerializer,
-    NotNull,
-    generate_uuid,
-)
+from ..entities._entity import Base, EntityMixin, EntitySerializer, NotNull, genprimkey
 from ..extensions import login_manager
 
 
@@ -22,7 +16,7 @@ def load_user(user_id):
 
 class User(flask_login.UserMixin, Base, EntityMixin):
     __tablename__ = "user"
-    id: Mapped[str] = NotNull(s.String(50), primary_key=True, default=generate_uuid)
+    id: Mapped[str] = NotNull(s.String(50), primary_key=True, default=genprimkey)
     email: Mapped[str] = NotNull(s.String(120), index=True, unique=True)
     name: Mapped[str] = NotNull(s.String(120))
     password: Mapped[str] = NotNull(s.String(128))

--- a/requirements-webapp.txt
+++ b/requirements-webapp.txt
@@ -30,3 +30,4 @@ requests
 sigfig
 SQLAlchemy>=2
 tenacity
+uuid7


### PR DESCRIPTION
This is for issue #789, see discussion over there.

I noted:
- The `s.String(50)` does not match the idea that the prim key is known to be of length 32. Does that mismatch matter?
- For some entitiy (run, at least) we still allow the user to inject the primary key. That needs to change, tracking this here: https://github.com/conbench/conbench/issues/1139

