### PR TITLE
ConbenchClient: login: add trailing slash

### DIFF
--- a/benchclients/python/benchclients/conbench.py
+++ b/benchclients/python/benchclients/conbench.py
@@ -154,7 +154,12 @@ class ConbenchClient(RetryingHTTPClient):
 
         login_result = self._make_request_retry_until_deadline(
             method="POST",
-            url=self._base_url + "/login",
+            # Trailing slash is important so that we do not get redirected.
+            # Some systems might redirect a POST to GET here.
+            # Interesting topic:
+            # https://github.com/galaxyproject/bioblend/pull/336
+            # https://github.com/aio-libs/aiohttp/issues/6764
+            url=self._base_url + "/login/",
             json=creds,
             expected_status_code=204,
             timeout=self.timeout_login_request,

--- a/benchclients/python/tests/test_conbench_client.py
+++ b/benchclients/python/tests/test_conbench_client.py
@@ -102,7 +102,7 @@ def test_cc_performs_login_when_env_is_set(
     }
 
     httpserver.expect_oneshot_request(
-        "/api/login", method="POST", json=creds
+        "/api/login/", method="POST", json=creds
     ).respond_with_data("", status=204)
 
     # This confirms that the initialization of this object performs an HTTP


### PR DESCRIPTION
Unclear why there's a difference between 
```
>>> requests.post("https://cb-staging/api/login", json={'lol':'rofl'})
<Response [405]>
```

curl:
```
$ curl -L --header "Content-Type: application/json"  -v --request POST  --data '{"username":"xyz","password":"xyz"}'  "https://cb-staging/api/login"
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 3.139.229.187:443...

> POST /api/login HTTP/2

* Mark bundle as not supporting multiuse
< HTTP/1.1 301 Moved Permanently
< Server: awselb/2.0

* h2h3 [:method: POST]

{"code": 400, "name": "Bad Request"}[jp:~]
```

The 301 allows for / demands for changing the request method from POST to GET, and maybe curl violates the rule here? (on purpose?)

Status code(s) to perform a permanent redirect without changing POST to GET are 307 and 308.

https://github.com/psf/requests/issues/5284
