### PR TITLE
requirements-webapp: pin Flask to 2.2.3, and Werkzeug to 2.2.3 (fix #1173)

### DIFF
--- a/requirements-webapp.txt
+++ b/requirements-webapp.txt
@@ -5,7 +5,7 @@ bokeh
 click
 dacite
 email-validator
-Flask
+Flask==2.2.3
 Flask-Bootstrap
 Flask-Compress
 Flask-Login

--- a/requirements-webapp.txt
+++ b/requirements-webapp.txt
@@ -11,6 +11,7 @@ Flask-Compress
 Flask-Login
 flask-swagger-ui
 Flask-WTF
+Werkzeug==2.2.3
 gitpython
 gunicorn
 marshmallow


### PR DESCRIPTION
Flask 2.2.4 was released today and broke us:
- https://flask.palletsprojects.com/en/2.2.x/changes/ 
- https://github.com/conbench/conbench/issues/1173

Pin to 2.2.3 for now.