### PR TITLE
benchalerts: Comparison step for run IDs

### DIFF
--- a/benchalerts/README.md
+++ b/benchalerts/README.md
@@ -47,7 +47,10 @@ pipeline = AlertPipeline(
             commit_hash=commit_hash,
             baseline_run_type=steps.BaselineRunCandidates.fork_point,
         ),
-        steps.GitHubCheckStep(repo=repo),
+        steps.GitHubCheckStep(
+            comparison_step_name="GetConbenchZComparisonStep",
+            repo=repo
+        ),
     ],
     error_handlers=[
         steps.GitHubCheckErrorHandler(

--- a/benchalerts/README.md
+++ b/benchalerts/README.md
@@ -43,7 +43,10 @@ build_url = (
 # Create a pipeline to update a GitHub Check
 pipeline = AlertPipeline(
     steps=[
-        steps.GetConbenchZComparisonStep(commit_hash=commit_hash),
+        steps.GetConbenchZComparisonStep(
+            commit_hash=commit_hash,
+            baseline_run_type=steps.BaselineRunCandidates.fork_point,
+        ),
         steps.GitHubCheckStep(repo=repo),
     ],
     error_handlers=[

--- a/benchalerts/benchalerts/pipeline_steps/__init__.py
+++ b/benchalerts/benchalerts/pipeline_steps/__init__.py
@@ -1,4 +1,8 @@
-from .conbench import GetConbenchZComparisonStep
+from .conbench import (
+    BaselineRunCandidates,
+    GetConbenchZComparisonForRunsStep,
+    GetConbenchZComparisonStep,
+)
 from .github import (
     GitHubCheckErrorHandler,
     GitHubCheckStep,
@@ -8,6 +12,8 @@ from .github import (
 )
 
 __all__ = [
+    "BaselineRunCandidates",
+    "GetConbenchZComparisonForRunsStep",
     "GetConbenchZComparisonStep",
     "GitHubCheckErrorHandler",
     "GitHubCheckStep",

--- a/benchalerts/benchalerts/pipeline_steps/conbench.py
+++ b/benchalerts/benchalerts/pipeline_steps/conbench.py
@@ -81,7 +81,6 @@ class GetConbenchZComparisonForRunsStep(AlertPipelineStep):
 
     def run_step(self, previous_outputs: Dict[str, Any]) -> FullComparisonInfo:
         log.info(f"Getting comparisons from {len(self.run_ids)} run(s)")
-        assert self.baseline_run_type
         return FullComparisonInfo(
             run_comparisons=[
                 self._get_one_run_comparison(run_id) for run_id in self.run_ids
@@ -90,6 +89,7 @@ class GetConbenchZComparisonForRunsStep(AlertPipelineStep):
 
     def _get_one_run_comparison(self, run_id: str) -> RunComparisonInfo:
         """Create and populate one RunComparisonInfo instance."""
+        assert self.baseline_run_type
         run_comparison = RunComparisonInfo(
             contender_info=self.conbench_client.get(f"/runs/{run_id}/")
         )

--- a/benchalerts/benchalerts/pipeline_steps/conbench.py
+++ b/benchalerts/benchalerts/pipeline_steps/conbench.py
@@ -1,6 +1,7 @@
 """Pipeline steps to talk to Conbench."""
 
-from typing import Any, Dict, Optional
+from enum import Enum
+from typing import Any, Dict, List, Optional
 
 from benchclients.conbench import LegacyConbenchClient
 from benchclients.logging import fatal_and_log, log
@@ -11,7 +12,122 @@ from ..conbench_dataclasses import FullComparisonInfo, RunComparisonInfo
 ConbenchClient = LegacyConbenchClient
 
 
-class GetConbenchZComparisonStep(AlertPipelineStep):
+class BaselineRunCandidates(Enum):
+    """Types of baselines available from `/api/runs/{run_id}` in the
+    `candidate_baseline_runs` field.
+    """
+
+    fork_point = "fork_point"
+    head_of_default = "head_of_default"
+    parent = "parent"
+
+
+class GetConbenchZComparisonForRunsStep(AlertPipelineStep):
+    """An ``AlertPipeline`` step to get information from Conbench comparing run(s) to
+    their baselines, using a z-score threshold. This is always the first step of the
+    pipeline.
+
+    Parameters
+    ----------
+    run_ids
+        A list of Conbench run IDs of the runs to compare.
+    baseline_run_type
+        The type of baseline to use. See ``BaselineCandidates`` for options.
+    z_score_threshold
+        The (positive) z-score threshold to send to the Conbench compare endpoint.
+        Benchmarks with a z-score more extreme than this threshold will be marked as
+        regressions or improvements in the result. Default is to use whatever Conbench
+        uses for default (at the time of writing, this is 5).
+    conbench_client
+        A ConbenchClient instance. If not given, one will be created using the standard
+        environment variables.
+    step_name
+        The name for this step. If not given, will default to this class's name.
+
+    Returns
+    -------
+    FullComparisonInfo
+        Information about each run associated with the contender commit, and a
+        comparison to its baseline run if that exists.
+
+    Notes
+    -----
+    Environment variables
+    ~~~~~~~~~~~~~~~~~~~~~
+    ``CONBENCH_URL``
+        The URL of the Conbench server. Only required if ``conbench_client`` is not
+        provided.
+    ``CONBENCH_EMAIL``
+        The email to use for Conbench login. Only required if ``conbench_client`` is not
+        provided and the server is private.
+    ``CONBENCH_PASSWORD``
+        The password to use for Conbench login. Only required if ``conbench_client`` is
+        not provided and the server is private.
+    """
+
+    def __init__(
+        self,
+        run_ids: List[str],
+        baseline_run_type: Optional[BaselineRunCandidates],
+        z_score_threshold: Optional[float] = None,
+        conbench_client: Optional[LegacyConbenchClient] = None,
+        step_name: Optional[str] = None,
+    ) -> None:
+        super().__init__(step_name)
+        self.run_ids = run_ids
+        self.baseline_run_type = baseline_run_type
+        self.z_score_threshold = z_score_threshold
+        self.conbench_client = conbench_client or ConbenchClient()
+
+    def run_step(self, previous_outputs: Dict[str, Any]) -> FullComparisonInfo:
+        log.info(f"Getting comparisons from {len(self.run_ids)} run(s)")
+        return FullComparisonInfo(
+            run_comparisons=[
+                self._get_one_run_comparison(run_id) for run_id in self.run_ids
+            ]
+        )
+
+    def _get_one_run_comparison(self, run_id: str) -> RunComparisonInfo:
+        """Create and populate one RunComparisonInfo instance."""
+        run_comparison = RunComparisonInfo(
+            contender_info=self.conbench_client.get(f"/runs/{run_id}/")
+        )
+
+        candidate_baseline_run = run_comparison.contender_info[
+            "candidate_baseline_runs"
+        ][self.baseline_run_type.value]
+        baseline_run_id = candidate_baseline_run["baseline_run_id"]
+
+        if baseline_run_id:
+            run_comparison.baseline_info = self.conbench_client.get(
+                f"/runs/{baseline_run_id}/"
+            )
+
+            # Get the comparison.
+            compare_params = (
+                {"threshold_z": self.z_score_threshold}
+                if self.z_score_threshold
+                else None
+            )
+            run_comparison.compare_results = self.conbench_client.get(
+                run_comparison.compare_path, params=compare_params
+            )
+
+        else:
+            log.warning(
+                f"Conbench could not find a {self.baseline_run_type.value} baseline run "
+                f"for the contender run {run_id}. Error: {candidate_baseline_run['error']}"
+            )
+            if run_comparison.has_errors:
+                # get more information so we have more details about errors
+                run_comparison.benchmark_results = self.conbench_client.get(
+                    "/benchmarks/", params={"run_id": run_id}
+                )
+
+        return run_comparison
+
+
+class GetConbenchZComparisonStep(GetConbenchZComparisonForRunsStep):
     """An ``AlertPipeline`` step to get information from Conbench comparing the runs on
     a contender commit to their baselines, using a z-score threshold. This is always the
     first step of the pipeline.
@@ -61,29 +177,29 @@ class GetConbenchZComparisonStep(AlertPipelineStep):
         conbench_client: Optional[LegacyConbenchClient] = None,
         step_name: Optional[str] = None,
     ) -> None:
-        super().__init__(step_name)
+        super().__init__(
+            run_ids=[],
+            # TODO populate and use this value properly
+            baseline_run_type=None,
+            z_score_threshold=z_score_threshold,
+            conbench_client=conbench_client,
+            step_name=step_name,
+        )
         self.commit_hash = commit_hash
-        self.z_score_threshold = z_score_threshold
-        self.conbench_client = conbench_client or ConbenchClient()
 
     def run_step(self, previous_outputs: Dict[str, Any]) -> FullComparisonInfo:
-        contender_run_ids = [
+        self.run_ids = [
             run["id"]
             for run in self.conbench_client.get(
                 "/runs/", params={"sha": self.commit_hash}
             )
         ]
-        if not contender_run_ids:
+        if not self.run_ids:
             fatal_and_log(
                 f"Contender commit '{self.commit_hash}' doesn't have any runs in Conbench."
             )
 
-        log.info(f"Getting comparisons from {len(contender_run_ids)} run(s)")
-        return FullComparisonInfo(
-            run_comparisons=[
-                self._get_one_run_comparison(run_id) for run_id in contender_run_ids
-            ]
-        )
+        return super().run_step(previous_outputs)
 
     def _get_one_run_comparison(self, run_id: str) -> RunComparisonInfo:
         """Create and populate one RunComparisonInfo instance."""

--- a/benchalerts/benchalerts/pipeline_steps/conbench.py
+++ b/benchalerts/benchalerts/pipeline_steps/conbench.py
@@ -18,7 +18,7 @@ class BaselineRunCandidates(Enum):
     """
 
     fork_point = "fork_point"
-    head_of_default = "head_of_default"
+    latest_default = "latest_default"
     parent = "parent"
 
 

--- a/benchalerts/benchalerts/pipeline_steps/conbench.py
+++ b/benchalerts/benchalerts/pipeline_steps/conbench.py
@@ -51,7 +51,7 @@ class GetConbenchZComparisonForRunsStep(AlertPipelineStep):
     run_ids
         A list of Conbench run IDs of the runs to compare.
     baseline_run_type
-        The type of baseline to use. See ``BaselineCandidates`` for options.
+        The type of baseline to use. See ``BaselineRunCandidates`` for options.
     z_score_threshold
         The (positive) z-score threshold to send to the Conbench compare endpoint.
         Benchmarks with a z-score more extreme than this threshold will be marked as

--- a/benchalerts/benchalerts/pipeline_steps/conbench.py
+++ b/benchalerts/benchalerts/pipeline_steps/conbench.py
@@ -81,6 +81,7 @@ class GetConbenchZComparisonForRunsStep(AlertPipelineStep):
 
     def run_step(self, previous_outputs: Dict[str, Any]) -> FullComparisonInfo:
         log.info(f"Getting comparisons from {len(self.run_ids)} run(s)")
+        assert self.baseline_run_type
         return FullComparisonInfo(
             run_comparisons=[
                 self._get_one_run_comparison(run_id) for run_id in self.run_ids

--- a/benchalerts/benchalerts/pipeline_steps/conbench.py
+++ b/benchalerts/benchalerts/pipeline_steps/conbench.py
@@ -12,24 +12,6 @@ from ..conbench_dataclasses import FullComparisonInfo, RunComparisonInfo
 ConbenchClient = LegacyConbenchClient
 
 
-CONBENCH_ENV_VAR_HELP = """
-
-    Notes
-    -----
-    Environment variables
-    ~~~~~~~~~~~~~~~~~~~~~
-    ``CONBENCH_URL``
-        The URL of the Conbench server. Only required if ``conbench_client`` is not
-        provided.
-    ``CONBENCH_EMAIL``
-        The email to use for Conbench login. Only required if ``conbench_client`` is not
-        provided and the server is private.
-    ``CONBENCH_PASSWORD``
-        The password to use for Conbench login. Only required if ``conbench_client`` is
-        not provided and the server is private.
-"""
-
-
 class BaselineRunCandidates(Enum):
     """Types of baselines available from `/api/runs/{run_id}` in the
     `candidate_baseline_runs` field.
@@ -41,8 +23,7 @@ class BaselineRunCandidates(Enum):
 
 
 class GetConbenchZComparisonForRunsStep(AlertPipelineStep):
-    (
-        """An ``AlertPipeline`` step to get information from Conbench comparing run(s) to
+    """An ``AlertPipeline`` step to get information from Conbench comparing run(s) to
     their baselines, using a z-score threshold. This is always the first step of the
     pipeline.
 
@@ -68,9 +49,21 @@ class GetConbenchZComparisonForRunsStep(AlertPipelineStep):
     FullComparisonInfo
         Information about each run associated with the contender commit, and a
         comparison to its baseline run if that exists.
+
+    Notes
+    -----
+    Environment variables
+    ~~~~~~~~~~~~~~~~~~~~~
+    ``CONBENCH_URL``
+        The URL of the Conbench server. Only required if ``conbench_client`` is not
+        provided.
+    ``CONBENCH_EMAIL``
+        The email to use for Conbench login. Only required if ``conbench_client`` is not
+        provided and the server is private.
+    ``CONBENCH_PASSWORD``
+        The password to use for Conbench login. Only required if ``conbench_client`` is
+        not provided and the server is private.
     """
-        + CONBENCH_ENV_VAR_HELP
-    )
 
     def __init__(
         self,
@@ -135,8 +128,7 @@ class GetConbenchZComparisonForRunsStep(AlertPipelineStep):
 
 
 class GetConbenchZComparisonStep(GetConbenchZComparisonForRunsStep):
-    (
-        """An ``AlertPipeline`` step to get information from Conbench comparing the runs on
+    """An ``AlertPipeline`` step to get information from Conbench comparing the runs on
     a contender commit to their baselines, using a z-score threshold. This is always the
     first step of the pipeline.
 
@@ -164,9 +156,21 @@ class GetConbenchZComparisonStep(GetConbenchZComparisonForRunsStep):
     FullComparisonInfo
         Information about each run associated with the contender commit, and a
         comparison to its baseline run if that exists.
+
+    Notes
+    -----
+    Environment variables
+    ~~~~~~~~~~~~~~~~~~~~~
+    ``CONBENCH_URL``
+        The URL of the Conbench server. Only required if ``conbench_client`` is not
+        provided.
+    ``CONBENCH_EMAIL``
+        The email to use for Conbench login. Only required if ``conbench_client`` is not
+        provided and the server is private.
+    ``CONBENCH_PASSWORD``
+        The password to use for Conbench login. Only required if ``conbench_client`` is
+        not provided and the server is private.
     """
-        + CONBENCH_ENV_VAR_HELP
-    )
 
     def __init__(
         self,

--- a/benchalerts/benchalerts/pipeline_steps/github.py
+++ b/benchalerts/benchalerts/pipeline_steps/github.py
@@ -18,7 +18,8 @@ from ..message_formatting import (
 
 class GitHubCheckStep(AlertPipelineStep):
     """An ``AlertPipeline`` step to update a GitHub Check on a commit on GitHub, based
-    on information collected in a previously-run ``GetConbenchZComparisonStep``.
+    on information collected in a previously-run ``GetConbenchZComparisonStep`` or
+    ``GetConbenchZComparisonForRunsStep``.
 
     You must use GitHub App authentication to use this step.
 
@@ -31,11 +32,14 @@ class GitHubCheckStep(AlertPipelineStep):
         A GitHubRepoClient instance. Either provide this or ``repo``.
     commit_hash
         The commit hash to update. Default is to use the same one that was analyzed in
-        the GetConbenchZComparisonStep earlier in the pipeline.
+        the ``GetConbenchZComparisonStep`` earlier in the pipeline. If
+        ``GetConbenchZComparisonForRunsStep`` is used because the contender lacks commit
+        metadata, ``commit_hash`` must be provided.
     comparison_step_name
-        The name of the ``GetConbenchZComparisonStep`` that ran earlier in the pipeline.
-        Defaults to "GetConbenchZComparisonStep" (which was the default if no name was
-        given to that step).
+        The name of the ``GetConbenchZComparisonStep`` or
+        ``GetConbenchZComparisonForRunsStep`` that ran earlier in the pipeline.
+        Defaults to "GetConbenchZComparisonStep" (which was the default for that step if
+        no name was given to that step).
     step_name
         The name for this step. If not given, will default to this class's name.
 
@@ -44,7 +48,8 @@ class GitHubCheckStep(AlertPipelineStep):
     dict
         The response body from the GitHub HTTP API as a dict.
     FullComparisonInfo
-        The FullComparisonInfo object that the GetConbenchZComparisonStep output.
+        The ``FullComparisonInfo`` object that the ``GetConbenchZComparisonStep`` or
+        ``GetConbenchZComparisonForRunsStep`` output.
 
     Notes
     -----
@@ -129,7 +134,8 @@ class GitHubCheckStep(AlertPipelineStep):
 
 class GitHubStatusStep(AlertPipelineStep):
     """An ``AlertPipeline`` step to update a GitHub Status on a commit on GitHub, based
-    on information collected in a previously-run ``GetConbenchZComparisonStep``.
+    on information collected in a previously-run ``GetConbenchZComparisonStep`` or
+    ``GetConbenchZComparisonForRunsStep``.
 
     Parameters
     ----------
@@ -140,11 +146,14 @@ class GitHubStatusStep(AlertPipelineStep):
         A GitHubRepoClient instance. Either provide this or ``repo``.
     commit_hash
         The commit hash to update. Default is to use the same one that was analyzed in
-        the GetConbenchZComparisonStep earlier in the pipeline.
+        the ``GetConbenchZComparisonStep`` earlier in the pipeline. If
+        ``GetConbenchZComparisonForRunsStep`` is used because the contender lacks commit
+        metadata, ``commit_hash`` must be provided.
     comparison_step_name
-        The name of the ``GetConbenchZComparisonStep`` that ran earlier in the pipeline.
-        Defaults to "GetConbenchZComparisonStep" (which was the default if no name was
-        given to that step).
+        The name of the ``GetConbenchZComparisonStep`` or
+        ``GetConbenchZComparisonForRunsStep`` that ran earlier in the pipeline.
+        Defaults to "GetConbenchZComparisonStep" (which was the default for that step if
+        no name was given to that step).
     step_name
         The name for this step. If not given, will default to this class's name.
 

--- a/benchalerts/benchalerts/pipeline_steps/github.py
+++ b/benchalerts/benchalerts/pipeline_steps/github.py
@@ -25,6 +25,11 @@ class GitHubCheckStep(AlertPipelineStep):
 
     Parameters
     ----------
+    comparison_step_name
+        The name of the ``GetConbenchZComparisonStep`` or
+        ``GetConbenchZComparisonForRunsStep`` that ran earlier in the pipeline. If
+        unspecified in that step, it defaults to the name of the step class, e.g.
+        ``"GetConbenchZComparisonStep"``.
     repo
         The repo name to post the status to, in the form "owner/repo". Either provide
         this or ``github_client``.
@@ -35,11 +40,6 @@ class GitHubCheckStep(AlertPipelineStep):
         the ``GetConbenchZComparisonStep`` earlier in the pipeline. If
         ``GetConbenchZComparisonForRunsStep`` is used because the contender lacks commit
         metadata, ``commit_hash`` must be provided.
-    comparison_step_name
-        The name of the ``GetConbenchZComparisonStep`` or
-        ``GetConbenchZComparisonForRunsStep`` that ran earlier in the pipeline.
-        Defaults to "GetConbenchZComparisonStep" (which was the default for that step if
-        no name was given to that step).
     step_name
         The name for this step. If not given, will default to this class's name.
 
@@ -67,10 +67,10 @@ class GitHubCheckStep(AlertPipelineStep):
 
     def __init__(
         self,
+        comparison_step_name: str,
         repo: Optional[str] = None,
         github_client: Optional[GitHubRepoClient] = None,
         commit_hash: Optional[str] = None,
-        comparison_step_name: str = "GetConbenchZComparisonStep",
         step_name: Optional[str] = None,
     ) -> None:
         super().__init__(step_name=step_name)
@@ -139,6 +139,11 @@ class GitHubStatusStep(AlertPipelineStep):
 
     Parameters
     ----------
+    comparison_step_name
+        The name of the ``GetConbenchZComparisonStep`` or
+        ``GetConbenchZComparisonForRunsStep`` that ran earlier in the pipeline.If
+        unspecified in that step, it defaults to the name of the step class, e.g.
+        ``"GetConbenchZComparisonStep"``.
     repo
         The repo name to post the status to, in the form "owner/repo". Either provide
         this or ``github_client``.
@@ -149,11 +154,6 @@ class GitHubStatusStep(AlertPipelineStep):
         the ``GetConbenchZComparisonStep`` earlier in the pipeline. If
         ``GetConbenchZComparisonForRunsStep`` is used because the contender lacks commit
         metadata, ``commit_hash`` must be provided.
-    comparison_step_name
-        The name of the ``GetConbenchZComparisonStep`` or
-        ``GetConbenchZComparisonForRunsStep`` that ran earlier in the pipeline.
-        Defaults to "GetConbenchZComparisonStep" (which was the default for that step if
-        no name was given to that step).
     step_name
         The name for this step. If not given, will default to this class's name.
 
@@ -183,10 +183,10 @@ class GitHubStatusStep(AlertPipelineStep):
 
     def __init__(
         self,
+        comparison_step_name: str,
         repo: Optional[str] = None,
         github_client: Optional[GitHubRepoClient] = None,
         commit_hash: Optional[str] = None,
-        comparison_step_name: str = "GetConbenchZComparisonStep",
         step_name: Optional[str] = None,
     ) -> None:
         super().__init__(step_name=step_name)

--- a/benchalerts/tests/integration_tests/test_alert_pipeline.py
+++ b/benchalerts/tests/integration_tests/test_alert_pipeline.py
@@ -76,13 +76,13 @@ def test_alert_pipeline(monkeypatch: pytest.MonkeyPatch, github_auth: str):
     pipeline_steps = [
         steps.GetConbenchZComparisonStep(
             commit_hash=velox_commit,
-            baseline_run_type=steps.BaselineRunCandidates.fork_point,
+            baseline_run_type=steps.BaselineRunCandidates.parent,
             z_score_threshold=None,
             step_name="z_none",
         ),
         steps.GetConbenchZComparisonStep(
             commit_hash=velox_commit,
-            baseline_run_type=steps.BaselineRunCandidates.fork_point,
+            baseline_run_type=steps.BaselineRunCandidates.parent,
             z_score_threshold=500,
             step_name="z_500",
         ),

--- a/benchalerts/tests/integration_tests/test_alert_pipeline.py
+++ b/benchalerts/tests/integration_tests/test_alert_pipeline.py
@@ -75,10 +75,16 @@ def test_alert_pipeline(monkeypatch: pytest.MonkeyPatch, github_auth: str):
     # now a real pipeline
     pipeline_steps = [
         steps.GetConbenchZComparisonStep(
-            commit_hash=velox_commit, z_score_threshold=None, step_name="z_none"
+            commit_hash=velox_commit,
+            baseline_run_type=steps.conbench.BaselineRunCandidates.fork_point,
+            z_score_threshold=None,
+            step_name="z_none",
         ),
         steps.GetConbenchZComparisonStep(
-            commit_hash=velox_commit, z_score_threshold=500, step_name="z_500"
+            commit_hash=velox_commit,
+            baseline_run_type=steps.conbench.BaselineRunCandidates.fork_point,
+            z_score_threshold=500,
+            step_name="z_500",
         ),
         steps.GitHubStatusStep(
             repo=test_status_repo,

--- a/benchalerts/tests/integration_tests/test_alert_pipeline.py
+++ b/benchalerts/tests/integration_tests/test_alert_pipeline.py
@@ -22,7 +22,6 @@ import benchalerts.pipeline_steps as steps
 from benchalerts import AlertPipeline
 
 
-@pytest.skip("Will fail until #1078 is deployed to these conbench instances")
 @pytest.mark.parametrize("github_auth", ["pat", "app"], indirect=True)
 def test_alert_pipeline(monkeypatch: pytest.MonkeyPatch, github_auth: str):
     """While this test is running, you can watch
@@ -107,6 +106,7 @@ def test_alert_pipeline(monkeypatch: pytest.MonkeyPatch, github_auth: str):
             )
 
     pipeline = AlertPipeline(pipeline_steps)
+    pytest.skip("Will fail until #1078 is deployed to these conbench instances")
     outputs = pipeline.run_pipeline()
 
     assert outputs["GitHubStatusStep"]["state"] == "success"

--- a/benchalerts/tests/integration_tests/test_alert_pipeline.py
+++ b/benchalerts/tests/integration_tests/test_alert_pipeline.py
@@ -22,6 +22,7 @@ import benchalerts.pipeline_steps as steps
 from benchalerts import AlertPipeline
 
 
+@pytest.skip("Will fail until #1078 is deployed to these conbench instances")
 @pytest.mark.parametrize("github_auth", ["pat", "app"], indirect=True)
 def test_alert_pipeline(monkeypatch: pytest.MonkeyPatch, github_auth: str):
     """While this test is running, you can watch

--- a/benchalerts/tests/integration_tests/test_alert_pipeline.py
+++ b/benchalerts/tests/integration_tests/test_alert_pipeline.py
@@ -76,13 +76,13 @@ def test_alert_pipeline(monkeypatch: pytest.MonkeyPatch, github_auth: str):
     pipeline_steps = [
         steps.GetConbenchZComparisonStep(
             commit_hash=velox_commit,
-            baseline_run_type=steps.conbench.BaselineRunCandidates.fork_point,
+            baseline_run_type=steps.BaselineRunCandidates.fork_point,
             z_score_threshold=None,
             step_name="z_none",
         ),
         steps.GetConbenchZComparisonStep(
             commit_hash=velox_commit,
-            baseline_run_type=steps.conbench.BaselineRunCandidates.fork_point,
+            baseline_run_type=steps.BaselineRunCandidates.fork_point,
             z_score_threshold=500,
             step_name="z_500",
         ),

--- a/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
+++ b/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
@@ -23,7 +23,6 @@ from benchalerts.pipeline_steps.conbench import (
 ConbenchClient = LegacyConbenchClient
 
 
-@pytest.skip("Will fail until #1078 is deployed to these conbench instances")
 @pytest.mark.parametrize(
     ["conbench_url", "commit", "baseline_type", "expected_len", "expected_bip"],
     [
@@ -80,6 +79,7 @@ def test_GetConbenchZComparisonStep(
         baseline_run_type=baseline_type,
         conbench_client=cb,
     )
+    pytest.skip("Will fail until #1078 is deployed to these conbench instances")
     full_comparison = step.run_step(previous_outputs={})
     assert len(full_comparison.run_comparisons) == expected_len
     for run in full_comparison.run_comparisons:

--- a/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
+++ b/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
@@ -24,7 +24,7 @@ ConbenchClient = LegacyConbenchClient
 
 
 @pytest.mark.parametrize(
-    ["conbench_url", "commit", "baseline_type", "expected_len", "expected_bip"],
+    ["conbench_url", "commit_hash", "baseline_type", "expected_len", "expected_bip"],
     [
         # baseline is parent
         (

--- a/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
+++ b/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
@@ -15,7 +15,10 @@
 import pytest
 from benchclients.conbench import LegacyConbenchClient
 
-from benchalerts.pipeline_steps.conbench import GetConbenchZComparisonStep
+from benchalerts.pipeline_steps.conbench import (
+    BaselineRunCandidates,
+    GetConbenchZComparisonStep,
+)
 
 ConbenchClient = LegacyConbenchClient
 
@@ -62,7 +65,11 @@ def test_GetConbenchZComparisonStep(
         )
     monkeypatch.setenv("CONBENCH_URL", conbench_url)
     cb = ConbenchClient()
-    step = GetConbenchZComparisonStep(commit_hash=commit, conbench_client=cb)
+    step = GetConbenchZComparisonStep(
+        commit_hash=commit,
+        baseline_run_type=BaselineRunCandidates.parent,
+        conbench_client=cb,
+    )
     full_comparison = step.run_step(previous_outputs={})
     assert len(full_comparison.run_comparisons) == expected_len
     for run in full_comparison.run_comparisons:

--- a/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
+++ b/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
@@ -46,7 +46,7 @@ ConbenchClient = LegacyConbenchClient
         (
             "https://velox-conbench.voltrondata.run",
             "b74e7045fade737e39b0f9867bc8b8b23fe00b78",
-            BaselineRunCandidates.head_of_default,
+            BaselineRunCandidates.latest_default,
             1,
             None,
         ),

--- a/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
+++ b/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
@@ -62,11 +62,11 @@ ConbenchClient = LegacyConbenchClient
 )
 def test_GetConbenchZComparisonStep(
     monkeypatch: pytest.MonkeyPatch,
-    conbench_url,
-    commit,
-    baseline_type,
-    expected_len,
-    expected_bip,
+    conbench_url: str,
+    commit_hash: str,
+    baseline_type: BaselineRunCandidates,
+    expected_len: int,
+    expected_bip: bool,
 ):
     if "ursa" in conbench_url:
         pytest.skip(
@@ -75,7 +75,7 @@ def test_GetConbenchZComparisonStep(
     monkeypatch.setenv("CONBENCH_URL", conbench_url)
     cb = ConbenchClient()
     step = GetConbenchZComparisonStep(
-        commit_hash=commit,
+        commit_hash=commit_hash,
         baseline_run_type=baseline_type,
         conbench_client=cb,
     )

--- a/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
+++ b/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
@@ -23,6 +23,7 @@ from benchalerts.pipeline_steps.conbench import (
 ConbenchClient = LegacyConbenchClient
 
 
+@pytest.skip("Will fail until #1078 is deployed to these conbench instances")
 @pytest.mark.parametrize(
     ["conbench_url", "commit", "baseline_type", "expected_len", "expected_bip"],
     [

--- a/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
+++ b/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
@@ -24,12 +24,13 @@ ConbenchClient = LegacyConbenchClient
 
 
 @pytest.mark.parametrize(
-    ["conbench_url", "commit", "expected_len", "expected_bip"],
+    ["conbench_url", "commit", "baseline_type", "expected_len", "expected_bip"],
     [
         # baseline is parent
         (
             "https://conbench.ursa.dev/",
             "bc7de406564fa7b2bcb9bf055cbaba31ca0ca124",
+            BaselineRunCandidates.parent,
             8,
             True,
         ),
@@ -37,6 +38,7 @@ ConbenchClient = LegacyConbenchClient
         (
             "https://velox-conbench.voltrondata.run",
             "2319922d288c519baa3bffe59c0bedbcb6c827cd",
+            BaselineRunCandidates.fork_point,
             1,
             False,
         ),
@@ -44,6 +46,7 @@ ConbenchClient = LegacyConbenchClient
         (
             "https://velox-conbench.voltrondata.run",
             "b74e7045fade737e39b0f9867bc8b8b23fe00b78",
+            BaselineRunCandidates.head_of_default,
             1,
             None,
         ),
@@ -51,13 +54,19 @@ ConbenchClient = LegacyConbenchClient
         (
             "https://conbench.ursa.dev",
             "9fa34df27eb1445ac11b0ab0298d421b04be80f7",
+            BaselineRunCandidates.parent,
             7,
             True,
         ),
     ],
 )
 def test_GetConbenchZComparisonStep(
-    monkeypatch: pytest.MonkeyPatch, conbench_url, commit, expected_len, expected_bip
+    monkeypatch: pytest.MonkeyPatch,
+    conbench_url,
+    commit,
+    baseline_type,
+    expected_len,
+    expected_bip,
 ):
     if "ursa" in conbench_url:
         pytest.skip(
@@ -67,7 +76,7 @@ def test_GetConbenchZComparisonStep(
     cb = ConbenchClient()
     step = GetConbenchZComparisonStep(
         commit_hash=commit,
-        baseline_run_type=BaselineRunCandidates.parent,
+        baseline_run_type=baseline_type,
         conbench_client=cb,
     )
     full_comparison = step.run_step(previous_outputs={})

--- a/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_contender_wo_base.json
+++ b/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_contender_wo_base.json
@@ -51,7 +51,7 @@
                 "commits_skipped": null,
                 "error": "the contender run is on the default branch"
             },
-            "head_of_default": {
+            "latest_default": {
                 "baseline_run_id": null,
                 "commits_skipped": null,
                 "error": "the contender run is on the default branch"

--- a/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_contender_wo_base.json
+++ b/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_contender_wo_base.json
@@ -45,6 +45,23 @@
             "list": "http://localhost/api/runs/",
             "self": "http://localhost/api/runs/some-run-uuid-1/"
         },
+        "candidate_baseline_runs": {
+            "fork_point": {
+                "baseline_run_id": null,
+                "commits_skipped": null,
+                "error": "the contender run is on the default branch"
+            },
+            "head_of_default": {
+                "baseline_run_id": null,
+                "commits_skipped": null,
+                "error": "the contender run is on the default branch"
+            },
+            "parent": {
+                "baseline_run_id": null,
+                "commits_skipped": [],
+                "error": "the contender run is the first commit"
+            }
+        },
         "name": "some run name",
         "reason": "some run reason",
         "timestamp": "2021-02-04T17:22:05.225583"

--- a/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_sha_abc.json
+++ b/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_sha_abc.json
@@ -45,6 +45,23 @@
                 "list": "http://localhost/api/runs/",
                 "self": "http://localhost/api/runs/some-run-uuid-1/"
             },
+            "candidate_baseline_runs": {
+                "fork_point": {
+                    "baseline_run_id": null,
+                    "commits_skipped": null,
+                    "error": "the contender run is on the default branch"
+                },
+                "head_of_default": {
+                    "baseline_run_id": null,
+                    "commits_skipped": null,
+                    "error": "the contender run is on the default branch"
+                },
+                "parent": {
+                    "baseline_run_id": null,
+                    "commits_skipped": [],
+                    "error": "the contender run is the first commit"
+                }
+            },
             "name": "some run name",
             "reason": "some run reason",
             "timestamp": "2021-02-04T17:22:05.225583"

--- a/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_sha_abc.json
+++ b/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_sha_abc.json
@@ -51,7 +51,7 @@
                     "commits_skipped": null,
                     "error": "the contender run is on the default branch"
                 },
-                "head_of_default": {
+                "latest_default": {
                     "baseline_run_id": null,
                     "commits_skipped": null,
                     "error": "the contender run is on the default branch"

--- a/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_sha_no_baseline.json
+++ b/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_sha_no_baseline.json
@@ -45,6 +45,23 @@
                 "list": "http://localhost/api/runs/",
                 "self": "http://localhost/api/runs/some-run-uuid-1/"
             },
+            "candidate_baseline_runs": {
+                "fork_point": {
+                    "baseline_run_id": null,
+                    "commits_skipped": null,
+                    "error": "the contender run is on the default branch"
+                },
+                "head_of_default": {
+                    "baseline_run_id": null,
+                    "commits_skipped": null,
+                    "error": "the contender run is on the default branch"
+                },
+                "parent": {
+                    "baseline_run_id": null,
+                    "commits_skipped": [],
+                    "error": "the contender run is the first commit"
+                }
+            },
             "name": "some run name",
             "reason": "some run reason",
             "timestamp": "2021-02-04T17:22:05.225583"

--- a/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_sha_no_baseline.json
+++ b/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_sha_no_baseline.json
@@ -51,7 +51,7 @@
                     "commits_skipped": null,
                     "error": "the contender run is on the default branch"
                 },
-                "head_of_default": {
+                "latest_default": {
                     "baseline_run_id": null,
                     "commits_skipped": null,
                     "error": "the contender run is on the default branch"

--- a/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_some_baseline.json
+++ b/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_some_baseline.json
@@ -51,7 +51,7 @@
                 "commits_skipped": [],
                 "error": null
             },
-            "head_of_default": {
+            "latest_default": {
                 "baseline_run_id": "another_baseline",
                 "commits_skipped": [],
                 "error": null

--- a/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_some_baseline.json
+++ b/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_some_baseline.json
@@ -45,6 +45,23 @@
             "list": "http://localhost/api/runs/",
             "self": "http://localhost/api/runs/some-run-uuid-1/"
         },
+        "candidate_baseline_runs": {
+            "fork_point": {
+                "baseline_run_id": "another_baseline",
+                "commits_skipped": [],
+                "error": null
+            },
+            "head_of_default": {
+                "baseline_run_id": "another_baseline",
+                "commits_skipped": [],
+                "error": null
+            },
+            "parent": {
+                "baseline_run_id": "another_baseline",
+                "commits_skipped": [],
+                "error": null
+            }
+        },
         "name": "some run name",
         "reason": "some run reason",
         "timestamp": "2021-02-04T17:22:05.225583"

--- a/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_some_contender.json
+++ b/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_some_contender.json
@@ -45,6 +45,23 @@
             "list": "http://localhost/api/runs/",
             "self": "http://localhost/api/runs/some-run-uuid-1/"
         },
+        "candidate_baseline_runs": {
+            "fork_point": {
+                "baseline_run_id": "some_baseline",
+                "commits_skipped": [],
+                "error": null
+            },
+            "head_of_default": {
+                "baseline_run_id": "some_baseline",
+                "commits_skipped": [],
+                "error": null
+            },
+            "parent": {
+                "baseline_run_id": "some_baseline",
+                "commits_skipped": [],
+                "error": null
+            }
+        },
         "name": "some run name",
         "reason": "some run reason",
         "timestamp": "2021-02-04T17:22:05.225583"

--- a/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_some_contender.json
+++ b/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_some_contender.json
@@ -51,7 +51,7 @@
                 "commits_skipped": [],
                 "error": null
             },
-            "head_of_default": {
+            "latest_default": {
                 "baseline_run_id": "some_baseline",
                 "commits_skipped": [],
                 "error": null

--- a/benchalerts/tests/unit_tests/test_alert_pipeline.py
+++ b/benchalerts/tests/unit_tests/test_alert_pipeline.py
@@ -25,12 +25,14 @@ def test_reasonable_pipeline(conbench_env, github_auth):
         steps=[
             steps.GetConbenchZComparisonStep(
                 commit_hash=commit_hash,
+                baseline_run_type=steps.BaselineRunCandidates.fork_point,
                 z_score_threshold=None,
                 conbench_client=conbench_client,
                 step_name="z_none",
             ),
             steps.GetConbenchZComparisonStep(
                 commit_hash=commit_hash,
+                baseline_run_type=steps.BaselineRunCandidates.fork_point,
                 z_score_threshold=500,
                 conbench_client=conbench_client,
                 step_name="z_500",

--- a/benchalerts/tests/unit_tests/test_pipeline_steps/test_conbench.py
+++ b/benchalerts/tests/unit_tests/test_pipeline_steps/test_conbench.py
@@ -39,6 +39,7 @@ def test_runs_comparison_fails_when_no_baseline(
 def test_GetConbenchZComparisonStep(conbench_env):
     step = GetConbenchZComparisonStep(
         commit_hash="abc",
+        baseline_run_type=BaselineRunCandidates.fork_point,
         z_score_threshold=500,
         conbench_client=ConbenchClient(adapter=MockAdapter()),
     )
@@ -49,6 +50,7 @@ def test_GetConbenchZComparisonStep(conbench_env):
 def test_comparison_fails_when_no_runs(conbench_env):
     step = GetConbenchZComparisonStep(
         commit_hash="no_runs",
+        baseline_run_type=BaselineRunCandidates.fork_point,
         conbench_client=ConbenchClient(adapter=MockAdapter()),
     )
     with pytest.raises(ValueError, match="runs"):
@@ -60,8 +62,9 @@ def test_comparison_warns_when_no_baseline(
 ):
     step = GetConbenchZComparisonStep(
         commit_hash="no_baseline",
+        baseline_run_type=BaselineRunCandidates.fork_point,
         conbench_client=ConbenchClient(adapter=MockAdapter()),
     )
     res = step.run_step(previous_outputs={})
     assert res
-    assert "could not find a baseline run" in caplog.text
+    assert "the contender run is on the default branch" in caplog.text

--- a/benchalerts/tests/unit_tests/test_pipeline_steps/test_conbench.py
+++ b/benchalerts/tests/unit_tests/test_pipeline_steps/test_conbench.py
@@ -1,11 +1,39 @@
 import pytest
 from benchclients.conbench import LegacyConbenchClient
 
-from benchalerts.pipeline_steps.conbench import GetConbenchZComparisonStep
+from benchalerts.pipeline_steps.conbench import (
+    BaselineRunCandidates,
+    GetConbenchZComparisonForRunsStep,
+    GetConbenchZComparisonStep,
+)
 
 from ..mocks import MockAdapter
 
 ConbenchClient = LegacyConbenchClient
+
+
+def test_GetConbenchZComparisonForRunsStep(conbench_env):
+    step = GetConbenchZComparisonForRunsStep(
+        run_ids=["some_contender"],
+        baseline_run_type=BaselineRunCandidates.fork_point,
+        z_score_threshold=500,
+        conbench_client=ConbenchClient(adapter=MockAdapter()),
+    )
+    res = step.run_step(previous_outputs={})
+    assert res
+
+
+def test_runs_comparison_fails_when_no_baseline(
+    conbench_env, caplog: pytest.LogCaptureFixture
+):
+    step = GetConbenchZComparisonForRunsStep(
+        run_ids=["contender_wo_base"],
+        baseline_run_type=BaselineRunCandidates.fork_point,
+        conbench_client=ConbenchClient(adapter=MockAdapter()),
+    )
+    res = step.run_step(previous_outputs={})
+    assert res
+    assert "the contender run is on the default branch" in caplog.text
 
 
 def test_GetConbenchZComparisonStep(conbench_env):


### PR DESCRIPTION
Closes #1031. Adds a `GetConbenchZComparisonForRunsStep` as a parent class of `GetConbenchComparisonStep` which operates on a list of run IDs instead of a commit hash.

~As of writing, the new class operates on the new results from the `/api/runs/{run_id}` endpoint with the `candidate_baseline_runs` dict, while the behavior of the old class is completely unchanged. Since versions are pinned everywhere, we probably do want to change the existing class to use the new data (and more of the same code), but for review and testing I haven't changed it yet.~

Both classes now use the new `candidate_baseline_runs` dict from the `/api/runs/{run_id}` endpoint, so this version will depend on those changes being deployed to whatever server they're being used with. Since versions are pinned, this update shouldn't be complicated.