### PR TITLE
BMRT cache: process database response in streaming fashion (reduce peak mem consumption during DB query)

### DIFF
--- a/conbench/job.py
+++ b/conbench/job.py
@@ -8,8 +8,6 @@ from typing import Dict, List, Optional, Tuple, TypedDict
 
 import sqlalchemy
 
-# from filprofiler.api import profile as filprofile
-
 import conbench.metrics
 from conbench.config import Config
 from conbench.db import Session

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -7,7 +7,8 @@ from collections import defaultdict
 from typing import Dict, List, Optional, Tuple, TypedDict
 
 import sqlalchemy
-from filprofiler.api import profile as filprofile
+
+# from filprofiler.api import profile as filprofile
 
 import conbench.metrics
 from conbench.config import Config
@@ -259,8 +260,8 @@ def _periodically_fetch_last_n_benchmark_results() -> None:
             t0 = time.monotonic()
 
             try:
-                filprofile(lambda: _fetch_and_cache_most_recent_results(), "fil-result")
-                # _fetch_and_cache_most_recent_results()
+                # filprofile(lambda: _fetch_and_cache_most_recent_results(), "fil-result")
+                _fetch_and_cache_most_recent_results()
             except Exception as exc:
                 # For now, log all error detail. (but handle all exceptions; do
                 # some careful log-reading after rolling this out).

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -117,11 +117,10 @@ def _fetch_and_cache_most_recent_results(n=0.08 * 10**6) -> None:
 
     # Corresponding to the `yield_per` magic, consume the returned value as an
     # iterator. `all()` would consume all results and would defeat the purpose
-    # of the memory-saving exercise. The following line of code does not do the
-    # work yet; that begins once the iterator is consumed.
+    # of the memory-saving exercise. The following line of code does not do
+    # much of the work yet; that begins once the iterator is consumed (maybe it
+    # fetches the first chunk?).
     result_rows_iterator = Session.scalars(query_statement)
-
-    t1 = time.monotonic()
 
     by_id_dict: Dict[str, BMRTBenchmarkResult] = {}
     by_name_dict: Dict[str, List[BMRTBenchmarkResult]] = defaultdict(list)
@@ -186,7 +185,7 @@ def _fetch_and_cache_most_recent_results(n=0.08 * 10**6) -> None:
         # uniquely / unambiguously define/identify this specific case.
         by_case_id_dict[str(result.case_id)].append(bmr)
 
-    t2 = time.monotonic()
+    t1 = time.monotonic()
 
     if len(by_name_dict) == 0:
         log.info("BMRT cache: no results")
@@ -214,18 +213,12 @@ def _fetch_and_cache_most_recent_results(n=0.08 * 10**6) -> None:
         n_results=len(by_name_dict),
     )
 
-    # t3 = time.monotonic()
-
     conbench.metrics.GAUGE_BMRT_CACHE_LAST_UPDATE_SECONDS.set(t2 - t0)
 
     log.info(
-        (
-            "BMRT cache: keys in cache: %s, "
-            "query took %.5f s, dict population took %.5f s"
-        ),
+        ("BMRT cache population done (%s results, took %.3f s)"),
         len(bmrt_cache["by_id"]),
         t1 - t0,
-        t2 - t1,
     )
 
 

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from typing import Dict, List, Optional, Tuple, TypedDict
 
 import sqlalchemy
+from filprofiler.api import profile as filprofile
 
 import conbench.metrics
 from conbench.config import Config
@@ -236,7 +237,8 @@ def _periodically_fetch_last_n_benchmark_results() -> None:
             t0 = time.monotonic()
 
             try:
-                _fetch_and_cache_most_recent_results()
+                filprofile(lambda: _fetch_and_cache_most_recent_results(), "fil-result")
+                # _fetch_and_cache_most_recent_results()
             except Exception as exc:
                 # For now, log all error detail. (but handle all exceptions; do
                 # some careful log-reading after rolling this out).

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -101,28 +101,40 @@ def _fetch_and_cache_most_recent_results(n=0.08 * 10**6) -> None:
     )
     t0 = time.monotonic()
 
+    # Note(JP): process query result rows in a streaming-like fashion in
+    # smaller chunks to keep peak memory usage in check. Also see
+    # https://docs.sqlalchemy.org/en/20/core/connections.html#using-server-side-cursors-a-k-a-stream-results
+    # https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#fetching-large-result-sets-with-yield-per
     # Also fetch hardware from associated Run, so that result.run is in cache,
     # too, and so that result.run.hardware is a quick lookup.
-    # Note that N here determines peak usage of memory.
     query_statement = (
         sqlalchemy.select(BenchmarkResult)
         .join(Run)
         .order_by(BenchmarkResult.timestamp.desc())
         .limit(n)
-    )
-    results = Session.scalars(query_statement).all()
+    ).execution_options(yield_per=2000)
+
+    # Corresponding to the `yield_per` magic, consume the returned value as an
+    # iterator. `all()` would consume all results and would defeat the purpose
+    # of the memory-saving exercise. The following line of code does not do the
+    # work yet; that begins once the iterator is consumed.
+    result_rows_iterator = Session.scalars(query_statement)
 
     t1 = time.monotonic()
-
-    if len(results) == 0:
-        log.info("BMRT cache: no results")
-        return
 
     by_id_dict: Dict[str, BMRTBenchmarkResult] = {}
     by_name_dict: Dict[str, List[BMRTBenchmarkResult]] = defaultdict(list)
     by_case_id_dict: Dict[str, List[BMRTBenchmarkResult]] = defaultdict(list)
 
