### PR TITLE
guarantee BenchmarkResult.mean again, add clarity in many ways, introduce 'single value summary' to feed plot and history api

### DIFF
--- a/conbench/api/_examples.py
+++ b/conbench/api/_examples.py
@@ -401,6 +401,8 @@ def _api_history_entity(benchmark_result_id, case_id, context_id, run_name):
             "data": BENCHMARK_ENTITY["stats"]["data"],
             "hardware_hash": "diana-2-2-4-17179869184",
             "mean": 0.036369,
+            "svs": 0.036369,
+            "svs_type": "mean",
             "repository": "https://github.com/org/repo",
             "run_name": run_name,
             "times": BENCHMARK_ENTITY["stats"]["times"],

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -577,7 +577,7 @@ def time_series_plot(
     # summary (SVS).
     curbmrdata = current_benchmark_result.data
     dummy_hs_for_min = copy.copy(dummy_hs_for_current_svs)
-    dummy_hs_for_min.svs = min(curbmrdata) if curbmrdata else math.nan
+    dummy_hs_for_min.svs = float(min(curbmrdata)) if curbmrdata else math.nan
     source_current_bm_min = _source(
         [dummy_hs_for_min],
         unit,

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -84,9 +84,10 @@ class BenchmarkResult(Base, EntityMixin):
     info: Mapped[Info] = relationship("Info", lazy="joined")
     context: Mapped[Context] = relationship("Context", lazy="joined")
 
-    # `unit` is required by schema and currently documented with "The unit of
-    # the data object (e.g. seconds, B/s)". Where do we systematically keep
-    # track of "less is better" or "more is better"?
+    # Why is this nullable? `unit` is required via the JSON schema and
+    # currently documented with "The unit of the data object (e.g. seconds,
+    # B/s)". Where do we systematically keep track of "less is better" or "more
+    # is better"?
     unit: Mapped[Optional[str]] = Nullable(s.Text)
     time_unit: Mapped[Optional[str]] = Nullable(s.Text)
 

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -3,7 +3,7 @@ import math
 import statistics
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import flask as f
 import marshmallow

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -99,9 +99,17 @@ class BenchmarkResult(Base, EntityMixin):
     # store is the user-given timestamp properly translated to UTC.
     timestamp: Mapped[datetime] = NotNull(s.DateTime(timezone=False))
     iterations: Mapped[Optional[int]] = Nullable(s.Integer)
+
+    # Mean can only be None for errored BenchmarkResults. Is guaranteed to have
+    # a numeric value for all non-errored BenchmarkResults, including those
+    # that have just one data point (when the mean is not an exciting
+    # statistic, but still a useful one).
+    mean: Mapped[Optional[float]] = Nullable(s.Numeric, check("mean>=0"))
+
+    # The remaining aggregates are only non-None when the BenchmarkResult has
+    # at least N data points (see below).
     min: Mapped[Optional[float]] = Nullable(s.Numeric, check("min>=0"))
     max: Mapped[Optional[float]] = Nullable(s.Numeric, check("max>=0"))
-    mean: Mapped[Optional[float]] = Nullable(s.Numeric, check("mean>=0"))
     median: Mapped[Optional[float]] = Nullable(s.Numeric, check("median>=0"))
     stdev: Mapped[Optional[float]] = Nullable(s.Numeric, check("stdev>=0"))
     q1: Mapped[Optional[float]] = Nullable(s.Numeric, check("q1>=0"))

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -489,8 +489,16 @@ def validate_and_aggregate_samples(stats_usergiven: Any):
 
     # Initialize all aggregate values explicitly to None -- values set below
     # must be meaningful.
+    # Initialize all aggregate values explicitly to None (except for `mean`,
+    # this has special treatment).
     for k in agg_keys:
         result_data_for_db[k] = None
+
+    # The `mean` is the only aggregate that is OK to be built for at least one
+    # data point (even if not that useful). That gives the guarantee that
+    # BenchmarkResult.mean is populated for all non-errored BenchmarkResults.
+    # See https://github.com/conbench/conbench/issues/1169
+    result_data_for_db["mean"] = np.mean(samples)
 
     if len(samples) >= 2:
         # There is a special case where for one sample the iteration count
@@ -509,7 +517,6 @@ def validate_and_aggregate_samples(stats_usergiven: Any):
         aggregates = {
             "q1": q1,
             "q3": q3,
-            "mean": np.mean(samples),
             "median": np.median(samples),
             "min": np.min(samples),
             "max": np.max(samples),

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -70,10 +70,10 @@ class BenchmarkResult(Base, EntityMixin):
 
     # These can be empty lists. An item in the list is of type float, which
     # includes `math.nan` as valid value.
-    data: Mapped[Optional[List[float]]] = Nullable(
+    data: Mapped[Optional[List[Decimal]]] = Nullable(
         postgresql.ARRAY(s.Numeric), default=[]
     )
-    times: Mapped[Optional[List[float]]] = Nullable(
+    times: Mapped[Optional[List[Decimal]]] = Nullable(
         postgresql.ARRAY(s.Numeric), default=[]
     )
 

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -531,17 +531,6 @@ class BenchmarkResult(Base, EntityMixin):
         The indirection here through `self.run` is interesting, might trigger
         database interaction.
         """
-
-        # try:
-        #     # Note: is this jinja2 behavior? when this fails with
-        #     # Attribute error like
-        #     # 'BenchmarkResult' object has no attribute 'hardware'
-        #     # then the template does not crash, but shows no value.
-        #     print(type(self.hardware) + "f")
-        # except Exception as exc:
-        #     print("exc:", exc)
-        #     raise exc
-
         hw = self.run.hardware
         if len(hw.name) > 15:
             return f"{hw.id[:4]}: " + hw.name[:15]
@@ -621,8 +610,8 @@ def validate_and_aggregate_samples(stats_usergiven: Any):
         for key, value in aggregates.items():
             result_data_for_db[key] = sigfig.round(value, sigfigs=5)
 
-            # Log upon conflict. Lett the automatically derived value win,
-            # to achieve consistency between the provided samples and the
+            # Log upon conflict. Let the automatically derived value win, to
+            # achieve consistency between the provided samples and the
             # aggregates.
             if key in stats_usergiven:
                 if not floatcomp(stats_usergiven[key], value):

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -4,6 +4,7 @@ import datetime
 import decimal
 import logging
 import math
+from collections import defaultdict
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -146,41 +146,6 @@ class HistorySample:
         d["commit_timestamp"] = self.commit_timestamp.isoformat()
         return d
 
-    @property
-    def single_value_for_plot(self) -> float:
-        """
-        Helper for plotting routines. This sample ended up in a collection that
-        wants to be plotted. For that, a single value is needed defining the
-        position on "y axis".
-
-        Downstream code relies on a float(y) value to be returned, which
-        includes `math.nan`.
-        """
-        if isinstance(self.mean, float):
-            if not math.isnan(self.mean):
-                return self.mean
-
-        # Mean value isn't set. That should imply that there are less than
-        # three data points. Do a sanity check.
-        if len(self.data) not in (1, 2):
-            # That is / should be an invariant: if there are more than two
-            # values set, then this HistorySample is expected to have a mean
-            # value set (upon database insertion). If this isn't the case,
-            # leave a log message.
-            log.warning(
-                "bad history sample: mean is %s, data length is %s",
-                self.mean,
-                len(self.data),
-            )
-            return math.nan
-
-        # There is at least one data point, at most two data points. See
-        # https://github.com/conbench/conbench/issues/1118. Lacking a better
-        # rationale, for now return one of both data points. If these are two
-        # values and they have vastly different values, then this is a
-        # non-ideal situation anyway.
-        return self.data[0]
-
 
 def get_history_for_benchmark(benchmark_result_id: str):
     # First, find case / context / hardware / repo combination based on the

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -121,6 +121,14 @@ class HistorySample:
     # logic in BenchmarkResult.create() which is quite intransparent today,
     # also there is a lack of spec
     mean: Optional[float]
+    # Experimental: introduce 'singe value summary' concept. An item in history
+    # reflects a benchmark result, and that must have a single value
+    # representation for plotting and analysis. If it does not have that, it
+    # should not be part of history (this cannot be None). Initially this is
+    # equivalent to mean. For consumers to make sense of this, also add a
+    # string field carrying the name. the name of this.
+    svs: float
+    svs_type: str
     # math.nan is allowed for representing a failed iteration.
     data: List[float]
     times: List[float]
@@ -275,6 +283,14 @@ def get_history_for_cchr(
                 case_id=sample.case_id,
                 context_id=sample.context_id,
                 mean=sample.mean,
+                # Keep exposing the `mean` property like before. This was meant
+                # to be the single value summary, guaranteed to have a value
+                # set. So, actually read this from the new .svs property which
+                # still is the mean as of today. Do not read this from
+                # BenchmarkResult.mean, because this can be None.
+                mean=result.svs,
+                svs=result.svs,
+                svs_type=result.svs_type,  # hard-code for now
                 data=data,
                 times=times,
                 unit=sample.unit,

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -145,7 +145,7 @@ class HistorySample:
         includes `math.nan`.
         """
         if isinstance(self.mean, float):
-            if not math.isnan(self.value):
+            if not math.isnan(self.mean):
                 # This is a numeric, floaty value (not `math.nan`).
                 return self.mean
 

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -144,14 +144,21 @@ class HistorySample:
         Downstream code relies on a float(y) value to be returned, which
         includes `math.nan`.
         """
-        if self.mean is not None:
+        if self.mean is not None and self.mean is not math.nan:
             # Want to be sure I understand what's happening. Context:
             # https://github.com/conbench/conbench/issues/1155
             assert isinstance(self.mean, float)
+            # This is a numeric, floaty value (not `math.nan`).
             return self.mean
 
+        # Mean value isn't set. That should imply that there are less than
+        # three data points. Do a sanity check.
         if len(self.data) not in (1, 2):
-            log.warning("bad history sample: mean is none, data length unexpected")
+            log.warning(
+                "bad history sample: mean is %s, data length is %s",
+                self.mean,
+                len(self.data),
+            )
             return math.nan
 
         # Assume there is at least one data point, at most two data points. See
@@ -159,7 +166,7 @@ class HistorySample:
         # rationale, for now return one of both data points. If these are two
         # values and they have vastly different values, then this is non-ideal
         # situation anyway.
-        return self.data[1]
+        return self.data[0]
 
 
 def get_history_for_benchmark(benchmark_result_id: str):

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -138,6 +138,9 @@ class HistorySample:
     # Note(JP):
     # we should expose the unit of `data` in this structure, too.
 
+    def __str__(self):
+        return f"<{self.__class__.__name__}(mean:{self.mean}),data:{self.data}>"
+
     def _dict_for_api_json(self) -> dict:
         d = dataclasses.asdict(self)
         # if performance is a concern then https://pypi.org/project/orjson/

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -146,12 +146,15 @@ class HistorySample:
         """
         if isinstance(self.mean, float):
             if not math.isnan(self.mean):
-                # This is a numeric, floaty value (not `math.nan`).
                 return self.mean
 
         # Mean value isn't set. That should imply that there are less than
         # three data points. Do a sanity check.
         if len(self.data) not in (1, 2):
+            # That is / should be an invariant: if there are more than two
+            # values set, then this HistorySample is expected to have a mean
+            # value set (upon database insertion). If this isn't the case,
+            # leave a log message.
             log.warning(
                 "bad history sample: mean is %s, data length is %s",
                 self.mean,
@@ -159,11 +162,11 @@ class HistorySample:
             )
             return math.nan
 
-        # Assume there is at least one data point, at most two data points. See
-        # https://github.com/conbench/conbench/issues/1118 Lacking a better
+        # There is at least one data point, at most two data points. See
+        # https://github.com/conbench/conbench/issues/1118. Lacking a better
         # rationale, for now return one of both data points. If these are two
-        # values and they have vastly different values, then this is non-ideal
-        # situation anyway.
+        # values and they have vastly different values, then this is a
+        # non-ideal situation anyway.
         return self.data[0]
 
 

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -144,12 +144,10 @@ class HistorySample:
         Downstream code relies on a float(y) value to be returned, which
         includes `math.nan`.
         """
-        if self.mean is not None and self.mean is not math.nan:
-            # Want to be sure I understand what's happening. Context:
-            # https://github.com/conbench/conbench/issues/1155
-            assert isinstance(self.mean, float)
-            # This is a numeric, floaty value (not `math.nan`).
-            return self.mean
+        if isinstance(self.mean, float):
+            if not math.isnan(self.value):
+                # This is a numeric, floaty value (not `math.nan`).
+                return self.mean
 
         # Mean value isn't set. That should imply that there are less than
         # three data points. Do a sanity check.

--- a/conbench/runner.py
+++ b/conbench/runner.py
@@ -446,8 +446,8 @@ class Conbench(Connection, MixinPython, MixinR):
         }
 
         if one_sample_no_mean:
-            # Brutal way to create a BenchmarkResult in a history that
-            # has no aggregates, in particular no mean value.
+            # Submit a BenchmarkResult in a history that has  one data point
+            # and no aggregates, in particular no (user-given) mean value set.
             agg_keys = ("q1", "q3", "mean", "median", "min", "max", "stdev", "iqr")
 
             result["data"] = [result["data"][0]]

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -683,6 +683,8 @@
                                     "mean": 0.036369,
                                     "repository": "https://github.com/org/repo",
                                     "run_name": "some run name",
+                                    "svs": 0.036369,
+                                    "svs_type": "mean",
                                     "times": [
                                         0.099094,
                                         0.037129,

--- a/conbench/tests/app/test_plots.py
+++ b/conbench/tests/app/test_plots.py
@@ -9,6 +9,8 @@ from ...app._plots import _should_format, _simple_source, _source
 def legacy_dict_to_hs(d: dict) -> HistorySample:
     return HistorySample(
         mean=d["mean"],
+        svs=d["mean"],
+        svs_type="mean",
         commit_msg=d["message"],
         commit_timestamp=util.tznaive_iso8601_to_tzaware_dt(d["timestamp"]),
         commit_hash=d["sha"],

--- a/conbench/tests/app/test_results.py
+++ b/conbench/tests/app/test_results.py
@@ -73,9 +73,8 @@ class TestBenchmarkResultGet(_asserts.GetEnforcer):
         self.authenticate(client)
         _, bmresults = _fixtures.gen_fake_data(one_sample_no_mean=True)
         bmr_id = bmresults[3].id
-        with pytest.raises(ValueError, match="invalid input Character"):
-            resp = client.get(f"benchmark-results/{bmr_id}/")
-            assert resp.status_code == 200, resp.text
+        resp = client.get(f"benchmark-results/{bmr_id}/")
+        assert resp.status_code == 200, resp.text
 
 
 class TestBenchmarkResultDelete(_asserts.DeleteEnforcer):

--- a/conbench/tests/entities/test_history.py
+++ b/conbench/tests/entities/test_history.py
@@ -303,6 +303,10 @@ def test_detect_shifts_with_trimmed_estimators():
             "timestamp": np.arange(100),
             "result_timestamp": np.arange(100),
             "mean": mean_vals,
+            # Introduce concept of single value summary (SVS), currently
+            # equivalent with mean, the single value representing the outcome
+            # of the benchmark result.
+            "svs": mean_vals,
         }
     )
 

--- a/conbench/tests/entities/test_history.py
+++ b/conbench/tests/entities/test_history.py
@@ -42,11 +42,25 @@ def _get_head_of_default(commit: Commit) -> Commit:
     ).first()
 
 
-def assert_equal_leeway(v1, v2, sfigs=4):
+def assert_equal_leeway(comparison, reference, figs=4):
     """
-    Compare two float values but allow for a relatively dimensioned epsilon.
+    Compare two Optional[float] values but allow for
+    - a tiny absolute epsilon
+    - a relatively dimensioned epsilon
     """
-    assert sigfig.round(v1, sigfigs=sfigs) == sigfig.round(v2, sigfigs=sfigs)
+    if reference is None or comparison is None:
+        assert comparison is reference
+        return
+
+    if abs(reference - comparison) < 10**-13:
+        return
+
+    # For tiny values close to zero the condition below can fail with for
+    # example `assert -3.846e-15 == 0.0` -- in our context is I think this can
+    # safely be considered numerical noise.
+    assert sigfig.round(reference, sigfigs=figs) == sigfig.round(
+        comparison, sigfigs=figs
+    )
 
 
 # These correspond to the benchmark_results of _fixtures.gen_fake_data() without modification

--- a/conbench/tests/entities/test_history.py
+++ b/conbench/tests/entities/test_history.py
@@ -4,6 +4,7 @@ from typing import Callable
 import numpy as np
 import pandas as pd
 import pytest
+import sigfig
 import sqlalchemy as s
 
 from ...db import Session
@@ -41,61 +42,68 @@ def _get_head_of_default(commit: Commit) -> Commit:
     ).first()
 
 
+def assert_equal_leeway(v1, v2, sfigs=4):
+    """
+    Compare two float values but allow for a relatively dimensioned epsilon.
+    """
+    assert sigfig.round(v1, sigfigs=sfigs) == sigfig.round(v2, sigfigs=sfigs)
+
+
 # These correspond to the benchmark_results of _fixtures.gen_fake_data() without modification
 EXPECTED_Z_SCORES = {
     "closest_defaultbranch_ancestor": [
         None,
         None,
-        28.477042698148946,
-        0.7071067811865444,
-        2.1213203435596393,
-        13.435028842544385,
-        1.0928748862317967,
-        -2.1857497724635935,
-        -4.486481486904943,
-        -4.946696853470237,
+        28.48,
+        0.7071,
+        2.121,
+        13.44,
+        1.093,
+        -2.186,
+        -4.487,
+        -4.947,
         None,
         None,
         None,
         None,
         None,
-        -5.98205200884773,
+        -5.982,
     ],
     "parent": [
         None,
         None,
-        28.477042698148946,
-        0.7071067811865444,
-        2.1213203435596393,
-        13.435028842544385,
-        1.0928748862317967,
-        -2.8246140882627757,
-        -4.486481486904943,
-        -4.946696853470237,
+        28.48,
+        0.7071,
+        2.121,
+        13.44,
+        1.093,
+        -2.825,
+        -4.487,
+        -4.947,
         None,
         None,
         None,
         None,
         None,
-        -5.98205200884773,
+        -5.982,
     ],
     "head_of_default": [
-        0.662490861131055,
-        0.6082868170201319,
-        1.726858274546817,
-        0.662490861131055,
-        0.7166949052419783,
-        1.1503272581293638,
-        1.1503272581293638,
-        0.12045042002182318,
-        -0.6022521001091159,
-        -0.7468142857529476,
+        0.6625,
+        0.6083,
+        1.7269,
+        0.6625,
+        0.7167,
+        1.150,
+        1.150,
+        0.1205,
+        -0.6023,
+        -0.7468,
         None,
         None,
         None,
         None,
         None,
-        -1.072038550418487,
+        -1.072,
     ],
 }
 
@@ -174,7 +182,7 @@ def test_set_z_scores(
     for benchmark_result, expected_z_score in zip(
         benchmark_results, EXPECTED_Z_SCORES[strategy_name]
     ):
-        assert benchmark_result.z_score == expected_z_score
+        assert_equal_leeway(benchmark_result.z_score, expected_z_score)
 
     if strategy_name == "head_of_default":
         return
@@ -199,7 +207,7 @@ def test_set_z_scores(
             name=benchmark_results[0].case.name,
         )
     )
-    expected_z_scores = EXPECTED_Z_SCORES[strategy_name] + [-52.9995128086829]
+    expected_z_scores = EXPECTED_Z_SCORES[strategy_name] + [-52.9993797469743]
 
     for benchmark_result in benchmark_results:
         baseline_commit = get_baseline_func(benchmark_result.run.commit)
@@ -212,7 +220,7 @@ def test_set_z_scores(
             benchmark_result.z_score = None
 
     for benchmark_result, expected_z_score in zip(benchmark_results, expected_z_scores):
-        assert benchmark_result.z_score == expected_z_score
+        assert_equal_leeway(benchmark_result.z_score, expected_z_score)
 
 
 @pytest.mark.parametrize(
@@ -259,7 +267,7 @@ def test_set_z_scores_with_distribution_change(
             benchmark_result.z_score = None
 
     for benchmark_result, expected_z_score in zip(benchmark_results, expected_z_scores):
-        assert benchmark_result.z_score == expected_z_score
+        assert_equal_leeway(benchmark_result.z_score, expected_z_score)
 
 
 def test_detect_shifts_with_trimmed_estimators():

--- a/conbench/units.py
+++ b/conbench/units.py
@@ -45,17 +45,6 @@ def fmt_unit(value: Optional[float], unit) -> Optional[str]:
     if value is None:
         return None
 
-    if value is math.nan:
-        # Must not call sigfig.round() with math.nan, see
-        # https://github.com/conbench/conbench/issues/1155
-        return None
-
-    if value == "null":
-        # sigfig.round("null", sigfigs=3) also results in the exception
-        # ValueError: invalid input Character "n" (position 1, state A)
-        log.warning('fmt_unit() was passed literal string "null"')
-        return None
-
     # These stringified values power a Bokeh plot. Ensure that the textual
     # representation of the numeric value encodes a desired minimum number of
     # significant digits, to allow for meaningful plotting resolution.
@@ -68,6 +57,7 @@ def fmt_unit(value: Optional[float], unit) -> Optional[str]:
     try:
         return f"{sigfig.round(value, sigfigs=4)} {unit}"
     except ValueError as exc:
+        # https://github.com/conbench/conbench/issues/1155
         log.warning("fmt_unit(): got unexpected value `%s`, exc: %s", repr(value), exc)
         return None
 

--- a/conbench/units.py
+++ b/conbench/units.py
@@ -1,5 +1,4 @@
 import logging
-import math
 from typing import Optional
 
 import sigfig

--- a/conbench/units.py
+++ b/conbench/units.py
@@ -58,7 +58,7 @@ def fmt_unit(value: Optional[float], unit) -> Optional[str]:
     except ValueError as exc:
         # https://github.com/conbench/conbench/issues/1155
         log.warning("fmt_unit(): got unexpected value `%s`, exc: %s", repr(value), exc)
-        return None
+        raise
 
 
 def formatter_for_unit(unit):

--- a/conbench/units.py
+++ b/conbench/units.py
@@ -65,7 +65,11 @@ def fmt_unit(value: Optional[float], unit) -> Optional[str]:
     # I have seen a KeyError being thrown which I could not reproduce anymore.
     # sigfig/sigfig.py line 551 does `del number.map[p]` and this resulted in
     # `KeyError: 0`. It was probably a programming mistake.
-    return f"{sigfig.round(value, sigfigs=4)} {unit}"
+    try:
+        return f"{sigfig.round(value, sigfigs=4)} {unit}"
+    except ValueError as exc:
+        log.warning("fmt_unit(): got unexpected value `%s`, exc: %s", repr(value), exc)
+        return None
 
 
 def formatter_for_unit(unit):


### PR DESCRIPTION
This was motivated by #1169 and #1155. The methodological fixes in here are almost boring, but where I hope the actual value is:

- clarification of assumptions and intent
- introduction of a 'single value summary' concept/interface (naming is hard)
- exposure of the good old BenchmarkResult object in the _plots module (that was soo much needed)
- more deliberate test coverage
- rather significant overhaul of some involved type checks

What's maybe not visible from the patch itself: type checking here was _incredibly_ useful, raising really important questions along the way; it's not just overhead keeping us busy, it really reveals those aspects where our intuition let us down and where thinking just wasn't right. The tighter and more correct the type annotations get, the more productive the feedback gets.

There's more to this patch, please also have a look at commit messages and code comments. They are all not perfect and might appear a little sloppily written here and there. But I figured quickly typing down thoughts is better than not doing it.

And in case it isn't obvious: so much sweat in this PR. Everything fell apart (largely self-inflicted, yes) and it was difficult to find out why.

Edit:

> introduction of a 'single value summary' concept/interface (naming is hard)

This makes it easier to do https://github.com/conbench/conbench/issues/594 and https://github.com/conbench/conbench/issues/640.

