### PR TITLE
BMRT cache: reduce cpu work in update

### DIFF
--- a/conbench/job.py
+++ b/conbench/job.py
@@ -8,9 +8,6 @@ from typing import Dict, List, Optional, Tuple, TypedDict
 
 import sqlalchemy
 
-# from filprofiler.api import profile as filprofile
-import yappi
-
 import conbench.metrics
 from conbench.config import Config
 from conbench.db import Session
@@ -21,6 +18,10 @@ from conbench.entities.benchmark_result import (
 )
 from conbench.entities.run import Run
 from conbench.hacks import get_case_kvpair_strings
+
+# from filprofiler.api import profile as filprofile
+# import yappi
+
 
 """
 This module implements a job which populates and provides a cache for the N
@@ -151,8 +152,8 @@ def _fetch_and_cache_most_recent_results(n=0.05 * 10**6) -> None:
         if first_result is None:
             first_result = result
 
-        if (idx % 1000) == 0:
-            log.info("1000 results processed")
+        if (idx % 6000) == 0:
+            log.info("6000 results processed")
 
         # For now: put both, failed and non-failed results into the cache.
         # It would be a nice code simplification to only consider succeeded
@@ -243,7 +244,7 @@ def _periodically_fetch_last_n_benchmark_results() -> None:
     """
     Immediately return after having spawned a thread triggers periodic action.
     """
-    first_sleep_seconds = 10
+    first_sleep_seconds = 3
     min_delay_between_runs_seconds = 120
 
     if Config.TESTING:
@@ -269,7 +270,7 @@ def _periodically_fetch_last_n_benchmark_results() -> None:
 
             t0 = time.monotonic()
 
-            yappi.start()
+            # yappi.start()
             try:
                 # filprofile(lambda: _fetch_and_cache_most_recent_results(), "fil-result")
                 _fetch_and_cache_most_recent_results()
@@ -277,26 +278,26 @@ def _periodically_fetch_last_n_benchmark_results() -> None:
                 # For now, log all error detail. (but handle all exceptions; do
                 # some careful log-reading after rolling this out).
                 log.exception("BMRT cache: exception during update: %s", exc)
-            yappi.stop()
+            # yappi.stop()
 
             last_call_duration_s = time.monotonic() - t0
 
-            threads = yappi.get_thread_stats()
-            print()
-            print()
-            for thread in threads:
-                print(
-                    "Function stats for (%s) (%d)" % (thread.name, thread.id)
-                )  # it is the Thread.__class__.__name__
+            # threads = yappi.get_thread_stats()
+            # print()
+            # print()
+            # for thread in threads:
+            #     print(
+            #         "Function stats for (%s) (%d)" % (thread.name, thread.id)
+            #     )  # it is the Thread.__class__.__name__
 
-                columns = {
-                    0: ("name", 150),
-                    1: ("ncall", 10),
-                    2: ("tsub", 12),
-                    3: ("ttot", 12),
-                    4: ("tavg", 12),
-                }
-                yappi.get_func_stats(ctx_id=thread.id).print_all(columns=columns)
+            #     columns = {
+            #         0: ("name", 150),
+            #         1: ("ncall", 10),
+            #         2: ("tsub", 12),
+            #         3: ("ttot", 12),
+            #         4: ("tavg", 12),
+            #     }
+            #     yappi.get_func_stats(ctx_id=thread.id).print_all(columns=columns)
 
             # Generally we want to spent the majority of the time _not_ doing
             # this thing here. So, if the last iteration lasted for e.g. ~60

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -114,7 +114,7 @@ _STARTED = False
 
 # Fetching one million items from a sample DB takes ~1 minute on my machine
 # (the `results = Session.scalars(....all())` call takes that long.
-def _fetch_and_cache_most_recent_results(n=0.05 * 10**6) -> None:
+def _fetch_and_cache_most_recent_results(n=0.08 * 10**6) -> None:
     log.debug(
         "BMRT cache: keys in cache: %s",
         len(bmrt_cache["by_id"]),

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -19,6 +19,8 @@ from conbench.entities.benchmark_result import (
 from conbench.entities.run import Run
 from conbench.hacks import get_case_kvpair_strings
 
+# A memory profiler, and a CPU profiler that are both tested to work well
+# with the process/threading model used here.
 # from filprofiler.api import profile as filprofile
 # import yappi
 
@@ -271,6 +273,7 @@ def _periodically_fetch_last_n_benchmark_results() -> None:
             t0 = time.monotonic()
 
             # yappi.start()
+
             try:
                 # filprofile(lambda: _fetch_and_cache_most_recent_results(), "fil-result")
                 _fetch_and_cache_most_recent_results()
@@ -278,26 +281,11 @@ def _periodically_fetch_last_n_benchmark_results() -> None:
                 # For now, log all error detail. (but handle all exceptions; do
                 # some careful log-reading after rolling this out).
                 log.exception("BMRT cache: exception during update: %s", exc)
+
             # yappi.stop()
+            # yappi_print_threads_stats()
 
             last_call_duration_s = time.monotonic() - t0
-
-            # threads = yappi.get_thread_stats()
-            # print()
-            # print()
-            # for thread in threads:
-            #     print(
-            #         "Function stats for (%s) (%d)" % (thread.name, thread.id)
-            #     )  # it is the Thread.__class__.__name__
-
-            #     columns = {
-            #         0: ("name", 150),
-            #         1: ("ncall", 10),
-            #         2: ("tsub", 12),
-            #         3: ("ttot", 12),
-            #         4: ("tavg", 12),
-            #     }
-            #     yappi.get_func_stats(ctx_id=thread.id).print_all(columns=columns)
 
             # Generally we want to spent the majority of the time _not_ doing
             # this thing here. So, if the last iteration lasted for e.g. ~60
@@ -336,6 +324,24 @@ def shutdown_handler(sig, frame):
     SHUTDOWN = True
     if sig == signal.SIGINT:
         original_sigint_handler(sig, frame)
+
+
+# def yappi_print_threads_stats():
+#     """ """
+#     threads = yappi.get_thread_stats()
+#     print("\n\n")
+#     for thread in threads:
+#         print("Stats for (%s) (%d)" % (thread.name, thread.id))
+#         # Didn't find docs, but after code inspection I found a way to
+#         # increase column width in output.
+#         columns = {
+#             0: ("name", 150),
+#             1: ("ncall", 10),
+#             2: ("tsub", 12),
+#             3: ("ttot", 12),
+#             4: ("tavg", 12),
+#         }
+#         yappi.get_func_stats(ctx_id=thread.id).print_all(columns=columns)
 
 
 # Handle the common signals that instruct us to gracefully shut down. We have

--- a/requirements-webapp.txt
+++ b/requirements-webapp.txt
@@ -33,4 +33,4 @@ sigfig
 SQLAlchemy>=2
 tenacity
 uuid7
-yappi
+

--- a/requirements-webapp.txt
+++ b/requirements-webapp.txt
@@ -33,3 +33,4 @@ sigfig
 SQLAlchemy>=2
 tenacity
 uuid7
+yappi


### PR DESCRIPTION
This addresses https://github.com/conbench/conbench/issues/1218.

Started with a Arrow DB snaptho. Tested with 50000 results. Processing took ~ 9.0 s.
- removed ui_mean_and_uncertainty() from hot path -> 5.0 s
- removed ui_rel_sem() from hot path -> 4.0 s

One more profiling round after that showed once again that the stdlib JSON decoder is heavily involved with
```
JSONDecoder.decode                                                                                        300000      0.832742      1.810002 
```

I reported that before in https://github.com/conbench/conbench/issues/1035 where I also mentioned an easy improvement for that.

Quickly replaced that with the orjson decoder (already introduced before). Gain was another 0.5 s.

That is, this patch cuts processing time with my test data from 9.0 to 3.5 seconds.

Just like before, I kept the boilerplate for the yappi-based profiling work in place so that we can quickly go back to it. You will notice that the relevant changes in this PR are very little.