### PR TITLE
units.py: do not call sigfig.round() with math.nan

### DIFF
--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -1,6 +1,7 @@
 import collections
 import copy
 import dataclasses
+import math
 import json
 import logging
 from typing import List, Optional, Tuple, no_type_check
@@ -183,11 +184,8 @@ def _should_format(floats: List[Optional[float]], unit):
     for f in floats:
         if f is None:
             # I think in legacy code this would have simply blown up in a
-            # `float(None)``
+            # `float(None)`
             continue
-
-        # Not yet understood. We got here for a non-float non-None value:
-        # https://github.com/conbench/conbench/issues/1155
         units_formatted.add(unit_fmt(f, unit).split(" ", 1)[1])
 
     unit_formatted = units_formatted.pop() if len(units_formatted) == 1 else None

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -1,7 +1,6 @@
 import collections
 import copy
 import dataclasses
-import math
 import json
 import logging
 from typing import List, Optional, Tuple, no_type_check

--- a/conbench/units.py
+++ b/conbench/units.py
@@ -1,3 +1,4 @@
+import math
 from typing import Optional
 
 import sigfig
@@ -39,6 +40,11 @@ def fmt_unit(value: Optional[float], unit) -> Optional[str]:
     # Maybe simplify function signature and never allow this to be called
     # with None.
     if value is None:
+        return None
+
+    if value == math.nan:
+        # Must not call sigfig.round() with math.nan, see
+        # https://github.com/conbench/conbench/issues/1155
         return None
 
     # These stringified values power a Bokeh plot. Ensure that the textual


### PR DESCRIPTION
Further follow-up from #1155, after reproducing the exception that we've seen thrown in the wild.