### PR TITLE
metrics.py: resolve circular import

### DIFF
--- a/conbench/metrics.py
+++ b/conbench/metrics.py
@@ -24,8 +24,6 @@ import flask
 import prometheus_client
 from prometheus_flask_exporter import NO_PREFIX, PrometheusMetrics
 
-from conbench import job
-
 log = logging.getLogger(__name__)
 
 
@@ -190,6 +188,9 @@ def periodically_set_q_rem() -> None:
     respect to their initialization state. For us, 0 is a special, allowed
     value and explicitly _not_ the initialization value.)
     """
+    # conbench.job ultimately depends on conbench.entities.commit, which imports this
+    # metrics module. Avoid circular import.
+    from conbench import job
 
     def func():
         log.info("periodically_set_q_rem(): initiate")


### PR DESCRIPTION
A bit of a thought dump accompanied by a tiny improvement. After #1162, I noticed the following error when developing locally:
```
Python 3.11.0 (main, Mar  1 2023, 12:33:14) [Clang 14.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import conbench.entities.commit
[230425-08:55:21.844] [34646] [conbench.db] INFO: psycopg2.__libpq_version__: 140007
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/austin/repos/conbench/conbench/entities/commit.py", line 15, in <module>
    from conbench import metrics, util
  File "/Users/austin/repos/conbench/conbench/metrics.py", line 27, in <module>
    from conbench import job
  File "/Users/austin/repos/conbench/conbench/job.py", line 14, in <module>
    from conbench.entities.benchmark_result import BenchmarkResult
  File "/Users/austin/repos/conbench/conbench/entities/benchmark_result.py", line 32, in <module>
    from ..entities.commit import TypeCommitInfoGitHub
ImportError: cannot import name 'TypeCommitInfoGitHub' from partially initialized module 'conbench.entities.commit' (most likely due to a circular import) (/Users/austin/repos/conbench/conbench/entities/commit.py)
```
Whenever something tries to import `conbench.entities.commit`, it fails due to a circular dependency, because it depends on `conbench.metrics`, which newly depends on `conbench.job`, which ultimately depends on `conbench.entities.commit`.

I was curious why this didn't fail any tests. For example, we do import this fully-qualified module in some database migrations:
https://github.com/conbench/conbench/blob/ffee0dc15f4e33d51f53e8e586aa9508575f53af/migrations/versions/4d8d67396f79_clean_commits.py#L39
But [that upgrade](https://github.com/conbench/conbench/actions/runs/4785648542/jobs/8508612942#step:4:1128) passed in CI. Looking into it a little, I noticed this passes:
```
Python 3.11.0 (main, Mar  1 2023, 12:33:14) [Clang 14.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import conbench.entities
>>> import conbench.entities.commit
[230425-09:07:06.338] [35827] [conbench.db] INFO: psycopg2.__libpq_version__: 140007
[230425-09:07:06.350] [35827] [conbench.entities.commit] INFO: GITHUB_API_TOKEN env is set, length of data: 40
[230425-09:07:06.350] [35827] [conbench.entities.commit] INFO: configured a single GitHub HTTP API auth token
>>>
```
So the full initialization of the parent module must be sufficient to avoid this circle. That's kind of good; it means the scope of this problem is small.

In the past, when writing tests, I've tried to use fully-qualified imports (e.g. `from conbench.entities.commit import ...`) instead of relative imports like we do today:
https://github.com/conbench/conbench/blob/ffee0dc15f4e33d51f53e8e586aa9508575f53af/conbench/tests/entities/test_commit.py#L10
Maybe that would have caught this problem?