### PR TITLE
metrics.py: fix: terminate the quota_remaining gauge init thread after first update was received

### DIFF
--- a/conbench/entities/commit.py
+++ b/conbench/entities/commit.py
@@ -895,8 +895,9 @@ class GitHubHTTPApiClient:
             # Expect the value to always be int-convertible.
             reqquota = int(resp.headers["x-ratelimit-remaining"])
             metrics.GAUGE_GITHUB_HTTP_API_QUOTA_REMAINING.set(reqquota)
-            # Temporary workaround, see metrics._periodically_set_q_rem()
-            metrics.gauge_gh_api_rem_set["set"] = False
+            # Setting this to `True` stops a thread from periodically setting
+            # this to -1, see metrics.periodically_set_q_rem()
+            metrics.gauge_gh_api_rem_set["first_value_seen"] = True
 
         # In the code block below `resp` reflects an actual HTTP response.
         if resp.status_code == 200:

--- a/conbench/metrics.py
+++ b/conbench/metrics.py
@@ -172,7 +172,7 @@ def http_handler_name(r: flask.Request) -> str:
 # This is a dictionary which can be mutated (from the outside, it's part of the
 # interface of this module) by other threads, to indicate when a meaningful
 # gauge value was set (see impl of _periodically_set_q_rem()).
-gauge_gh_api_rem_set = {"set": False}
+gauge_gh_api_rem_set = {"first_value_seen": False}
 
 
 def periodically_set_q_rem() -> None:
@@ -194,7 +194,7 @@ def periodically_set_q_rem() -> None:
         while True:
             time.sleep(1)
 
-            if gauge_gh_api_rem_set["set"]:
+            if gauge_gh_api_rem_set["first_value_seen"]:
                 # This process set an actual, meaningful value. Stop
                 # reinforcing the initial state.
                 log.info("periodically_set_q_rem(): terminate thread")

--- a/conbench/metrics.py
+++ b/conbench/metrics.py
@@ -190,13 +190,14 @@ def periodically_set_q_rem() -> None:
     """
 
     def func():
+        log.info("periodically_set_q_rem(): initiate")
         while True:
-            time.sleep(10)
+            time.sleep(1)
 
             if gauge_gh_api_rem_set["set"]:
                 # This process set an actual, meaningful value. Stop
                 # reinforcing the initial state.
-                log.info("_periodically_set_q_rem(): terminate thread")
+                log.info("periodically_set_q_rem(): terminate thread")
                 return
 
             GAUGE_GITHUB_HTTP_API_QUOTA_REMAINING.set(-1)


### PR DESCRIPTION
The thread terminator was never invoked because of a boolean booboo.
