### PR TITLE
BMRT cache: use selectinload strategy

### DIFF
--- a/conbench/job.py
+++ b/conbench/job.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from typing import Dict, List, Optional, Tuple, TypedDict
 
 import sqlalchemy
+from sqlalchemy.orm import selectinload
 
 import conbench.metrics
 from conbench.config import Config
@@ -16,7 +17,6 @@ from conbench.entities.benchmark_result import (
     ui_mean_and_uncertainty,
     ui_rel_sem,
 )
-from conbench.entities.run import Run
 from conbench.hacks import get_case_kvpair_strings
 
 # A memory profiler, and a CPU profiler that are both tested to work well


### PR DESCRIPTION
For #1222. I started looking at the specific query count with this method:
```
± cat count-queries.patch 
diff --git a/conbench/db.py b/conbench/db.py
index 62c62c8..4c184e4 100644
--- a/conbench/db.py
+++ b/conbench/db.py
@@ -35,7 +35,7 @@ def configure_engine(url):
     engine = create_engine(
         url,
         future=True,
-        echo=False,
+        # echo=True,
         pool_pre_ping=True,
         # As of today some requests take a (too) long while to generate a
         # response for. We want to improve that fundamentally over time. Until
diff --git a/conbench/job.py b/conbench/job.py
index 9991f1f..f10ea3c 100644
--- a/conbench/job.py
+++ b/conbench/job.py
@@ -17,6 +17,7 @@ from conbench.entities.benchmark_result import (
     ui_rel_sem,
 )
 from conbench.entities.run import Run
+from conbench.entities.hardware import Hardware
 from conbench.hacks import get_case_kvpair_strings
 
 # A memory profiler, and a CPU profiler that are both tested to work well
@@ -34,6 +35,7 @@ Central cache data structure are Python dictionaries (with thread-safe(atomic)
 set/get operations).
 """
 
+
 original_sigint_handler = signal.getsignal(signal.SIGINT)
 original_sigquit_handler = signal.getsignal(signal.SIGQUIT)
 
@@ -111,6 +113,28 @@ bmrt_cache: CacheDict = {
 SHUTDOWN = False
 _STARTED = False
 
+import contextlib
+from sqlalchemy import event
+
+
+@contextlib.contextmanager
+def count_queries(conn):
+    queries = []
+
+    def before_cursor_execute(
+        conn, cursor, statement, parameters, context, executemany
+    ):
+        queries.append(statement)
+
+    event.listen(conn, "before_cursor_execute", before_cursor_execute)
+    try:
+        yield queries
+    finally:
+        event.remove(conn, "before_cursor_execute", before_cursor_execute)
+
+
+from sqlalchemy.orm import selectinload, raiseload
+
 
 # Fetching one million items from a sample DB takes ~1 minute on my machine
 # (the `results = Session.scalars(....all())` call takes that long.
@@ -129,6 +153,9 @@ def _fetch_and_cache_most_recent_results(n=0.08 * 10**6) -> None:
     # too, and so that result.run.hardware is a quick lookup.
     query_statement = (
         sqlalchemy.select(BenchmarkResult)
+        # .options(selectinload(BenchmarkResult.run))
+        # .options(selectinload(Run.hardware))
+        # .options(raiseload(BenchmarkResult.run.commit))
         .join(Run)
         .order_by(BenchmarkResult.timestamp.desc())
         .limit(n)
@@ -280,7 +307,9 @@ def _periodically_fetch_last_n_benchmark_results() -> None:
 
             try:
                 # filprofile(lambda: _fetch_and_cache_most_recent_results(), "fil-result")
-                _fetch_and_cache_most_recent_results()
+                with count_queries(Session.connection()) as queries:
+                    _fetch_and_cache_most_recent_results()
+                print("total number of queries: %s" % len(queries))
             except Exception as exc:
                 # For now, log all error detail. (but handle all exceptions; do
                 # some careful log-reading after rolling this out).

```
props to Mike, as always: https://github.com/sqlalchemy/sqlalchemy/issues/5709#issuecomment-729689097


With the `.join(Run)`: `total number of queries: 225`
With `.options(selectinload(BenchmarkResult.run))`: `total number of queries: 41`

Let's try out which difference this makes in our RDS/cloud deployment scenario.