### PR TITLE
gunicorn-conf: adjust keepalive, threads, and worker_connections

### DIFF
--- a/conbench/gunicorn-conf.py
+++ b/conbench/gunicorn-conf.py
@@ -34,7 +34,7 @@ backlog = 300
 # core is after all serving requests).
 # https://github.com/conbench/conbench/issues/1018
 workers = 1
-threads = 10
+threads = 15
 
 # This is the worker timeout; an observer process will terminate the observed
 # worker process if the observed process hasn't responded within that
@@ -48,6 +48,10 @@ timeout = 120
 # that's longer than 60 (some cloud load balancers default to this). but it's
 # shorter than nginx' default of 75 seconds.
 keepalive = 70
+
+# Reduce this from the default (1000), and have gunicorn reject further
+# TCP connections. This makes sense in terms of back-pressure.
+worker_connections = 400
 
 
 def post_worker_init(worker):


### PR DESCRIPTION
Goes hand-in-hand with https://github.com/conbench/conbench/commit/be766c9b95b36a41cfcface5193ec727cd042f7f.

This is for https://github.com/conbench/conbench/issues/1156. Pushed the `keepalive = 70` accidentally right before opening this PR [to `main`](https://github.com/conbench/conbench/commit/be766c9b95b36a41cfcface5193ec727cd042f7f) (branch protection didn't prevent this from happening, I fat-fingered this and did `git push` before `git checkout -b ...`, and was on `main` :shrug: ). Also making number of threads (max number of concurrently processed requests) a little higher, but maximum number of `accept()`able TCP connections a little lower.
