### PR TITLE
BenchmarkResult: fix SEM calculation (division by zero)

### DIFF
--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -446,12 +446,11 @@ class BenchmarkResult(Base, EntityMixin):
         We also may want to instruct SQLAlchemy to return numbers as floats
         directly.
         """
-        values = []
-        if not self.is_failed:
-            assert self.data is not None
-            values = [float(d) for d in self.data]
+        if self.is_failed:
+            return []
 
-        return values
+        assert self.data is not None
+        return [float(d) for d in self.data]
 
     @property
     def ui_mean_and_uncertainty(self) -> str:


### PR DESCRIPTION
https://github.com/conbench/conbench/issues/532 strikes back. Ran into this with real-world DB state (Arrow DB snapshot).

The methods we are working on here are not yet perfect. I would love to be able to iterate on them, and change their names and docs and code over time. But there should be convergence towards a minimal, stable, valuable set of methods that is used across the code base. Methods that hide some of the madness around what `data` can be in the database, methods that buy in to the idea of `is_failed`, etc.