### PR TITLE
webapp container image: set up postgres-client-15, misc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,6 @@ RUN pwd && /bin/ls -1 .
 COPY ./buildinfo.json /buildinfo.json
 
 # Re-active this to get ideas for how the image size can be further reduced.
-#RUN echo "biggest dirs"
-#RUN cd / && du -ha . | sort -r -h | head -n 50 || true
+# RUN echo "biggest dirs"
+# RUN cd / && du -ha . | sort -r -h | head -n 50 || true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # The downside here is that with `build-essential` baked into the image we
 # do a bad job optimizing for image size; but we do that anyway so far, so
 # maybe it's really not a big deal.
-FROM python:3.11-slim
+FROM python:3.11-slim-bullseye
 
 # curl is needed for docker-compose health checks. `git` is needed by some unit
 # tests as of today.

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,8 @@ RUN pwd && /bin/ls -1 .
 # Installing this package as of now is necessary not for installing
 # dependencies, but for preventing:
 # importlib.metadata.PackageNotFoundError: No package metadata was found for conbench
-# RUN pip install .
+# This needs cleanup, see https://github.com/conbench/conbench/issues/617
+RUN pip install .
 
 # Bake build information into container image. This invalidates the layer
 # cache for every commit and therefore it is important to do this as late as

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN pwd && /bin/ls -1 .
 # Installing this package as of now is necessary not for installing
 # dependencies, but for preventing:
 # importlib.metadata.PackageNotFoundError: No package metadata was found for conbench
-RUN pip install .
+# RUN pip install .
 
 # Bake build information into container image. This invalidates the layer
 # cache for every commit and therefore it is important to do this as late as

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,10 @@ lint-ci:
 	curlylint conbench/templates/
 	djlint . --extension=html.j2 --check --indent=2 conbench/templates/*html
 
+.PHONY: lint-html
+lint-html:
+	curlylint conbench/templates/
+	djlint . --extension=html.j2 --reformat --indent=2 conbench/templates/*html
 
 .PHONY: rebuild-expected-api-docs
 rebuild-expected-api-docs: run-app-bg


### PR DESCRIPTION
- Explicit Debian Bullseye (no Debian dist version moving target)
- Install PG 15 tooling from official PG APT repo
- Remove legacy hack: https://github.com/conbench/conbench/commit/56215d66ae4e80521fea1aed6c39b32fe9a24f1b (this can unlock image cleanup)
- Show container image size as part of build pipeline
- Tiny bit of variable cleanup ("FLASK_APP" carries a name for a container image, this has quite a bit of drag


Desired side effect:
```
conbench.db] INFO: psycopg2.__libpq_version__: 150002
```
(i.e. the psycopg2 source build picks up the more modern libpq-dev)