### PR TITLE
kube-prometheus: bump retention time by factor 2

### DIFF
--- a/k8s/kube-prometheus/conbench-flavor.jsonnet
+++ b/k8s/kube-prometheus/conbench-flavor.jsonnet
@@ -65,7 +65,7 @@ local kp =
           // vd-2 in mind. Almost ephemeral setup. But we want to retain
           // data across kube-prometheus updates. Use short retention and tiny
           // persistent volumes.
-          retention: '6d',
+          retention: '12d',
           // <comment-used-by-ci: pvc-start>
           storage: {
             volumeClaimTemplate: {


### PR DESCRIPTION
In vd-2 we use two different small EBS devices; I didn't know how big we can set the retention time before things reach their limit. By now we have quite a bit of experience. See these two screenshots (lovely self-monitoring; this is kube-prometheus' monitoring stack monitoring its own k8s persistent volumes):

[vol1](https://user-images.githubusercontent.com/265630/236174148-c8918f6d-64bd-4426-9909-c20525a89fd4.png) -- 30 % full, stable
[vol2](https://user-images.githubusercontent.com/265630/236174175-cd493a93-e54b-4d01-bd12-80e70bc1caa6.png) -- 17 % full, stable
