### PR TITLE
benchalerts: let GitHubCheckStep use the external_id attribute

### DIFF
--- a/benchalerts/benchalerts/integrations/github.py
+++ b/benchalerts/benchalerts/integrations/github.py
@@ -264,6 +264,7 @@ class GitHubRepoClient(BaseClient):
         summary: Optional[str] = None,
         details: Optional[str] = None,
         details_url: Optional[str] = None,
+        external_id: Optional[str] = None,
     ):
         """Adds a new (or updates an existing) GitHub Check on a commit.
 
@@ -293,6 +294,8 @@ class GitHubRepoClient(BaseClient):
             Details about the check results. Supports Markdown. Default None.
         details_url
             A URL to be linked to when clicking on check Details. Default None.
+        external_id
+            An optional reference to another system. Default None.
 
         Returns
         -------
@@ -317,5 +320,8 @@ class GitHubRepoClient(BaseClient):
 
         if details_url:
             json["details_url"] = details_url
+
+        if external_id:
+            json["external_id"] = external_id
 
         return self.post("/check-runs", json=json)

--- a/benchalerts/benchalerts/pipeline_steps/github.py
+++ b/benchalerts/benchalerts/pipeline_steps/github.py
@@ -39,6 +39,9 @@ class GitHubCheckStep(AlertPipelineStep):
         A GitHubRepoClient instance. Either provide this or ``repo``.
     step_name
         The name for this step. If not given, will default to this class's name.
+    external_id
+        An optional reference to another system. This argument will set the
+        "external_id" property of the posted GitHub Check, but do nothing else.
 
     Returns
     -------
@@ -69,6 +72,7 @@ class GitHubCheckStep(AlertPipelineStep):
         repo: Optional[str] = None,
         github_client: Optional[GitHubRepoClient] = None,
         step_name: Optional[str] = None,
+        external_id: Optional[str] = None,
     ) -> None:
         super().__init__(step_name=step_name)
         self.github_client = github_client or GitHubRepoClient(repo=repo or "")
@@ -79,6 +83,7 @@ class GitHubCheckStep(AlertPipelineStep):
             )
         self.commit_hash = commit_hash
         self.comparison_step_name = comparison_step_name
+        self.external_id = external_id
 
     def run_step(
         self, previous_outputs: Dict[str, Any]
@@ -101,6 +106,7 @@ class GitHubCheckStep(AlertPipelineStep):
             details=self._default_check_details(full_comparison),
             # point to the homepage table filtered to runs of this commit
             details_url=f"{full_comparison.app_url}/?search={full_comparison.commit_hash}",
+            external_id=self.external_id,
         )
         log.debug(res)
         return res, full_comparison

--- a/benchalerts/tests/integration_tests/test_alert_pipeline.py
+++ b/benchalerts/tests/integration_tests/test_alert_pipeline.py
@@ -100,6 +100,7 @@ def test_alert_pipeline(monkeypatch: pytest.MonkeyPatch, github_auth: str):
                 repo=test_status_repo,
                 commit_hash=test_status_commit,
                 comparison_step_name="z_none",
+                external_id="123",
             )
         )
         if not os.getenv("CI"):  # don't post PR comments in CI

--- a/benchalerts/tests/unit_tests/test_alert_pipeline.py
+++ b/benchalerts/tests/unit_tests/test_alert_pipeline.py
@@ -41,6 +41,7 @@ def test_reasonable_pipeline(conbench_env, github_auth):
                 commit_hash=commit_hash,
                 comparison_step_name="z_none",
                 github_client=github_client,
+                external_id="123",
             ),
             steps.GitHubStatusStep(
                 commit_hash=commit_hash,

--- a/benchalerts/tests/unit_tests/test_integrations/test_github.py
+++ b/benchalerts/tests/unit_tests/test_integrations/test_github.py
@@ -71,6 +71,7 @@ class TestGitHubRepoClient:
             summary="Testing something",
             details="Some details",
             details_url="https://conbench.biz/",
+            external_id="123",
         )
         assert res["output"]["summary"] == "Testing something"
 

--- a/benchalerts/tests/unit_tests/test_pipeline_steps/test_github.py
+++ b/benchalerts/tests/unit_tests/test_pipeline_steps/test_github.py
@@ -47,6 +47,7 @@ def test_GitHubCheckStep(
                 commit_hash="abc",
                 github_client=GitHubRepoClient(repo="some/repo", adapter=MockAdapter()),
                 comparison_step_name="comparison_step",
+                external_id="123",
             )
         return
 
@@ -54,6 +55,7 @@ def test_GitHubCheckStep(
         commit_hash="abc",
         github_client=GitHubRepoClient(repo="some/repo", adapter=MockAdapter()),
         comparison_step_name="comparison_step",
+        external_id="123",
     )
     gh_res, full_comparison = step.run_step({"comparison_step": mock_comparison_info})
     assert gh_res


### PR DESCRIPTION
When posting a GitHub Check Run, you can include an arbitrary string in the `external_id` field of the Check. This is useful for storing data that may be used downstream by a particular installation. This PR surfaces that field to users of benchalerts.