### PR TITLE
benchclients: fix oversight, invert connect() and recv() timeout

### DIFF
--- a/benchclients/python/benchclients/conbench.py
+++ b/benchclients/python/benchclients/conbench.py
@@ -53,9 +53,9 @@ class ConbenchClient(RetryingHTTPClient):
     # context-specific timeout constant is for a login request, see below.
     # Note: for now, this `timeout_long_running_requests` timeout constant
     # applies to all requests unless specified otherwise.
-    timeout_long_running_requests = (120, 3.5)
+    timeout_long_running_requests = (3.5, 120)
 
-    timeout_login_request = (10, 3.5)
+    timeout_login_request = (3.5, 10)
 
     def __init__(self, default_retry_for_seconds=None, adapter=None):
         # If this library is embedded into a Python program that has stdlib


### PR DESCRIPTION
This is towards https://github.com/conbench/conbench/issues/801.

The oversight did not _yet_ result in a fallout. It would, if a response is expected to arrive after more than 3.5 s -- then it can never be fetched.

Ref docs, specifying order:

```
timeout (float or tuple) – (optional)
How many seconds to wait for the server to send data before giving up, as a float, or a (connect timeout, read timeout) tuple.
```
from https://requests.readthedocs.io/en/latest/api/

Seen via careful log reading:
```
230502-09:52:09.739 INFO: error during request/response cycle (treat as retryable, retry soon): 
    HTTPSConnectionPool(host='<redacted>', port=443):
         Read timed out. (read timeout=3.5)
```