### PR TITLE
webapp: gzip-compress HTTP responses (issue #1140)

### DIFF
--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -19,6 +19,8 @@ import logging
 import os
 from typing import TYPE_CHECKING
 
+import flask_compress
+
 import conbench.logger
 
 try:
@@ -86,6 +88,13 @@ def create_application(config) -> "flask.Flask":
 
     # This mutates `app` in-place.
     conbench.metrics.decorate_flask_app_with_metrics(app)
+
+    # This also mutates the app in-place, sets up
+    # https://github.com/colour-science/flask-compress for deployments that do
+    # not run an HTTP reverse proxy with proper response compression in front
+    # of Conbench. Conbench amy emit large JSON and HTML responses, and simple
+    # gzip compression yields huge value.
+    flask_compress.Compress().init_app(app)
 
     return app
 

--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -19,8 +19,6 @@ import logging
 import os
 from typing import TYPE_CHECKING
 
-import flask_compress
-
 import conbench.logger
 
 try:
@@ -48,6 +46,7 @@ log = logging.getLogger(__name__)
 
 def create_application(config) -> "flask.Flask":
     import flask as f
+    import flask_compress
 
     import conbench.metrics
 

--- a/requirements-webapp.txt
+++ b/requirements-webapp.txt
@@ -7,6 +7,7 @@ dacite
 email-validator
 Flask
 Flask-Bootstrap
+Flask-Compress
 Flask-Login
 flask-swagger-ui
 Flask-WTF


### PR DESCRIPTION
This works:

```
$ curl -sH 'Accept-encoding: gzip' localhost:5000 | gunzip - | head -n3
<!DOCTYPE html>
  <html lang="en">
      <head>
```

```
 $ curl -sH 'Accept-encoding: gzip' localhost:5000/api/benchmarks/ | gunzip - | head -n3
[
  {
    "id": "0644107c9f5f79bf800082e0cb94fe12",
```

