### PR TITLE
history sample: add single_value_for_plot() method 

### DIFF
--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -185,6 +185,9 @@ def _should_format(floats: List[Optional[float]], unit):
             # I think in legacy code this would have simply blown up in a
             # `float(None)``
             continue
+
+        # Not yet understood. We got here for a non-float non-None value:
+        # https://github.com/conbench/conbench/issues/1155
         units_formatted.add(unit_fmt(f, unit).split(" ", 1)[1])
 
     unit_formatted = units_formatted.pop() if len(units_formatted) == 1 else None
@@ -473,7 +476,11 @@ def time_series_plot(
     with_dist = [s for s in samples if s.zscorestats.rolling_mean]
     inliers = [s for s in samples if not s.zscorestats.is_outlier]
     outliers = [s for s in samples if s.zscorestats.is_outlier]
-    formatted, axis_unit = _should_format([s.mean for s in samples], unit)
+
+    formatted, axis_unit = _should_format(
+        [s.single_value_for_plot for s in samples], unit
+    )
+
     dist_change_indexes = [
         ix
         for ix, sample in enumerate(samples)

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -138,10 +138,11 @@ class HistorySample:
     def single_value_for_plot(self) -> float:
         """
         Helper for plotting routines. This sample ended up in a collection that
-        wants to be plotted. For that, of course single value is needed,
-        defining the position on "y axis".
+        wants to be plotted. For that, a single value is needed defining the
+        position on "y axis".
 
-        Downstream code relies on a float(y) value to be returned.
+        Downstream code relies on a float(y) value to be returned, which
+        includes `math.nan`.
         """
         if self.mean is not None:
             # Want to be sure I understand what's happening. Context:

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -123,6 +123,9 @@ class HistorySample:
     run_name: str
     zscorestats: HistorySampleZscoreStats
 
+    # Note(JP):
+    # we should expose the unit of `data` in this structure, too.
+
     def _dict_for_api_json(self) -> dict:
         d = dataclasses.asdict(self)
         # if performance is a concern then https://pypi.org/project/orjson/
@@ -130,6 +133,32 @@ class HistorySample:
         # instances into JSON.
         d["commit_timestamp"] = self.commit_timestamp.isoformat()
         return d
+
+    @property
+    def single_value_for_plot(self) -> float:
+        """
+        Helper for plotting routines. This sample ended up in a collection that
+        wants to be plotted. For that, of course single value is needed,
+        defining the position on "y axis".
+
+        Downstream code relies on a float(y) value to be returned.
+        """
+        if self.mean is not None:
+            # Want to be sure I understand what's happening. Context:
+            # https://github.com/conbench/conbench/issues/1155
+            assert isinstance(self.mean, float)
+            return self.mean
+
+        if len(self.data) not in (1, 2):
+            log.warning("bad history sample: mean is none, data length unexpected")
+            return math.nan
+
+        # Assume there is at least one data point, at most two data points. See
+        # https://github.com/conbench/conbench/issues/1118 Lacking a better
+        # rationale, for now return one of both data points. If these are two
+        # values and they have vastly different values, then this is non-ideal
+        # situation anyway.
+        return self.data[1]
 
 
 def get_history_for_benchmark(benchmark_result_id: str):


### PR DESCRIPTION
This helps for debugging and conceptually addressing #1155.

This helps centralizing and documenting how to pick the main "y axis value" from a HistorySample (which is in general a multi-sample benchmark result with almost no guarantees, in particular in view of legacy database state).