### PR TITLE
API: Fix typo in benchmark-results URL

### DIFF
--- a/conbench/api/results.py
+++ b/conbench/api/results.py
@@ -266,7 +266,7 @@ rule(
     methods=["GET", "POST"],
 )
 rule(
-    "/benchmark=results/<benchmark_result_id>/",
+    "/benchmark-results/<benchmark_result_id>/",
     view_func=benchmark_entity_view,
     methods=["GET", "DELETE", "PUT"],
 )


### PR DESCRIPTION
Literally a 1-character PR to fix a typo in the `/api/benchmark-results/<benchmark_result_id>` endpoint