-    for result in results:
+    first_result = None
+    last_result = None
+    for result in result_rows_iterator:  # pylint: disable=E1133
+        # Keep track of the first (newest) and last (oldest) result while
+        # consuming the iterator. If n=1 they are the same.
+        last_result = result
+        if first_result is None:
+            first_result = result
+
         # For now: put both, failed and non-failed results into the cache.
         # It would be a nice code simplification to only consider succeeded
         # ones, but then we miss out on reporting about the failed ones.
@@ -173,6 +185,16 @@ def _fetch_and_cache_most_recent_results(n=0.08 * 10**6) -> None:
         # uniquely / unambiguously define/identify this specific case.
         by_case_id_dict[str(result.case_id)].append(bmr)
 
+    t2 = time.monotonic()
+
+    if len(by_name_dict) == 0:
+        log.info("BMRT cache: no results")
+        return
+
+    # This helps mypy, too.
+    assert first_result
+    assert last_result
+
     # Mutate the dictionary which is accessed by other threads, do this in a
     # quick fashion -- each of this assignments is atomic (thread-safe), but
     # between those two assignments a thread might perform read access. (minor
@@ -183,15 +205,15 @@ def _fetch_and_cache_most_recent_results(n=0.08 * 10**6) -> None:
     bmrt_cache["by_benchmark_name"] = by_name_dict
     bmrt_cache["by_case_id"] = by_case_id_dict
     bmrt_cache["meta"] = CacheUpdateMetaInfo(
-        newest_result_time_str=results[0].ui_time_started_at,
+        newest_result_time_str=first_result.ui_time_started_at,
         covered_timeframe_days_approx=str(
-            (results[0].timestamp - results[-1].timestamp).days
+            (first_result.timestamp - last_result.timestamp).days
         ),
-        oldest_result_time_str=results[-1].ui_time_started_at,
-        n_results=len(results),
+        oldest_result_time_str=last_result.ui_time_started_at,
+        n_results=len(by_name_dict),
     )
 
-    t2 = time.monotonic()
+    # t3 = time.monotonic()
 
     conbench.metrics.GAUGE_BMRT_CACHE_LAST_UPDATE_SECONDS.set(t2 - t0)
 

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -213,7 +213,7 @@ def _fetch_and_cache_most_recent_results(n=0.08 * 10**6) -> None:
         n_results=len(by_name_dict),
     )
 
-    conbench.metrics.GAUGE_BMRT_CACHE_LAST_UPDATE_SECONDS.set(t2 - t0)
+    conbench.metrics.GAUGE_BMRT_CACHE_LAST_UPDATE_SECONDS.set(t1 - t0)
 
     log.info(
         ("BMRT cache population done (%s results, took %.3f s)"),

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,7 +4,8 @@
 services:
   app:
     # Add --reload to command, to reload on file change.
-    command: ["fil-profile", "python", "-m",  "gunicorn", "-c", "conbench/gunicorn-conf.py", "--reload"]
+    # command: ["fil-profile", "python", "-m",  "gunicorn", "-c", "conbench/gunicorn-conf.py", "--reload"]
+    command: ["gunicorn", "-c", "conbench/gunicorn-conf.py", "--reload"]
     volumes:
       # Left-hand path: relative to this compose file. Mount the directory
       # that this compose file resided in as `/app` into the container.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,7 +4,7 @@
 services:
   app:
     # Add --reload to command, to reload on file change.
-    command: ["gunicorn", "-c", "conbench/gunicorn-conf.py", "--reload"]
+    command: ["fil-profile", "python", "-m",  "gunicorn", "-c", "conbench/gunicorn-conf.py", "--reload"]
     volumes:
       # Left-hand path: relative to this compose file. Mount the directory
       # that this compose file resided in as `/app` into the container.

--- a/requirements-webapp.txt
+++ b/requirements-webapp.txt
@@ -8,6 +8,7 @@ email-validator
 Flask==2.2.3
 Flask-Bootstrap
 Flask-Compress
+filprofiler
 Flask-Login
 flask-swagger-ui
 Flask-WTF

--- a/requirements-webapp.txt
+++ b/requirements-webapp.txt
@@ -8,7 +8,6 @@ email-validator
 Flask==2.2.3
 Flask-Bootstrap
 Flask-Compress
-filprofiler
 Flask-Login
 flask-swagger-ui
 Flask-WTF


### PR DESCRIPTION
Had a deeper look at how `results = Session.scalars(query_statement).all()` behaves in terms of memory consumption. I was wrongly assuming that this is already using a small buffer, but in fact it's using a big buffer where the entire database response is stored in memory before processing in application code can continue. Also see https://github.com/sqlalchemy/sqlalchemy/discussions/9735.

I want to quote from https://docs.sqlalchemy.org/en/20/core/connections.html, corroborating the architectural choices that we're going to make here, and giving a bit more insight on the trade-offs:


> From this basic architecture it follows that a “server side cursor” is more memory efficient when fetching very large result sets, while at the same time may introduce more complexity in the client/server communication process and be less efficient for small result sets (typically less than 10000 rows).

The next obvious thing to do here is to change paradigms, to process the data in chunks (semi "streaming fashion" :-)). Keeping buffers in check, so to say.

Also see my comment here: https://github.com/conbench/conbench/pull/1205#issuecomment-1534359324.

Relevant docs:
- https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#orm-queryguide-yield-per
- https://docs.sqlalchemy.org/en/20/core/connections.html