### PR TITLE
k8s: alb annotation: set idle_timeout to 50 s (reduce rate of load balancer 502 responses)

### DIFF
--- a/k8s/conbench-cloud-ingress.templ.yml
+++ b/k8s/conbench-cloud-ingress.templ.yml
@@ -32,6 +32,10 @@ metadata:
     # will be ignored." That is preclisely what we want, a no-brainer
     # configuration parameter that disallows serving traffic via non-TLS.
     alb.ingress.kubernetes.io/ssl-redirect: '443'
+    # This is here mainly to take active control. Must be shorter than the
+    # timeout constant of the other end, see
+    # https://github.com/conbench/conbench/issues/1156
+    alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=50
     alb.ingress.kubernetes.io/certificate-arn: <CERTIFICATE_ARN>
   labels:
     app: conbench-ingress


### PR DESCRIPTION
For issue #1156. Docs:
https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout



> We also recommend that you configure the idle timeout of your
> application to be larger than the idle timeout configured
> for the load balancer. Otherwise, if the application closes
> the TCP connection to the load balancer ungracefully, the
> load balancer might send a request to the application before
> it receives the packet indicating that the connection is
> closed. If this is the case, then the load balancer sends
> an HTTP 502 Bad Gateway error to the client.

> By default, Elastic Load Balancing sets the idle timeout
> value for your load balancer to 60 seconds.