### PR TITLE
c-benchmarks: work on 'landing page' a bit

### DIFF
--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -539,7 +539,7 @@ class BenchmarkResult(Base, EntityMixin):
         """
         Return UI-friendly version of self.timestamp (user-given 'start time').
         """
-        return self.timestamp.strftime("%Y-%m-%d %H:%M:%S") + " (UTC)"
+        return self.timestamp.strftime("%Y-%m-%d %H:%M:%S") + " UTC"
 
     @property
     def ui_hardware_short(self) -> str:

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -93,7 +93,7 @@ _STARTED = False
 
 # Fetching one million items from a sample DB takes ~1 minute on my machine
 # (the `results = Session.scalars(....all())` call takes that long.
-def _fetch_and_cache_most_recent_results(n=0.06 * 10**6) -> None:
+def _fetch_and_cache_most_recent_results(n=0.08 * 10**6) -> None:
     log.debug(
         "BMRT cache: keys in cache: %s",
         len(bmrt_cache["by_id"]),

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -34,6 +34,7 @@ log = logging.getLogger(__name__)
 class CacheUpdateMetaInfo:
     newest_result_time_str: str
     oldest_result_time_str: str
+    covered_timeframe_days_approx: str  # stringified integer, for UI
     n_results: int
 
 
@@ -74,12 +75,15 @@ class CacheDict(TypedDict):
 # parent, maybe via https://pypi.org/project/shared-memory-dict/ this is _not_
 # as stdlib pickling dict
 # https://github.com/luizalabs/shared-memory-dict/issues/10
-_cache_bmrs: CacheDict = {
+bmrt_cache: CacheDict = {
     "by_id": {},
     "by_benchmark_name": {},
     "by_case_id": {},
     "meta": CacheUpdateMetaInfo(
-        newest_result_time_str="n/a", oldest_result_time_str="n/a", n_results=0
+        newest_result_time_str="n/a",
+        oldest_result_time_str="n/a",
+        n_results=0,
+        covered_timeframe_days_approx="n/a",
     ),
 }
 
@@ -92,7 +96,7 @@ _STARTED = False
 def _fetch_and_cache_most_recent_results(n=0.06 * 10**6) -> None:
     log.debug(
         "BMRT cache: keys in cache: %s",
-        len(_cache_bmrs["by_id"]),
+        len(bmrt_cache["by_id"]),
     )
     t0 = time.monotonic()
 
@@ -173,12 +177,15 @@ def _fetch_and_cache_most_recent_results(n=0.06 * 10**6) -> None:
     # between those two assignments a thread might perform read access. (minor
     # inconsistency is possible). Of course we can add another lookup
     # indirection layer by assembling a completely new dictionary here and then
-    # re-defining the name _cache_bmrs.
-    _cache_bmrs["by_id"] = by_id_dict
-    _cache_bmrs["by_benchmark_name"] = by_name_dict
-    _cache_bmrs["by_case_id"] = by_case_id_dict
-    _cache_bmrs["meta"] = CacheUpdateMetaInfo(
+    # re-defining the name bmrt_cache.
+    bmrt_cache["by_id"] = by_id_dict
+    bmrt_cache["by_benchmark_name"] = by_name_dict
+    bmrt_cache["by_case_id"] = by_case_id_dict
+    bmrt_cache["meta"] = CacheUpdateMetaInfo(
         newest_result_time_str=results[0].ui_time_started_at,
+        covered_timeframe_days_approx=str(
+            (results[0].timestamp - results[-1].timestamp).days
+        ),
         oldest_result_time_str=results[-1].ui_time_started_at,
         n_results=len(results),
     )
@@ -192,7 +199,7 @@ def _fetch_and_cache_most_recent_results(n=0.06 * 10**6) -> None:
             "BMRT cache: keys in cache: %s, "
             "query took %.5f s, dict population took %.5f s"
         ),
-        len(_cache_bmrs["by_id"]),
+        len(bmrt_cache["by_id"]),
         t1 - t0,
         t2 - t1,
     )

--- a/conbench/templates/c-benchmark-cases.html
+++ b/conbench/templates/c-benchmark-cases.html
@@ -9,7 +9,7 @@
     <br>
     Based on {{ bmr_cache_meta.n_results }} results reported in
     total between {{ bmr_cache_meta.oldest_result_time_str }} and
-    {{ bmr_cache_meta.newest_result_time_str }}.
+    {{ bmr_cache_meta.newest_result_time_str }}
   </p>
   <div class="mt-5">
     <table class="table table-hover conbench-datatable"

--- a/conbench/templates/c-benchmarks.html
+++ b/conbench/templates/c-benchmarks.html
@@ -7,25 +7,24 @@
     Based on {{ benchmark_result_count }} results reported in
     total between <strong>{{ bmr_cache_meta.oldest_result_time_str }}</strong> and
     <strong>{{ bmr_cache_meta.newest_result_time_str }}</strong>
-    (~{{ bmr_cache_meta.covered_timeframe_days_approx}} days).
+    (~{{ bmr_cache_meta.covered_timeframe_days_approx }} days).
   </p>
-    <div class="row mt-5">
-      <div class="col">
-        <h4>By name</h4>
-        {% for benchmark_name, results in benchmarks_by_name_sorted_alphabetically.items() %}
+  <div class="row mt-5">
+    <div class="col">
+      <h4>By name</h4>
+      {% for benchmark_name, results in benchmarks_by_name_sorted_alphabetically.items() %}
         <strong><a href="{{ url_for('app.show_benchmark_cases', bname=benchmark_name) }}">{{ benchmark_name }}</a></strong>
         ({{ results|length }} results)
         <br>
-        {% endfor %}
-      </div>
-      <div class="col">
-        <h4>By most recent result (top 15)</h4>
-        {% for benchmark_name, results in benchmarks_by_name_sorted_by_most_recent_result_topN.items() %}
-        <strong><a href="{{ url_for('app.show_benchmark_cases', bname=benchmark_name) }}">{{ benchmark_name }}</a></strong>
-        ({{ results|length }} results)
-        <br>
-        {% endfor %}
-      </div>
+      {% endfor %}
     </div>
-
+    <div class="col">
+      <h4>By most recent result (top 15)</h4>
+      {% for benchmark_name, results in benchmarks_by_name_sorted_by_most_recent_result_topN.items() %}
+        <strong><a href="{{ url_for('app.show_benchmark_cases', bname=benchmark_name) }}">{{ benchmark_name }}</a></strong>
+        ({{ results|length }} results)
+        <br>
+      {% endfor %}
+    </div>
+  </div>
 {% endblock %}

--- a/conbench/templates/c-benchmarks.html
+++ b/conbench/templates/c-benchmarks.html
@@ -1,15 +1,31 @@
 {% extends "app.html" %}
 {% block app_content %}
-  <h4>Benchmarks (by name)</h4>
+  <h3>
+    <strong>Benchmarks</strong>
+  </h3>
   <p>
     Based on {{ benchmark_result_count }} results reported in
-    total between {{ bmr_cache_meta.oldest_result_time_str }} and
-    {{ bmr_cache_meta.newest_result_time_str }}.
+    total between <strong>{{ bmr_cache_meta.oldest_result_time_str }}</strong> and
+    <strong>{{ bmr_cache_meta.newest_result_time_str }}</strong>
+    (~{{ bmr_cache_meta.covered_timeframe_days_approx}} days).
   </p>
-  <br>
-  {% for benchmark_name, results in benchmarks_by_name.items() %}
-    <a href="{{ url_for('app.show_benchmark_cases', bname=benchmark_name) }}">{{ benchmark_name }}</a>
-    ({{ results|length }} results)
-    <br>
-  {% endfor %}
+    <div class="row mt-5">
+      <div class="col">
+        <h4>By name</h4>
+        {% for benchmark_name, results in benchmarks_by_name_sorted_alphabetically.items() %}
+        <strong><a href="{{ url_for('app.show_benchmark_cases', bname=benchmark_name) }}">{{ benchmark_name }}</a></strong>
+        ({{ results|length }} results)
+        <br>
+        {% endfor %}
+      </div>
+      <div class="col">
+        <h4>By most recent result (top 15)</h4>
+        {% for benchmark_name, results in benchmarks_by_name_sorted_by_most_recent_result_topN.items() %}
+        <strong><a href="{{ url_for('app.show_benchmark_cases', bname=benchmark_name) }}">{{ benchmark_name }}</a></strong>
+        ({{ results|length }} results)
+        <br>
+        {% endfor %}
+      </div>
+    </div>
+
 {% endblock %}


### PR DESCRIPTION
- show covered timeframe
- two columns: sort by name, and by recency

Also: misc changes, rename vars, cover 80.000 last benchmark results.

Minor style change.

![image](https://user-images.githubusercontent.com/265630/235960683-ad7b3bf0-336a-4156-bbb2-a79b65fc0cb6.png)
