### PR TITLE
c-bench tinyplot: show unit, link to last result

### DIFF
--- a/conbench/templates/c-benchmark-results-for-case.html
+++ b/conbench/templates/c-benchmark-results-for-case.html
@@ -63,7 +63,7 @@
         {% for hwctx, plotinfo in infos_for_uplots.items() %}
           <!-- with xl-6 I have tested that each plot (fixed width) has enough space -->
           <div class="col-xl-6 mb-5">
-              {{ plotinfo.title }}, <a href="{{ plotinfo.url_to_newest_result }}">newest result</a>
+            {{ plotinfo.title }}, <a href="{{ plotinfo.url_to_newest_result }}">newest result</a>
             <div class="cb-plot-{{ hwctx }}" style="width: 550px"></div>
           </div>
         {% endfor %}

--- a/conbench/templates/c-benchmark-results-for-case.html
+++ b/conbench/templates/c-benchmark-results-for-case.html
@@ -63,7 +63,7 @@
         {% for hwctx, plotinfo in infos_for_uplots.items() %}
           <!-- with xl-6 I have tested that each plot (fixed width) has enough space -->
           <div class="col-xl-6 mb-5">
-            <h5 class="mt-2">{{ plotinfo.title }}</h5>
+              {{ plotinfo.title }}, <a href="{{ plotinfo.url_to_newest_result }}">newest result</a>
             <div class="cb-plot-{{ hwctx }}" style="width: 550px"></div>
           </div>
         {% endfor %}
@@ -158,6 +158,7 @@
         axes: [
           {},
           {
+            label: "{{ y_unit_for_all_plots }}",
             scale: "y",
             // give y axis labels some space
             //size: 57,


### PR DESCRIPTION
For issues #1154 and #1240. Two improvements on the tinyplots / small multiples:

### Axis label (benchmark metric unit):

Current state (before this patch, plot not showing unit on y-axis/ordinate:
![image](https://user-images.githubusercontent.com/265630/236807284-3a747234-6639-4ac4-b263-a735881235e1.png)

That's of course a no-go. Mentioned that in #1154, but now that we have #1243 I also like to link to that.

With this patch, we show the unit on the ordinate ("axis label"):
![image](https://user-images.githubusercontent.com/265630/236807951-63a14a02-1a20-43c9-bcfe-db6f82c7a3a5.png)

### Link to "most recent result" shown in plot

For the proper history plot.

![Screenshot from 2023-05-06 17-48-36](https://user-images.githubusercontent.com/265630/236808307-619ee071-4b77-4d54-9bd7-595fbe4fe5a4.png)
