### PR TITLE
benchmark-centric view(s): increase BMRT cache size, display topN newest results with 'timeago'. various visual tweaks

### DIFF
--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -38,21 +38,28 @@ def list_benchmarks() -> str:
         )
     )
 
-    benchmarks_by_name_sorted_by_most_recent_result = dict(
-        sorted(
-            bmrt_cache["by_benchmark_name"].items(),
-            key=lambda item: time_of_newest_of_many_results(item[1]),
+    newest_result_by_bname = {
+        bname: newest_of_many_results(bmrlist)
+        for bname, bmrlist in bmrt_cache["by_benchmark_name"].items()
+    }
+
+    newest_result_for_each_benchmark_name_sorted = [
+        bmr
+        for _, bmr in sorted(
+            newest_result_by_bname.items(),
+            key=lambda item: item[1].started_at,
+            reverse=True,
         )
-    )
+    ]
 
     return flask.render_template(
         "c-benchmarks.html",
         benchmarks_by_name=bmrt_cache["by_benchmark_name"],
         benchmark_result_count=len(bmrt_cache["by_id"]),
         benchmarks_by_name_sorted_alphabetically=benchmarks_by_name_sorted_alphabetically,
-        benchmarks_by_name_sorted_by_most_recent_result_topN=get_first_n_dict_subset(
-            benchmarks_by_name_sorted_by_most_recent_result, 15
-        ),
+        newest_result_for_each_benchmark_name_topN=newest_result_for_each_benchmark_name_sorted[
+            :15
+        ],
         bmr_cache_meta=bmrt_cache["meta"],
         application=Config.APPLICATION_NAME,
         title=Config.APPLICATION_NAME,  # type: ignore

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -126,7 +126,7 @@ _STARTED = False
 
 # Fetching one million items from a sample DB takes ~1 minute on my machine
 # (the `results = Session.scalars(....all())` call takes that long.
-def _fetch_and_cache_most_recent_results(n=0.08 * 10**6) -> None:
+def _fetch_and_cache_most_recent_results(n=0.2 * 10**6) -> None:
     log.debug(
         "BMRT cache: keys in cache: %s",
         len(bmrt_cache["by_id"]),

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -4,12 +4,14 @@ import signal
 import threading
 import time
 from collections import defaultdict
+from datetime import datetime
 from typing import Dict, List, Optional, Tuple, TypedDict
 
 import sqlalchemy
 from sqlalchemy.orm import selectinload
 
 import conbench.metrics
+import conbench.util
 from conbench.config import Config
 from conbench.db import Session
 from conbench.entities.benchmark_result import (
@@ -83,6 +85,16 @@ class BMRTBenchmarkResult:
     @property
     def ui_rel_sem(self) -> Tuple[str, str]:
         return ui_rel_sem(self.data)
+
+    @property
+    def started_at_iso(self) -> str:
+        """
+        Add an ISO timestring on the object so that JavaScript's `new
+        Date(input)` can parse this into a tz-aware object.
+        """
+        return conbench.util.tznaive_dt_to_aware_iso8601_for_api(
+            datetime.fromtimestamp(self.started_at)
+        )
 
 
 class CacheDict(TypedDict):

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -239,7 +239,7 @@ def _fetch_and_cache_most_recent_results(n=0.08 * 10**6) -> None:
             (first_result.timestamp - last_result.timestamp).days
         ),
         oldest_result_time_str=last_result.ui_time_started_at,
-        n_results=len(by_name_dict),
+        n_results=len(by_id_dict),
     )
 
     conbench.metrics.GAUGE_BMRT_CACHE_LAST_UPDATE_SECONDS.set(t1 - t0)

--- a/conbench/static/app.css
+++ b/conbench/static/app.css
@@ -7,6 +7,13 @@ html {
   font-size: 14px;
 }
 
+/* spacing between DT items */
+div.dataTables_filter label {
+  font-size: 12px;
+  margin-left: 10px;
+ }
+
+
 /* fix blue border on button click */
 .btn:focus,.btn:active {
   outline: none !important;

--- a/conbench/templates/c-benchmark-cases.html
+++ b/conbench/templates/c-benchmark-cases.html
@@ -58,6 +58,8 @@
             // published in https://cdn.datatables.net/plug-ins/1.13.3/features/.
             // kudos to https://stackoverflow.com/a/29639664/145400
           "conditionalPaging": true,
+          // hide the "Showing 1 to 12 of 12 entries" element
+          "bInfo" : false,
           "responsive": true,
             // the default default seems to be the first item in lengthMenu.
           "lengthMenu": [ 5, 10, 50, 75, 100, 250, 750 ],
@@ -65,8 +67,14 @@
           "pageLength": 50,
             // Take rather precise control of layouting elements, put bottom elements
             // into a mult-col single row, using BS's grid system.
-          "dom": 'lfrt<"row"<"col-6"i><".col-6"p>>',
-            // default sort order: by result count, highest first
+          "dom": '<"row"<"d-flex flex-row-reverse p-0"fl>>rt<"row p-2"<"col-6"i><".col-6"p>>',
+          "language": {
+            "search": '',
+            "searchPlaceholder": "search all columns",
+            "lengthMenu": "show _MENU_ cases",
+          },
+
+          // default sort order: by result count, highest first
           "order": [[2, 'desc']],
           "columnDefs": [{ "orderable": true }],
           initComplete: function () {

--- a/conbench/templates/c-benchmark-cases.html
+++ b/conbench/templates/c-benchmark-cases.html
@@ -1,17 +1,14 @@
 {% extends "app.html" %}
 {% block app_content %}
   <h3>
-    <strong>{{ benchmark_name }}</strong> / unique case permutations
+    Case permutations for benchmark <strong>{{ benchmark_name }}</strong>
   </h3>
   <p>
-    Found {{ benchmark_result_count }} result(s) for benchmark <code>{{ benchmark_name }}</code>,
-    spanning {{ results_by_case_id|length }} case(s).
+    Found <strong>{{ results_by_case_id|length }}</strong> unique case permutation(s)
+    across <strong>{{ benchmark_result_count }}</strong> result(s).
     <br>
-    Based on {{ bmr_cache_meta.n_results }} results reported in
-    total between {{ bmr_cache_meta.oldest_result_time_str }} and
-    {{ bmr_cache_meta.newest_result_time_str }}
   </p>
-  <div class="mt-5">
+  <div class="mt-3">
     <table class="table table-hover conbench-datatable"
            style="width:100%;
                   display: none">
@@ -41,6 +38,9 @@
       </tbody>
     </table>
   </div>
+  Report based on {{ bmr_cache_meta.n_results }} results reported in
+  total between {{ bmr_cache_meta.oldest_result_time_str }} and
+  {{ bmr_cache_meta.newest_result_time_str }}
 {% endblock %}
 {% block scripts %}
   {{ super() }}

--- a/conbench/templates/c-benchmarks.html
+++ b/conbench/templates/c-benchmarks.html
@@ -4,9 +4,12 @@
     <strong>Benchmarks</strong>
   </h3>
   <p>
-    Based on <strong>{{ benchmark_result_count }}</strong> results reported in
-    total between <strong>{{ bmr_cache_meta.oldest_result_time_str }}</strong> and
-    <strong>{{ bmr_cache_meta.newest_result_time_str }}</strong>
+    <strong>{{ benchmarks_by_name | length }}</strong> unique benchmark names
+    across the <strong>{{ bmr_cache_meta.n_results }}</strong> most recently submitted results.
+    <br>
+    Time window:
+    {{ bmr_cache_meta.oldest_result_time_str }} to
+    {{ bmr_cache_meta.newest_result_time_str }}
     (~{{ bmr_cache_meta.covered_timeframe_days_approx }} days).
   </p>
   <div class="row mt-5">
@@ -19,12 +22,21 @@
       {% endfor %}
     </div>
     <div class="col">
-      <h4>by most recent result (top 15)</h4>
-      {% for benchmark_name, results in benchmarks_by_name_sorted_by_most_recent_result_topN.items() %}
-        <strong><a href="{{ url_for('app.show_benchmark_cases', bname=benchmark_name) }}">{{ benchmark_name }}</a></strong>
-        ({{ results|length }} results)
+      <h4>by most recent result</h4>
+      {% for result in newest_result_for_each_benchmark_name_topN %}
+        <strong><a href="{{ url_for('app.show_benchmark_cases', bname=result.benchmark_name) }}">{{ result.benchmark_name }}</a></strong>
+        (<time class="timeago" datetime="{{ result.started_at_iso }}">{{ result.ui_time_started_at }}</time>)
         <br>
       {% endfor %}
     </div>
   </div>
+{% endblock %}
+{% block scripts %}
+  {{ super() }}
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-timeago/1.6.7/jquery.timeago.min.js"></script>
+  <script type="text/javascript">
+  $(document).ready(function() {
+     $("time.timeago").timeago();
+  });
+  </script>
 {% endblock %}


### PR DESCRIPTION
More "UI work", enabled by recent architectural changes, also see
https://github.com/conbench/conbench/issues/1222
https://github.com/conbench/conbench/issues/1218
https://github.com/conbench/conbench/issues/1211

Related: https://github.com/conbench/conbench/issues/1154

Landing page example:
![Screenshot from 2023-05-05 15-15-25](https://user-images.githubusercontent.com/265630/236467825-e0906449-81aa-4e2a-92e9-e680366d1e78.png)

Case permutation listing example:
![image](https://user-images.githubusercontent.com/265630/236468483-1aa72a84-e487-4e3a-9bc5-8a741aaa288b.png)

This is a small milestone worth integrating. The overall change set looks small, but I spent quite a bit of time on this. This borrows fragments from #1193.
