### PR TITLE
benchalerts: link to compare/benchmarks when we can

### DIFF
--- a/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
+++ b/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
@@ -87,7 +87,7 @@ def test_GetConbenchZComparisonStep(
         assert run.contender_link
         assert run.contender_id
         if run.compare_results:
-            assert run.compare_link
+            assert run.run_compare_link
             for benchmark in run.compare_results:
                 # new compare result format
                 if "analysis" in benchmark:

--- a/benchalerts/tests/unit_tests/expected_md/comment_errors_baselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_errors_baselines.md
@@ -3,15 +3,15 @@ Conbench analyzed the 3 benchmark runs on commit `abc`.
 There were 3 benchmark results with an error:
 
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
-  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmarks/some-benchmark-uuid-4)
-  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmarks/some-benchmark-uuid-4)
+  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-2...some-benchmark-uuid-4)
+  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-2...some-benchmark-uuid-4)
 - and 1 more (see the report linked below)
 
 There were 3 benchmark results indicating a performance regression:
 
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
-  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)
-  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)
+  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
+  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
 - and 1 more (see the report linked below)
 
 The [full Conbench report](https://github.com/github/hello-world/runs/4) has more details.

--- a/benchalerts/tests/unit_tests/expected_md/comment_errors_nobaselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_errors_nobaselines.md
@@ -3,8 +3,8 @@ Conbench analyzed the 2 benchmark runs on commit `abc`.
 There were 2 benchmark results with an error:
 
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
-  - [file-write](http://localhost/benchmarks/some-benchmark-uuid-2)
-  - [file-write](http://localhost/benchmarks/some-benchmark-uuid-2)
+  - [file-write](http://localhost/benchmark-results/some-benchmark-uuid-2)
+  - [file-write](http://localhost/benchmark-results/some-benchmark-uuid-2)
 
 There weren't enough matching historic benchmark runs to make a call on whether there were regressions.
 

--- a/benchalerts/tests/unit_tests/expected_md/comment_regressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_regressions.md
@@ -3,7 +3,7 @@ Conbench analyzed the 3 benchmark runs on commit `abc`.
 There were 2 benchmark results indicating a performance regression:
 
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
-  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)
-  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)
+  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
+  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
 
 The [full Conbench report](https://github.com/github/hello-world/runs/4) has more details.

--- a/benchalerts/tests/unit_tests/expected_md/summary_errors_baselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_errors_baselines.md
@@ -5,9 +5,9 @@ Conbench analyzed the 3 benchmark runs on commit `abc`.
 These are errors that were caught while running the benchmarks. You can click each link to go to the Conbench entry for that benchmark, which might have more information about what the error was.
 
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
-  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmarks/some-benchmark-uuid-4)
-  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmarks/some-benchmark-uuid-4)
-  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmarks/some-benchmark-uuid-4)
+  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-2...some-benchmark-uuid-4)
+  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-2...some-benchmark-uuid-4)
+  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-2...some-benchmark-uuid-4)
 
 ## Benchmarks with performance regressions
 
@@ -16,9 +16,9 @@ There were 3 possible performance regressions, according to the lookback z-score
 ### Benchmarks with regressions:
 
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
-  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)
-  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)
-  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)
+  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
+  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
+  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
 
 ## All benchmark runs analyzed:
 

--- a/benchalerts/tests/unit_tests/expected_md/summary_errors_nobaselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_errors_nobaselines.md
@@ -5,8 +5,8 @@ Conbench analyzed the 2 benchmark runs on commit `abc`.
 These are errors that were caught while running the benchmarks. You can click each link to go to the Conbench entry for that benchmark, which might have more information about what the error was.
 
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
-  - [file-write](http://localhost/benchmarks/some-benchmark-uuid-2)
-  - [file-write](http://localhost/benchmarks/some-benchmark-uuid-2)
+  - [file-write](http://localhost/benchmark-results/some-benchmark-uuid-2)
+  - [file-write](http://localhost/benchmark-results/some-benchmark-uuid-2)
 
 ## Benchmarks with performance regressions
 

--- a/benchalerts/tests/unit_tests/expected_md/summary_regressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_regressions.md
@@ -7,8 +7,8 @@ There were 2 possible performance regressions, according to the lookback z-score
 ### Benchmarks with regressions:
 
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
-  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)
-  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/benchmarks/some-benchmark-uuid-3)
+  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
+  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
 
 ## All benchmark runs analyzed:
 


### PR DESCRIPTION
Closes #1189. This PR changes the links in the Check summaries and PR comments to link to the compare pages for benchmark results, not just the contender pages, whenever we can.