### PR TITLE
tests: add test for reproducing #1155

### DIFF
--- a/conbench/entities/commit.py
+++ b/conbench/entities/commit.py
@@ -740,8 +740,6 @@ class GitHubHTTPApiClient:
         return fork_point_sha
 
     def get_branch_from_pr_number(self, name: str, pr_number: int) -> Optional[str]:
-        log.info("type of pr_number: %s", type(pr_number))
-
         # Warning, here be dragons. For our test suite, do not hit the GitHub
         # HTTP API. Use a special PR number to trigger this magic. This was a
         # bit mean:

--- a/conbench/runner.py
+++ b/conbench/runner.py
@@ -418,7 +418,7 @@ class Conbench(Connection, MixinPython, MixinR):
         }
 
     @staticmethod
-    def _stats(data, unit, times, time_unit):
+    def _stats(data, unit, times, time_unit, one_sample_no_mean=False):
         fmt = "{:.6f}"
 
         def _format(f, data, min_length=0):
@@ -444,5 +444,16 @@ class Conbench(Connection, MixinPython, MixinR):
             "q3": fmt.format(q3),
             "iqr": fmt.format(q3 - q1),
         }
+
+        if one_sample_no_mean:
+            # Brutal way to create a BenchmarkResult in a history that
+            # has no aggregates, in particular no mean value.
+            agg_keys = ("q1", "q3", "mean", "median", "min", "max", "stdev", "iqr")
+
+            result["data"] = [result["data"][0]]
+            result["times"] = [result["times"][0]] if result["times"] else []
+            result["iterations"] = 1
+            for k in agg_keys:
+                del result[k]
 
         return result

--- a/conbench/tests/api/_fixtures.py
+++ b/conbench/tests/api/_fixtures.py
@@ -231,6 +231,7 @@ def benchmark_result(
     error=None,
     empty_results=False,
     reason=None,
+    one_sample_no_mean=False,
 ):
     """Create BenchmarkResult and directly write to database.
 
@@ -281,7 +282,7 @@ def benchmark_result(
 
     if results is not None:
         unit = unit if unit else "s"
-        data["stats"] = Conbench._stats(results, unit, [], "s")
+        data["stats"] = Conbench._stats(results, unit, [], "s", one_sample_no_mean)
 
     if empty_results:
         data.pop("stats", None)
@@ -292,11 +293,16 @@ def benchmark_result(
     return BenchmarkResult.create(data)
 
 
-def gen_fake_data() -> Tuple[Dict[str, Commit], List[BenchmarkResult]]:
+def gen_fake_data(
+    one_sample_no_mean=False,
+) -> Tuple[Dict[str, Commit], List[BenchmarkResult]]:
     """Populate the database with fake Commits and BenchmarkResults to use when testing
     most of the entities.
 
     Return a dict of commits (keyed by hash) and list of BenchmarkResults.
+
+    Note(JP): I believe the major point here really is to create a 'history of
+    benchmark results', related through commits.
     """
     # Manually post all the Commits to the database first, so that upon posting
     # BenchmarkResults, the server doesn't hit the GitHub API for more commit information.
@@ -412,6 +418,7 @@ def gen_fake_data() -> Tuple[Dict[str, Commit], List[BenchmarkResult]]:
                     commit=commit,
                     name=name,
                     pull_request=commit.branch == "branch" if commit else False,
+                    one_sample_no_mean=one_sample_no_mean,
                 )
             )
         else:
@@ -421,6 +428,7 @@ def gen_fake_data() -> Tuple[Dict[str, Commit], List[BenchmarkResult]]:
                     commit=commit,
                     name=name,
                     pull_request=commit.branch == "branch" if commit else False,
+                    one_sample_no_mean=one_sample_no_mean,
                 )
             )
 


### PR DESCRIPTION
A test that
- generates history relationship between benchmark results
- where benchmark results have no `mean` (and no other aggregates) set
- fetches the /benchmark-result/{id} UI view for one of the results