### PR TITLE
units.py and history.py: more safeguards in single_value_for_plot() and fmt_unit()

### DIFF
--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -145,7 +145,7 @@ class HistorySample:
         includes `math.nan`.
         """
         if isinstance(self.mean, float):
-            if not math.isnan(self.value):
+            if not math.isnan(self.mean):
                 # This is a numeric, floaty value (not `math.nan`).
                 return self.mean
 

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -144,14 +144,21 @@ class HistorySample:
         Downstream code relies on a float(y) value to be returned, which
         includes `math.nan`.
         """
-        if self.mean is not None:
+        if self.mean is not None and self.mean is not math.nan:
             # Want to be sure I understand what's happening. Context:
             # https://github.com/conbench/conbench/issues/1155
             assert isinstance(self.mean, float)
+            # This is a numeric, floaty value (not `math.nan`).
             return self.mean
 
+        # Mean value isn't set. That should imply that there are less than
+        # three data points. Do a sanity check.
         if len(self.data) not in (1, 2):
-            log.warning("bad history sample: mean is none, data length unexpected")
+            log.warning(
+                "bad history sample: mean is %s, data length is %s",
+                self.mean,
+                len(self.data),
+            )
             return math.nan
 
         # Assume there is at least one data point, at most two data points. See
@@ -159,7 +166,7 @@ class HistorySample:
         # rationale, for now return one of both data points. If these are two
         # values and they have vastly different values, then this is non-ideal
         # situation anyway.
-        return self.data[1]
+        return self.data[0]
 
 
 def get_history_for_benchmark(benchmark_result_id: str):

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -146,12 +146,15 @@ class HistorySample:
         """
         if isinstance(self.mean, float):
             if not math.isnan(self.mean):
-                # This is a numeric, floaty value (not `math.nan`).
                 return self.mean
 
         # Mean value isn't set. That should imply that there are less than
         # three data points. Do a sanity check.
         if len(self.data) not in (1, 2):
+            # That is / should be an invariant: if there are more than two
+            # values set, then this HistorySample is expected to have a mean
+            # value set (upon database insertion). If this isn't the case,
+            # leave a log message.
             log.warning(
                 "bad history sample: mean is %s, data length is %s",
                 self.mean,
@@ -159,11 +162,11 @@ class HistorySample:
             )
             return math.nan
 
-        # Assume there is at least one data point, at most two data points. See
-        # https://github.com/conbench/conbench/issues/1118 Lacking a better
+        # There is at least one data point, at most two data points. See
+        # https://github.com/conbench/conbench/issues/1118. Lacking a better
         # rationale, for now return one of both data points. If these are two
-        # values and they have vastly different values, then this is non-ideal
-        # situation anyway.
+        # values and they have vastly different values, then this is a
+        # non-ideal situation anyway.
         return self.data[0]
 
 

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -144,12 +144,10 @@ class HistorySample:
         Downstream code relies on a float(y) value to be returned, which
         includes `math.nan`.
         """
-        if self.mean is not None and self.mean is not math.nan:
-            # Want to be sure I understand what's happening. Context:
-            # https://github.com/conbench/conbench/issues/1155
-            assert isinstance(self.mean, float)
-            # This is a numeric, floaty value (not `math.nan`).
-            return self.mean
+        if isinstance(self.mean, float):
+            if not math.isnan(self.value):
+                # This is a numeric, floaty value (not `math.nan`).
+                return self.mean
 
         # Mean value isn't set. That should imply that there are less than
         # three data points. Do a sanity check.

--- a/conbench/units.py
+++ b/conbench/units.py
@@ -45,17 +45,6 @@ def fmt_unit(value: Optional[float], unit) -> Optional[str]:
     if value is None:
         return None
 
-    if value is math.nan:
-        # Must not call sigfig.round() with math.nan, see
-        # https://github.com/conbench/conbench/issues/1155
-        return None
-
-    if value == "null":
-        # sigfig.round("null", sigfigs=3) also results in the exception
-        # ValueError: invalid input Character "n" (position 1, state A)
-        log.warning('fmt_unit() was passed literal string "null"')
-        return None
-
     # These stringified values power a Bokeh plot. Ensure that the textual
     # representation of the numeric value encodes a desired minimum number of
     # significant digits, to allow for meaningful plotting resolution.
@@ -68,6 +57,7 @@ def fmt_unit(value: Optional[float], unit) -> Optional[str]:
     try:
         return f"{sigfig.round(value, sigfigs=4)} {unit}"
     except ValueError as exc:
+        # https://github.com/conbench/conbench/issues/1155
         log.warning("fmt_unit(): got unexpected value `%s`, exc: %s", repr(value), exc)
         return None
 

--- a/conbench/units.py
+++ b/conbench/units.py
@@ -1,5 +1,4 @@
 import logging
-import math
 from typing import Optional
 
 import sigfig

--- a/conbench/units.py
+++ b/conbench/units.py
@@ -65,7 +65,11 @@ def fmt_unit(value: Optional[float], unit) -> Optional[str]:
     # I have seen a KeyError being thrown which I could not reproduce anymore.
     # sigfig/sigfig.py line 551 does `del number.map[p]` and this resulted in
     # `KeyError: 0`. It was probably a programming mistake.
-    return f"{sigfig.round(value, sigfigs=4)} {unit}"
+    try:
+        return f"{sigfig.round(value, sigfigs=4)} {unit}"
+    except ValueError as exc:
+        log.warning("fmt_unit(): got unexpected value `%s`, exc: %s", repr(value), exc)
+        return None
 
 
 def formatter_for_unit(unit):


### PR DESCRIPTION
We still got this:
![image](https://user-images.githubusercontent.com/265630/234091292-2355265b-192b-4dfc-9e30-237d5a8bd92d.png)

Throwing more tools and a different approach at this challenge. Also, reading more docs.

https://docs.python.org/3/library/math.html#math.nan
https://docs.python.org/3/library/math.html#math.isnan