### PR TITLE
BMRT cache: use __slots__-based minimal typed objects instead of massive and magic SQLAlchemy-flavored objects, misc

### DIFF
--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -837,7 +837,7 @@ def get_source_for_single_benchmark_result(
         cur_run["commit"]["timestamp"]
     )
 
-    if current_benchmark_result.is_failed():
+    if current_benchmark_result.is_failed:
         return None, None
 
     dummy_hs_for_current_svs = HistorySample(

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -10,7 +10,6 @@ from conbench.app import app
 from conbench.app._endpoint import authorize_or_terminate
 from conbench.config import Config
 
-# from conbench.entities.benchmark_result import BenchmarkResult
 from conbench.job import BMRTBenchmarkResult, _cache_bmrs
 
 log = logging.getLogger(__name__)
@@ -22,7 +21,7 @@ def list_benchmarks() -> str:
     return flask.render_template(
         "c-benchmarks.html",
         # benchmarks_by_name=benchmarks_by_name,
-        benchmarks_by_name=_cache_bmrs["by_benchmark_name"],
+        benchmarks_by_name=_cache_bmrs["by_benchmark_nameresults_by_case"],
         benchmark_result_count=len(_cache_bmrs["by_id"]),
         bmr_cache_meta=_cache_bmrs["meta"],
         application=Config.APPLICATION_NAME,
@@ -55,15 +54,14 @@ def show_benchmark_cases(bname: str) -> str:
     log.info("building hardware_count_per_case took %.3f s", time.monotonic() - t0)
 
     last_result_per_case_id: Dict[str, BMRTBenchmarkResult] = {}
-    context_count_per_case_id = {}
+
+    context_count_per_case_id: Dict[str, int] = {}
     for case_id, results in results_by_case_id.items():
         context_count_per_case_id[case_id] = len(set([r.context_id for r in results]))
         last_result_per_case_id[case_id] = max(results, key=lambda r: r.started_at)
 
     return flask.render_template(
         "c-benchmark-cases.html",
-        # benchmarks_by_name=benchmarks_by_name,
-        # benchmarks_results=results,
         benchmark_name=bname,
         bmr_cache_meta=_cache_bmrs["meta"],
         results_by_case_id=results_by_case_id,

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -20,7 +20,7 @@ def list_benchmarks() -> str:
     return flask.render_template(
         "c-benchmarks.html",
         # benchmarks_by_name=benchmarks_by_name,
-        benchmarks_by_name=_cache_bmrs["by_benchmark_nameresults_by_case"],
+        benchmarks_by_name=_cache_bmrs["by_benchmark_name"],
         benchmark_result_count=len(_cache_bmrs["by_id"]),
         bmr_cache_meta=_cache_bmrs["meta"],
         application=Config.APPLICATION_NAME,

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -9,7 +9,6 @@ import orjson
 from conbench.app import app
 from conbench.app._endpoint import authorize_or_terminate
 from conbench.config import Config
-
 from conbench.job import BMRTBenchmarkResult, _cache_bmrs
 
 log = logging.getLogger(__name__)

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 import math
 import statistics
@@ -414,7 +415,7 @@ class BenchmarkResult(Base, EntityMixin):
         - https://github.com/conbench/conbench/issues/640
         - https://github.com/conbench/conbench/issues/530
         """
-        if self.is_failed():
+        if self.is_failed:
             return math.nan
 
         if self.mean is None:

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -429,6 +429,26 @@ class BenchmarkResult(Base, EntityMixin):
 
         return float(self.mean)
 
+    @functools.cached_property
+    def measurements(self) -> List[float]:
+        """
+        Return list of floats. Each item is guaranteed to not be NaN. The
+        returned list may however be empty (for all failed results).
+
+        This is an experiment for a hopefully valuable abstraction. I think we
+        maybe want to make users of this class not use the `.data` property
+        anymore.
+
+        We also may want to instruct SQLAlchemy to return numbers as floats
+        directly.
+        """
+        values = []
+        if not self.is_failed:
+            assert self.data is not None
+            values = [float(d) for d in self.data]
+
+        return values
+
     @property
     def ui_mean_and_uncertainty(self) -> str:
         """

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -345,6 +345,7 @@ class BenchmarkResult(Base, EntityMixin):
             },
         }
 
+    @functools.cached_property
     def is_failed(self):
         """
         Return True if this BenchmarkResult is considered to be 'failed' /

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -68,8 +68,9 @@ class BenchmarkResult(Base, EntityMixin):
     # performed on demand.
     run: Mapped[Run] = relationship("Run", lazy="select", back_populates="results")
 
-    # These can be empty lists. An item in the list is of type float, which
-    # includes `math.nan` as valid value.
+    # `data` holds the numeric values derived from N repetitions of the same
+    # measurement (experiment). These can be empty lists. An item in the list
+    # is of type float, which includes `math.nan` as valid value.
     data: Mapped[Optional[List[Decimal]]] = Nullable(
         postgresql.ARRAY(s.Numeric), default=[]
     )
@@ -386,8 +387,11 @@ class BenchmarkResult(Base, EntityMixin):
     def _single_value_summary(self) -> float:
         """
         Return a single numeric value summarizing the collection of data points
-        D associated with this benchmark result. Currently static (mean), can
-        be dynamic in the future.
+        D associated with this benchmark result.
+
+        Return `math.nan` if this result is failed.
+
+        Summary: currently static (mean), can be dynamic in the future.
 
         Assumption: each non-errored benchmark result (self.is_failed() returns
         False) is guaranteed to have at least one data point.

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -355,15 +355,12 @@ class BenchmarkResult(Base, EntityMixin):
         across components.
         """
         if self.data is None:
-            log.info("data is none")
             return True
 
         if do_iteration_samples_look_like_error(self.data):
-            log.info("iterations look like err")
             return True
 
         if self.error is not None:
-            log.info("selferr is not none")
             return True
 
         return False

--- a/conbench/entities/context.py
+++ b/conbench/entities/context.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import flask as f
 import sqlalchemy as s
 from sqlalchemy.dialects import postgresql
@@ -10,6 +12,16 @@ class Context(Base, EntityMixin["Context"]):
     __tablename__ = "context"
     id: Mapped[str] = NotNull(s.String(50), primary_key=True, default=genprimkey)
     tags: Mapped[dict] = NotNull(postgresql.JSONB)
+
+    def to_dict(self) -> Dict:
+        """
+        Be sure to return `self.tags` directly so that we do not need to keep a
+        huge amount of copies of this in memory (this may be shared across many
+        benchmark result objects). This here is basically just an indirection
+        from the name "tags" to "to_dict()" which I think is more intuitive to
+        work with. Think "context dictionary".
+        """
+        return self.tags
 
 
 s.Index("context_index", Context.tags, unique=True)

--- a/conbench/hacks.py
+++ b/conbench/hacks.py
@@ -3,7 +3,6 @@ from typing import Dict, List
 
 from conbench.entities.benchmark_result import BenchmarkResult
 
-
 log = logging.getLogger(__name__)
 
 

--- a/conbench/hacks.py
+++ b/conbench/hacks.py
@@ -3,12 +3,6 @@ from typing import Dict, List
 
 from conbench.entities.benchmark_result import BenchmarkResult
 
-# Note(JP): ideally this contains just a single key. I think that this here is
-# purely for display purposes, not for storing in the DB. Now that I think
-# about it: Let's keep things simple: this is part of the case permutation in
-# the database, so show it.
-#  CASE_KEYS_DO_NOT_USE_FOR_STRING = ("id", "name", "suite", "source", "dataset")
-
 
 log = logging.getLogger(__name__)
 
@@ -27,6 +21,8 @@ def get_case_kvpair_strings(tags: Dict[str, str]) -> List[str]:
     Special keys are omitted (does that make sense?)
 
     Keep those with None value.
+
+    TODO: move to different module
     """
     return [f"{k}={v}" for k, v in sorted(tags.items()) if k not in ("name")]
 
@@ -36,6 +32,8 @@ def set_display_case_permutation(bmresult: Dict | BenchmarkResult):
     Build and set a string reflecting the case permutation (specific variation
     of str/str key/value pairs, each pair reflecting a case parameter) for this
     benchmark result object.
+
+    TODO: move to different module
     """
 
     # Extract `tags` object.
@@ -85,6 +83,8 @@ def set_display_benchmark_name(bmresult):
     """
     Build and set a string reflecting the benchmark identity (the conceptual
     benchmark) for this benchmark result.
+
+    TODO: move to different module
     """
     is_api = isinstance(bmresult, dict)
     # will this next line not raise a KeyError of is_api is false?
@@ -101,6 +101,10 @@ def set_display_benchmark_name(bmresult):
 
 
 def sorted_data(benchmarks):
+    """
+    TODO: identify what this does, assess the value, and re-implement in
+    a different module.
+    """
     data = []
     for benchmark in benchmarks:
         if benchmark["error"]:
@@ -127,3 +131,70 @@ def sorted_data(benchmarks):
     new_data = sorted(new_data)
 
     return [row[1] for row in new_data]
+
+
+# Note(JP): Keeping this here because this turned out to be highly useful and
+# we want to maybe re-use that. I started with
+# https://goshippo.com/blog/measure-real-size-any-python-object/ and
+# https://stackoverflow.com/a/40880923 and then brute-forced may way through
+# Flask/SQLAlchemy special conditions. This tries to answer "How big is this
+# object" in memory? I applied it to a big dictionary which held other
+# dictionaries which held SQLAlchemy DB entity-entangled objects
+# (DeclarativeBase-derived) entangled with Flask/werkzeug-app context /
+# "request locals". My goal was to get this to count at least something. The
+# special cases below with dubious handling happen rarely, i.e. this counts the
+# majority of what matters. Note however for result interpretation you need to
+# understand some things about CPython's memory management (string interning,
+# etc). The more macroscopic view (heap size of CPython process is after all
+# showing if changes/insights are helpful or not). I am ke def get_size(obj,
+# seen=None): """Recursively finds size of objects"""
+
+#     if obj is None:
+#         return 0
+
+#     if isinstance(obj, werkzeug.local.ContextVar):
+#         return 0
+
+#     size = sys.getsizeof(obj)
+
+#     if seen is None:
+#         seen = set()
+
+#     obj_id = id(obj)
+#     if obj_id in seen:
+#         return 0
+#     # Important mark as seen *before* entering recursion to gracefully handle
+#     # self-referential objects
+#     seen.add(obj_id)
+
+#     if isinstance(obj, dict):
+#         size += sum([get_size(v, seen) for v in obj.values()])
+#         size += sum([get_size(k, seen) for k in obj.keys()])
+
+#     elif hasattr(obj, "__dict__"):
+#         try:
+#             size += get_size(obj.__dict__, seen)
+#         except RuntimeError:
+#             # handle werkzeug.local special context var protection:
+#             # https://github.com/pallets/werkzeug/blob/2.2.3/src/werkzeug/local.py
+#             log.info("ignore werkzeug RuntimeErr")
+#             return 0
+
+#     elif hasattr(obj, "__iter__") and not isinstance(obj, (str, bytes, bytearray)):
+#         if obj is None:
+#             return 0
+
+#         # from typing import _SpecialForm.
+#         if isinstance(obj, _SpecialForm):
+#             # Ignore this obj: TypeError: '_SpecialForm' object is not iterable
+#             return 0
+
+#         try:
+#             size += sum([get_size(i, seen) for i in obj])
+#         except TypeError:
+#             # Might still fail with
+#             # TypeError: 'NoneType' object is not iterable
+#             log.info("ignore not-yet-understood TypeError")
+#             seen.add(id(obj))
+#             return 0
+#     return size

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -1,17 +1,12 @@
 import dataclasses
 import logging
 import signal
-import sys
 import threading
-
-
 import time
 from collections import defaultdict
-from typing import Dict, List, Optional, Tuple, TypedDict, _SpecialForm
-
+from typing import Dict, List, Optional, Tuple, TypedDict
 
 import sqlalchemy
-
 
 import conbench.metrics
 from conbench.config import Config
@@ -172,8 +167,6 @@ def _fetch_and_cache_most_recent_results(n=0.06 * 10**6) -> None:
         # Build the textual representation of this case which should also
         # uniquely / unambiguously define/identify this specific case.
         by_case_id_dict[str(result.case_id)].append(bmr)
-
-    first_bmr = next(iter(by_id_dict))
 
     # Mutate the dictionary which is accessed by other threads, do this in a
     # quick fashion -- each of this assignments is atomic (thread-safe), but

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -1,12 +1,17 @@
 import dataclasses
 import logging
 import signal
+import sys
 import threading
+
+
 import time
 from collections import defaultdict
-from typing import Dict, List, TypedDict
+from typing import Dict, List, Optional, Tuple, TypedDict, _SpecialForm
 
-from sqlalchemy import select
+
+import sqlalchemy
+
 
 import conbench.metrics
 from conbench.config import Config
@@ -37,10 +42,36 @@ class CacheUpdateMetaInfo:
     n_results: int
 
 
+# CPython 3.10/3.11 feature:  dataclass nicely integrated with slots. __slots__
+# saves memory: prevents the automatic creation of __dict__ and __weakref__ for
+# each instance. See
+# https://docs.python.org/3/reference/datamodel.html#object.__slots__
+# https://www.trueblade.com/blogs/news/python-3-10-new-dataclass-features
+@dataclasses.dataclass(slots=True)
+class BMRTBenchmarkResult:
+    id: str
+    case_id: str
+    context_id: str
+    data: List[float]
+    mean: Optional[float]
+    unit: str
+    benchmark_name: str
+    started_at: float
+    hardware_id: str
+    hardware_name: str
+    case_text_id: str
+    context_dict: Dict
+    ui_time_started_at: str
+    ui_rel_sem: Tuple[str, str]
+    ui_hardware_short: str
+    ui_non_null_sample_count: str
+    ui_mean_and_uncertainty: str
+
+
 class CacheDict(TypedDict):
-    by_id: Dict[str, BenchmarkResult]
-    by_benchmark_name: Dict[str, List[BenchmarkResult]]
-    by_case_id: Dict[str, List[BenchmarkResult]]
+    by_id: Dict[str, BMRTBenchmarkResult]
+    by_benchmark_name: Dict[str, List[BMRTBenchmarkResult]]
+    by_case_id: Dict[str, List[BMRTBenchmarkResult]]
     meta: CacheUpdateMetaInfo
 
 
@@ -72,33 +103,77 @@ def _fetch_and_cache_most_recent_results(n=0.06 * 10**6) -> None:
 
     # Also fetch hardware from associated Run, so that result.run is in cache,
     # too, and so that result.run.hardware is a quick lookup.
-    results = Session.scalars(
-        select(BenchmarkResult)
+    # Note that N here determines peak usage of memory.
+    query_statement = (
+        sqlalchemy.select(BenchmarkResult)
         .join(Run)
         .order_by(BenchmarkResult.timestamp.desc())
         .limit(n)
-    ).all()
+    )
+    results = Session.scalars(query_statement).all()
 
     t1 = time.monotonic()
 
     if len(results) == 0:
-        log.debug("BMRT cache: no results (testing mode?)")
+        log.info("BMRT cache: no results")
         return
 
-    by_id_dict: Dict[str, BenchmarkResult] = {}
-    by_name_dict: Dict[str, List[BenchmarkResult]] = defaultdict(list)
-    by_case_dict: Dict[str, List[BenchmarkResult]] = defaultdict(list)
+    by_id_dict: Dict[str, BMRTBenchmarkResult] = {}
+    by_name_dict: Dict[str, List[BMRTBenchmarkResult]] = defaultdict(list)
+    by_case_id_dict: Dict[str, List[BMRTBenchmarkResult]] = defaultdict(list)
+
     for result in results:
-        by_id_dict[result.id] = result
-        # Add property _hardware on result obj, from Run.
-        result._hardware = result.run.hardware
-        # point of confusion: `result.case.name` is the benchmark name
-        by_name_dict[result.case.name].append(result)
+        # For now: put both, failed and non-failed results into the cache.
+        # It would be a nice code simplification to only consider succeeded
+        # ones, but then we miss out on reporting about the failed ones.
+
+        benchmark_name = str(result.case.name)
+
+        # A textual representation of the case permutation. As it is 'complete'
+        # it should also work as a proper identifier (like primary key).
+        case_text_id = " ".join(get_case_kvpair_strings(result.case.tags))
+
+        bmr = BMRTBenchmarkResult(
+            id=str(result.id),
+            benchmark_name=benchmark_name,
+            started_at=result.timestamp.timestamp(),
+            data=result.measurements,
+            mean=float(result.mean) if result.mean else None,
+            unit=str(result.unit) if result.unit else "n/a",
+            hardware_id=str(result.run.hardware.id),
+            hardware_name=str(result.run.hardware.name),
+            case_id=str(result.case_id),
+            context_id=str(result.context_id),
+            # These context dictionaries are often the largest part of these
+            # BMRTBenchmarkResult object (in terms of memory usage) -- they can
+            # be a rather big collection of strings. However, by the nature of
+            # the processed data there can be a high degree of duplication
+            # across benchmark results. The data source uses a unique
+            # constraint (enforced in DB) with an index on the entire
+            # dictionary, i.e. use the _same_ object here and assume it may be
+            # shared across potentially many BMRTBenchmarkResult objects.
+            context_dict=result.context.to_dict(),
+            case_text_id=case_text_id,
+            ui_hardware_short=str(result.ui_hardware_short),
+            ui_time_started_at=str(result.ui_time_started_at),
+            ui_rel_sem=result.ui_rel_sem,
+            ui_non_null_sample_count=result.ui_non_null_sample_count,
+            ui_mean_and_uncertainty=result.ui_mean_and_uncertainty,
+        )
+
+        # The str() indirections below (and above) are here to quickly make
+        # sure that there is no more SQLAlchemy magic associated to objects we
+        # store here (no more mapping to columns). Maybe that is not needed
+        # but instead of making that experiment I took the quick way.
+        by_id_dict[str(result.id)] = bmr
+        by_name_dict[benchmark_name].append(bmr)
+
         # Add a property on the Case object, on the fly.
         # Build the textual representation of this case which should also
         # uniquely / unambiguously define/identify this specific case.
-        result.case.text_id = " ".join(get_case_kvpair_strings(result.case.tags))
-        by_case_dict[result.case.id].append(result)
+        by_case_id_dict[str(result.case_id)].append(bmr)
+
+    first_bmr = next(iter(by_id_dict))
 
     # Mutate the dictionary which is accessed by other threads, do this in a
     # quick fashion -- each of this assignments is atomic (thread-safe), but
@@ -108,7 +183,7 @@ def _fetch_and_cache_most_recent_results(n=0.06 * 10**6) -> None:
     # re-defining the name _cache_bmrs.
     _cache_bmrs["by_id"] = by_id_dict
     _cache_bmrs["by_benchmark_name"] = by_name_dict
-    _cache_bmrs["by_case_id"] = by_case_dict
+    _cache_bmrs["by_case_id"] = by_case_id_dict
     _cache_bmrs["meta"] = CacheUpdateMetaInfo(
         newest_result_time_str=results[0].ui_time_started_at,
         oldest_result_time_str=results[-1].ui_time_started_at,

--- a/conbench/templates/c-benchmark-cases.html
+++ b/conbench/templates/c-benchmark-cases.html
@@ -26,16 +26,16 @@
         </tr>
       </thead>
       <tbody>
-        {% for case, results in results_by_case.items() %}
+        {% for case_id, results in results_by_case_id.items() %}
           <tr>
             <td class="font-monospace">
-              <a href="{{ url_for('app.show_benchmark_results', bname=benchmark_name, caseid=case.id) }}">{{ case.id[:10] }}</a>
+              <a href="{{ url_for('app.show_benchmark_results', bname=benchmark_name, caseid=case_id) }}">{{ case_id[:10] }}</a>
             </td>
-            <td class="font-monospace">{{ case.text_id }}</td>
-            <td class="font-monospace">{{ last_result_per_case[case].ui_time_started_at }}</td>
+            <td class="font-monospace">{{ results[0].case_text_id }}</td>
+            <td class="font-monospace">{{ last_result_per_case_id[case_id].ui_time_started_at }}</td>
             <td class="font-monospace">{{ results|length }}</td>
-            <td class="font-monospace">{{ hardware_count_per_case[case] }}</td>
-            <td class="font-monospace">{{ context_count_per_case[case] }}</td>
+            <td class="font-monospace">{{ hardware_count_per_case_id[case_id] }}</td>
+            <td class="font-monospace">{{ context_count_per_case_id[caseid] }}</td>
           </tr>
         {% endfor %}
       </tbody>

--- a/conbench/templates/c-benchmark-cases.html
+++ b/conbench/templates/c-benchmark-cases.html
@@ -5,7 +5,7 @@
   </h3>
   <p>
     Found {{ benchmark_result_count }} result(s) for benchmark <code>{{ benchmark_name }}</code>,
-    spanning {{ results_by_case|length }} case(s).
+    spanning {{ results_by_case_id|length }} case(s).
     <br>
     Based on {{ bmr_cache_meta.n_results }} results reported in
     total between {{ bmr_cache_meta.oldest_result_time_str }} and
@@ -35,7 +35,7 @@
             <td class="font-monospace">{{ last_result_per_case_id[case_id].ui_time_started_at }}</td>
             <td class="font-monospace">{{ results|length }}</td>
             <td class="font-monospace">{{ hardware_count_per_case_id[case_id] }}</td>
-            <td class="font-monospace">{{ context_count_per_case_id[caseid] }}</td>
+            <td class="font-monospace">{{ context_count_per_case_id[case_id] }}</td>
           </tr>
         {% endfor %}
       </tbody>

--- a/conbench/templates/c-benchmark-results-for-case.html
+++ b/conbench/templates/c-benchmark-results-for-case.html
@@ -2,9 +2,9 @@
 {% block app_content %}
   <div>
     <h3>
-      <strong>{{ benchmark_name }}</strong> / case {{ case.id[:7] }}
+      <strong>{{ benchmark_name }}</strong> / case {{ this_case_id[:7] }}
     </h3>
-    <span class="fs-4"><code>{{ case.text_id }}</code></span>
+    <span class="fs-4"><code>{{ this_case_text_id }}</code></span>
     <p>
       Identified {{ matching_benchmark_result_count }} result(s) matching this case permutation.
       Based on {{ bmr_cache_meta.n_results }} results reported in
@@ -41,7 +41,7 @@
                 <a href="{{ url_for('app.benchmark-result', benchmark_result_id=result.id) }}">{{ result.id [:9] }}</a>
               </td>
               <td class="font-monospace">{{ result.ui_hardware_short }}</td>
-              <td class="font-monospace">{{ result.context.id[:8] }}</td>
+              <td class="font-monospace">{{ result.context_id[:8] }}</td>
               <td class="font-monospace">{{ result.ui_non_null_sample_count }}</td>
               <td class="font-monospace">{{ result.ui_mean_and_uncertainty }}</td>
               <td class="font-monospace" data-order="{{ result.ui_rel_sem[0] }}">{{ result.ui_rel_sem[1] }}</td>


### PR DESCRIPTION
This is mainly for #1211.

See commit messages.

Need to see impact on mem consumption in staging. Based on brief local analysis I think it might be significant. Curious.