### PR TITLE
benchalerts: add intro to PR comment

### DIFF
--- a/benchalerts/benchalerts/message_formatting.py
+++ b/benchalerts/benchalerts/message_formatting.py
@@ -140,7 +140,16 @@ def pr_comment_link_to_check(
     full_comparison: FullComparisonInfo, check_link: str
 ) -> str:
     """Generate a GitHub PR comment that summarizes and links to a GitHub Check."""
-    comment = ""
+    s = _Pluralizer(full_comparison.run_comparisons).s
+    comment = (
+        _clean(
+            f"""
+            Conbench analyzed the {len(full_comparison.run_comparisons)} benchmark
+            run{s} on commit `{full_comparison.commit_hash[:8]}`.
+            """
+        )
+        + "\n\n"
+    )
 
     if full_comparison.benchmarks_with_errors:
         pluralizer = _Pluralizer(full_comparison.benchmarks_with_errors)

--- a/benchalerts/tests/integration_tests/test_alert_pipeline.py
+++ b/benchalerts/tests/integration_tests/test_alert_pipeline.py
@@ -109,7 +109,9 @@ def test_alert_pipeline(monkeypatch: pytest.MonkeyPatch, github_auth: str):
         assert outputs["GitHubStatusStep"]["creator"]["type"] == "Bot"
         assert outputs["GitHubCheckStep"][0]["conclusion"] == "failure"
         if not os.getenv("CI"):
-            expected_comment = """There was 1 benchmark result indicating a performance regression:
+            expected_comment = """Conbench analyzed the 1 benchmark run on commit `c76715c9`.
+
+There was 1 benchmark result indicating a performance regression:
 
 - Commit Run at [2023-02-28 18:08:51Z](http://velox-conbench.voltrondata.run/compare/runs/GHA-4273957972-1...GHA-4296026775-1/)
   - [flatMap](http://velox-conbench.voltrondata.run/benchmarks/ff7a1a86df5a4d56b6dbfb006c13c638)

--- a/benchalerts/tests/unit_tests/expected_md/comment_errors_baselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_errors_baselines.md
@@ -1,3 +1,5 @@
+Conbench analyzed the 3 benchmark runs on commit `abc`.
+
 There were 3 benchmark results with an error:
 
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_contender...some_contender/)

--- a/benchalerts/tests/unit_tests/expected_md/comment_errors_nobaselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_errors_nobaselines.md
@@ -1,3 +1,5 @@
+Conbench analyzed the 2 benchmark runs on commit `no_basel`.
+
 There were 2 benchmark results with an error:
 
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)

--- a/benchalerts/tests/unit_tests/expected_md/comment_noerrors_nobaselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_noerrors_nobaselines.md
@@ -1,3 +1,5 @@
+Conbench analyzed the 2 benchmark runs on commit `no_basel`.
+
 There weren't enough matching historic benchmark runs to make a call on whether there were regressions.
 
 The [full Conbench report](https://github.com/github/hello-world/runs/4) for commit `no_basel` has more details.

--- a/benchalerts/tests/unit_tests/expected_md/comment_noregressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_noregressions.md
@@ -1,3 +1,5 @@
+Conbench analyzed the 2 benchmark runs on commit `abc`.
+
 There were no benchmark performance regressions. 🎉
 
 The [full Conbench report](https://github.com/github/hello-world/runs/4) for commit `abc` has more details.

--- a/benchalerts/tests/unit_tests/expected_md/comment_regressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_regressions.md
@@ -1,3 +1,5 @@
+Conbench analyzed the 3 benchmark runs on commit `no_basel`.
+
 There were 2 benchmark results indicating a performance regression:
 
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_contender...some_contender/)


### PR DESCRIPTION
Fixes #1177. This adds a small intro sentence to `benchalerts` PR comments.