### PR TITLE
BenchmarkResult: fix `.data` type, think through `.unit` type, use more `.measurements`

### DIFF
--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -462,10 +462,9 @@ class BenchmarkResult(Base, EntityMixin):
         if self.is_failed:
             return []
 
-        # The following two asserts might be even costly in terms of
-        # performance. However, they explicitly document two assumptions that
-        # we rely on to be valid after is_failed returned False. Also, these
-        # the first assert statements is piicked up by mypy for type inference.
+        # The following two asserts explicitly document two assumptions that we
+        # rely on to be valid after is_failed returned False. Also, these the
+        # first assert statements is piicked up by mypy for type inference.
         # Note that `assert all(d is not None for d in self.data)` did not help
         # mypy narrow down the type. See
         # https://github.com/python/mypy/issues/15180. To keep keep the


### PR DESCRIPTION
The type annotation for BenchmarkResult.data we had in place already was useful and helped us fix bugs and move forward. But it wasn't quite correct yet. This patch accounts for the fact that individual iterations may report as `None`.

That is, we go from `Mapped[Optional[List[Decimal]]]` to `Mapped[Optional[List[Optional[Decimal]]]]`. :fire: 

That again provided interesting mypy feedback that I acted on.

I also doubled down on `self.measurements` which has the simple return type signature of `List[float]` which is what we _really_ want further down in application code. That allowed for vast simplification of some other functions.

Think `Mapped[Optional[List[Optional[Decimal]]]]` ->  `List[float]` -- looks useful, right? Of course this needs proper spec/docstrings to prevent misunderstandings from happening, but I think we're on a good path. Key ingredient here is the `is_failed` abstraction that I have been carrying along for a while. I think it really helps.

See code comments, and commit messages.

The bigger methods `BenchmarkResult.ui_mean_and_uncertainty()` and `BenchmarkResult.ui_rel_sem()` I did not just move, but I reworked them using newly gained simplicity.

Along the way I wondered about mypy's type inference and opened https://github.com/python/mypy/issues/15180.