### PR TITLE
c-benchmarks: card grid, results-per-case panel, tinyplots in gutter, work on plot presentation

### DIFF
--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -25,7 +25,8 @@ import conbench.logger
 try:
     __version__ = importlib_metadata.version(__name__)
 except Exception:
-    # When is this expected to happen?
+    # When is this expected to happen? Is this meant for the CLI code path?
+    # Or for the web app?
     __version__ = importlib_metadata.version("conbench")
 
 del importlib_metadata

--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -26,7 +26,7 @@ try:
     __version__ = importlib_metadata.version(__name__)
 except Exception:
     # When is this expected to happen? Is this meant for the CLI code path?
-    # Or for the web app?
+    # Or for the web app? TODO: https://github.com/conbench/conbench/issues/617
     __version__ = importlib_metadata.version("conbench")
 
 del importlib_metadata

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Tuple, TypedDict
 import flask
 import orjson
 
+import conbench.numstr
 from conbench.app import app
 from conbench.app._endpoint import authorize_or_terminate
 from conbench.config import Config
@@ -233,7 +234,9 @@ def show_benchmark_results(bname: str, caseid: str) -> str:
 
     # Need to find a way to put bytes straight into jinja template.
     # still is still a tiny bit faster than using stdlib json.dumps()
-    infos_for_uplots_json = orjson.dumps(infos_for_uplots).decode("utf-8")
+    infos_for_uplots_json = orjson.dumps(
+        infos_for_uplots, option=orjson.OPT_INDENT_2
+    ).decode("utf-8")
 
     return flask.render_template(
         "c-benchmark-results-for-case.html",

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -39,7 +39,7 @@ def list_benchmarks() -> str:
         )
     )
 
-    newest_result_by_bname = {
+    newest_result_by_bname: Dict[str, BMRTBenchmarkResult] = {
         bname: newest_of_many_results(bmrlist)
         for bname, bmrlist in bmrt_cache["by_benchmark_name"].items()
     }
@@ -53,13 +53,22 @@ def list_benchmarks() -> str:
         )
     ]
 
+    benchmarks_by_name_sorted_by_resultcount = dict(
+        sorted(
+            bmrt_cache["by_benchmark_name"].items(),
+            key=lambda item: len(item[1]),
+            reverse=True,
+        ),
+    )
+
     return flask.render_template(
         "c-benchmarks.html",
         benchmarks_by_name=bmrt_cache["by_benchmark_name"],
         benchmark_result_count=len(bmrt_cache["by_id"]),
         benchmarks_by_name_sorted_alphabetically=benchmarks_by_name_sorted_alphabetically,
+        benchmarks_by_name_sorted_by_resultcount=benchmarks_by_name_sorted_by_resultcount,
         newest_result_for_each_benchmark_name_topN=newest_result_for_each_benchmark_name_sorted[
-            :15
+            :20
         ],
         bmr_cache_meta=bmrt_cache["meta"],
         application=Config.APPLICATION_NAME,

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -197,10 +197,17 @@ def show_benchmark_results(bname: str, caseid: str) -> str:
 
         infos_for_uplots[f"{hwid}_{ctxid}"] = {
             "data_for_uplot": [
-                [r.started_at for r in results],
-                # rely on mean to be correct? use all data for
-                # error vis
-                [float(r.mean) for r in results if r.mean is not None],
+                # Send timestamp with 1 second resolution.
+                [int(r.started_at) for r in results],
+                # Use single value summary (right now: mean or NaN). Also:
+                # there is no need to send an abstruse number of significant
+                # digits here (64 bit floating point precision). Benchmark
+                # results should not vary across many orders of magnitude
+                # between invocations. If they do, it's a qualitative problem
+                # and the _precise_ difference does not need to be readable
+                # from these plots. I think sending detail across seven orders
+                # of magnitude is fine.
+                [conbench.numstr.numstr(r.svs, 7) for r in results],
             ],
             # Rely on at least one result being in the list.
             "title": "hardware: %s, context: %s, %s results"

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -61,12 +61,34 @@ def list_benchmarks() -> str:
         ),
     )
 
+    # Note(JP): build an average "results per case" metric to normalize for
+    # those benchmarks that have many results but also many case permutations.
+    # As we frequently find us saying in discussions, the individual case
+    # permutation is what we look at as the individual benchmark.
+    benchmark_names_by_results_per_case: Dict[str, str] = {}
+    for bname, results in bmrt_cache["by_benchmark_name"].items():
+        case_count = len(set(r.case_id for r in results))
+        ratio = len(results) / float(case_count)
+        # Sort order is not too important when there is a clash here as of
+        # loss in precision.
+        ratio_str = f"{ratio:.1f}"
+        benchmark_names_by_results_per_case[bname] = ratio_str
+
+    benchmark_names_by_results_per_case_sorted = dict(
+        sorted(
+            benchmark_names_by_results_per_case.items(),
+            key=lambda item: float(item[1]),
+            reverse=True,
+        )
+    )
+
     return flask.render_template(
         "c-benchmarks.html",
         benchmarks_by_name=bmrt_cache["by_benchmark_name"],
         benchmark_result_count=len(bmrt_cache["by_id"]),
         benchmarks_by_name_sorted_alphabetically=benchmarks_by_name_sorted_alphabetically,
         benchmarks_by_name_sorted_by_resultcount=benchmarks_by_name_sorted_by_resultcount,
+        benchmark_names_by_results_per_case_sorted=benchmark_names_by_results_per_case_sorted,
         newest_result_for_each_benchmark_name_topN=newest_result_for_each_benchmark_name_sorted[
             :20
         ],

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -5,7 +5,7 @@ import threading
 import time
 from collections import defaultdict
 from datetime import datetime
-from typing import Dict, List, Optional, Tuple, TypedDict
+from typing import Dict, List, Tuple, TypedDict
 
 import sqlalchemy
 from sqlalchemy.orm import selectinload

--- a/conbench/static/app.css
+++ b/conbench/static/app.css
@@ -14,6 +14,13 @@ div.dataTables_filter label {
  }
 
 
+div.cb-tinyplot {
+  background-color: #f3f3f3;
+  /* make div as wide as content, not as wide as wrapper */
+  display: inline-block;
+
+}
+
 /* fix blue border on button click */
 .btn:focus,.btn:active {
   outline: none !important;

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -20,6 +20,12 @@
           <link href="{{ url_for('static', filename='app.css') }}" rel=stylesheet type=text/css>
           <link rel="stylesheet"
                 href="https://cdn.jsdelivr.net/npm/uplot@1.6.24/dist/uPlot.min.css">
+          <link rel="preconnect" href="https://fonts.googleapis.com">
+          <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+          <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@300;400&display=swap"
+                rel="stylesheet">
+
+
         {% endblock %}
         <title>
           {% block title %}

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -24,8 +24,6 @@
           <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
           <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@300;400&display=swap"
                 rel="stylesheet">
-
-
         {% endblock %}
         <title>
           {% block title %}

--- a/conbench/templates/c-benchmark-results-for-case.html
+++ b/conbench/templates/c-benchmark-results-for-case.html
@@ -223,8 +223,8 @@
     };
 
     $(document).ready(function () {
-    // Enable bootstrap tooltips on this page.
-    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+      // Enable bootstrap tooltips on this page.
+      const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
       const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));
 
       $('table.conbench-datatable').each(function() {

--- a/conbench/templates/c-benchmark-results-for-case.html
+++ b/conbench/templates/c-benchmark-results-for-case.html
@@ -69,6 +69,7 @@
         {% endfor %}
       </div>
     </div>
+    <div style="font-family: 'Roboto Mono';">.</div>
   </div>
 {% endblock %}
 {% block scripts %}
@@ -119,6 +120,7 @@
       }
       return 45;
     }
+    function renderPlots() {
       function generateUPlotOpts(yValues) {
       return {
         title: "",
@@ -137,13 +139,13 @@
             sorted: 0,
             show: true,
             spanGaps: false,
-            stroke: 'rgb(87, 125, 134)',
-            width: 0.5,
+            stroke: "#812570", // dark magenta, main line color
+            width: 0.6,
             // I have been taking greenish colors from this palette:
             // https://colorhunt.co/palette/b9eddd87cbb9569daa577d86 We can
             // think about greenifying some graphs, and reddifying others,
             // based on their properties.
-            fill: "rgba(135, 203, 185, 0.4)",
+            fill: "#38BDD122", // skyblue, transp
             //fill: "rgba(255, 0, 0, 0.3)",
             //dash: [10, 5],
             scale: "y",
@@ -156,9 +158,29 @@
           }
         ],
         axes: [
-          {},
+          {
+            label: "benchmark time",
+            labelFont: "bold 12px 'Roboto Mono'",
+            font: "11px 'Roboto Mono'",
+            stroke: "#812570", // dark magenta
+            // 24 hour format on time axis ticks, remove am/pm, etc.
+            // Copied the default value from docs, then edited.
+            values: [
+            // tick incr          default           year                             month    day                        hour     min                sec       mode
+              [3600 * 24 * 365,   "{YYYY}",         null,                            null,    null,                      null,    null,              null,        1],
+              [3600 * 24 * 28,    "{MMM}",          "\n{YYYY}",                      null,    null,                      null,    null,              null,        1],
+              [3600 * 24,         "{MM}/{DD}",        "\n{YYYY}",                      null,    null,                      null,    null,              null,        1],
+              [3600,              "{HH}",        "\n{YYYY}-{MM}-{DD}",                null,    "\n{MM}-{DD}",               null,    null,              null,        1],
+              [60,                "{HH}:{mm}",   "\n{YYYY}-{MM}-{DD}",                null,    "\n{MM}-{DD}",               null,    null,              null,        1],
+              [1,                 ":{ss}",          "\n{YYYY}-{MM}-{DD} {HH}:{mm}",   null,    "\n{MM}-{DD} {HH}:{mm}",  null,    "\n{HH}:{mm}",  null,        1],
+              [0.001,             ":{ss}.{fff}",    "\n{YYYY}-{MM}-{DD} {HH}:{mm}",   null,    "\n{MM}-{DD} {HH}:{mm}",  null,    "\n{HH}:{mm}",  null,        1],
+            ],
+          },
           {
             label: "{{ y_unit_for_all_plots }}",
+            labelFont: "bold 12px 'Roboto Mono'",
+            font: "11px  'Roboto Mono'",
+            stroke: "#812570", // dark magenta
             scale: "y",
             // give y axis labels some space
             //size: 57,
@@ -183,7 +205,7 @@
 
           }
         },
-      };
+      }};
 
       {% for hwctx, plotinfo in infos_for_uplots.items() %}
         // About plot_info_by_hwctx[xxx]["data_for_uplot"]:
@@ -196,8 +218,11 @@
           );
       {% endfor %}
 
+    };
+
+    $(document).ready(function () {
     // Enable bootstrap tooltips on this page.
-      const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
       const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));
 
       $('table.conbench-datatable').each(function() {
@@ -228,5 +253,26 @@
         });
       });
     });
+
+  // https://stackoverflow.com/a/7289880/145400
+  // https://github.com/typekit/webfontloader
+  WebFontConfig = {
+      google: {
+        families: ['Roboto']
+      },
+      active: function() {
+      /* code to execute once all font families are loaded */
+      console.log(" I sure hope my font is loaded now. ");
+      renderPlots();
+    }
+   };
+
+   (function(d) {
+      var wf = d.createElement('script'), s = d.scripts[0];
+      wf.src = 'https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js';
+      wf.async = true;
+      s.parentNode.insertBefore(wf, s);
+   })(document);
+
   </script>
 {% endblock %}

--- a/conbench/templates/c-benchmark-results-for-case.html
+++ b/conbench/templates/c-benchmark-results-for-case.html
@@ -1,73 +1,75 @@
 {% extends "app.html" %}
 {% block app_content %}
-  <div>
-    <h3>
-      <strong>{{ benchmark_name }}</strong> / case {{ this_case_id[:7] }}
-    </h3>
-    <span class="fs-4"><code>{{ this_case_text_id }}</code></span>
-    <p>
-      Identified {{ matching_benchmark_result_count }} result(s) matching this case permutation.
-      Based on {{ bmr_cache_meta.n_results }} results reported in
-      total between {{ bmr_cache_meta.oldest_result_time_str }} and
-      {{ bmr_cache_meta.newest_result_time_str }}.
-    </p>
-    <p>Showing {{ benchmark_results_for_table|length }} of {{ matching_benchmark_result_count }} results:</p>
-    <div class="mt-5">
-      <table class="table table-hover conbench-datatable"
-             style="width:100%;
-                    display: none">
-        <thead>
+  <h3>
+    <strong>{{ benchmark_name }}</strong> / case {{ this_case_id[:7] }}
+  </h3>
+  <span class="fs-4"><code>{{ this_case_text_id }}</code></span>
+  <p>
+    Identified {{ matching_benchmark_result_count }} result(s) matching this case permutation.
+    Based on {{ bmr_cache_meta.n_results }} results reported in
+    total between {{ bmr_cache_meta.oldest_result_time_str }} and
+    {{ bmr_cache_meta.newest_result_time_str }}.
+  </p>
+  <p>Showing {{ benchmark_results_for_table|length }} of {{ matching_benchmark_result_count }} results:</p>
+  <div class="mt-5">
+    <table class="table table-hover conbench-datatable"
+           style="width:100%;
+                  display: none">
+      <thead>
+        <tr>
+          <th scope="col" style="width: 21%">time</th>
+          <th scope="col">result</th>
+          <th scope="col">hardware</th>
+          <th scope="col">ctx id</th>
+          <th scope="col" style="width: 10%">measurements</th>
+          <th scope="col" style="width: 20%">data</th>
+          <th scope="col" style="width: 10%">
+            rel err
+            <sup><i class="bi bi-info-circle"
+   data-bs-toggle="tooltip"
+   data-bs-title=" Relative standard error: standard error of the mean in relationship to the mean value. Only built when at least three samples are reported by this result. ">
+            </i></sup>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for result in benchmark_results_for_table %}
           <tr>
-            <th scope="col" style="width: 21%">time</th>
-            <th scope="col">result</th>
-            <th scope="col">hardware</th>
-            <th scope="col">ctx id</th>
-            <th scope="col" style="width: 10%"># samples</th>
-            <th scope="col" style="width: 20%">data</th>
-            <th scope="col" style="width: 10%">
-              rel err
-              <i class="bi bi-info-circle"
-                 data-bs-toggle="tooltip"
-                 data-bs-title=" Relative standard error: standard error of the mean in relationship to the mean value. Only built when at least three samples are reported by this result. ">
-              </i>
-            </th>
+            <td class="font-monospace">{{ result.ui_time_started_at }}</td>
+            <td class="font-monospace">
+              <a href="{{ url_for('app.benchmark-result', benchmark_result_id=result.id) }}">{{ result.id [:9] }}</a>
+            </td>
+            <td class="font-monospace">{{ result.ui_hardware_short }}</td>
+            <td class="font-monospace">{{ result.context_id[:8] }}</td>
+            <td class="font-monospace">{{ result.ui_non_null_sample_count }}</td>
+            <td class="font-monospace">{{ result.ui_mean_and_uncertainty }}</td>
+            <td class="font-monospace" data-order="{{ result.ui_rel_sem[0] }}">{{ result.ui_rel_sem[1] }}</td>
           </tr>
-        </thead>
-        <tbody>
-          {% for result in benchmark_results_for_table %}
-            <tr>
-              <td class="font-monospace">{{ result.ui_time_started_at }}</td>
-              <td class="font-monospace">
-                <a href="{{ url_for('app.benchmark-result', benchmark_result_id=result.id) }}">{{ result.id [:9] }}</a>
-              </td>
-              <td class="font-monospace">{{ result.ui_hardware_short }}</td>
-              <td class="font-monospace">{{ result.context_id[:8] }}</td>
-              <td class="font-monospace">{{ result.ui_non_null_sample_count }}</td>
-              <td class="font-monospace">{{ result.ui_mean_and_uncertainty }}</td>
-              <td class="font-monospace" data-order="{{ result.ui_rel_sem[0] }}">{{ result.ui_rel_sem[1] }}</td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-    <div class="mt-5">
-      <h4 class="mb-3">
-        Plots
-        <i class="bi bi-info-circle"
-           data-bs-toggle="tooltip"
-           data-bs-title="Benchmark results, grouped by unique (hardware, context) combinations. Time axis: benchmark result start time (associated commit data is not used), ordinate: mean value, if multisample. A plot is only shown for at least three data points. ">
-        </i>
-      </h4>
-      <!-- https://getbootstrap.com/docs/5.2/layout/grid/#row-columns -->
-      <div class="row .row-cols-auto">
-        {% for hwctx, plotinfo in infos_for_uplots.items() %}
-          <!-- with xl-6 I have tested that each plot (fixed width) has enough space -->
-          <div class="col-xl-6 mb-5">
-            {{ plotinfo.title }}, <a href="{{ plotinfo.url_to_newest_result }}">newest result</a>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  <div class="mt-5">
+    <h3 class="mb-3">
+      History plots
+      <sup><i style="font-size: 12px"
+   class="bi bi-info-circle"
+   data-bs-toggle="tooltip"
+   data-bs-title="Benchmark results, grouped by unique (hardware, context) combinations. Time axis: benchmark result start time (associated commit data is not used), ordinate: mean value, if multisample. A plot is only shown for at least three data points. ">
+      </i></sup>
+    </h3>
+    <!--  Strategy: BS gutters, see https://getbootstrap.com/docs/5.2/layout/gutters/  -->
+    <div class="row gy-5">
+      {% for hwctx, plotinfo in infos_for_uplots.items() %}
+        <div class="col-6" style="width: 600px">
+          <div class="cb-tinyplot pt-4 shadow">
+            <div class="text-center">
+              {{ plotinfo.title }}, <a href="{{ plotinfo.url_to_newest_result }}">newest result</a>
+            </div>
             <div class="cb-plot-{{ hwctx }}" style="width: 550px"></div>
           </div>
-        {% endfor %}
-      </div>
+        </div>
+      {% endfor %}
     </div>
     <div style="font-family: 'Roboto Mono';">.</div>
   </div>
@@ -85,7 +87,7 @@
       let oommax = Math.floor(Math.log(max) / Math.LN10 + 0.000000001);
       return oommax;
     }
-    $(document).ready(function () {
+
     function switchToScientifcNotation(values) {
       // Switch to scientific notation for large values, and for small
       // values. Assume only positive values.
@@ -120,7 +122,9 @@
       }
       return 45;
     }
+
     function renderPlots() {
+
       function generateUPlotOpts(yValues) {
       return {
         title: "",
@@ -150,7 +154,7 @@
             //dash: [10, 5],
             scale: "y",
             points: {
-                // Without `show: true`, points do not always show.
+              // Without `show: true`, points do not always show.
               show: true,
               size: 5,
               fill: 'rgba(87, 125, 134, 0.7)'
@@ -166,7 +170,6 @@
             // 24 hour format on time axis ticks, remove am/pm, etc.
             // Copied the default value from docs, then edited.
             values: [
-            // tick incr          default           year                             month    day                        hour     min                sec       mode
               [3600 * 24 * 365,   "{YYYY}",         null,                            null,    null,                      null,    null,              null,        1],
               [3600 * 24 * 28,    "{MMM}",          "\n{YYYY}",                      null,    null,                      null,    null,              null,        1],
               [3600 * 24,         "{MM}/{DD}",        "\n{YYYY}",                      null,    null,                      null,    null,              null,        1],
@@ -188,18 +191,17 @@
             // This is used for y axis formatting. Trade-off:
             // predictable width, medium precision is sufficient.
             values: (u, splits) => formatValuesForAxis(splits),
-            //values: (u, splits) => splits.map((v) => v.toExponential(2)),
           }
         ],
         scales: {
 
           "y": {
             range: (u, datamin, datamax) => {
-                    // Preparing for all kinds of ranges and orders of
-                    // magnitude, always show the zero for keeping plots most
-                    // meaningful -- if the relative change is very small then
-                    // it will be rather invisible in a plot like this, which
-                    // is the goal.
+              // Preparing for all kinds of ranges and orders of
+              // magnitude, always show the zero for keeping plots most
+              // meaningful -- if the relative change is very small then
+              // it will be rather invisible in a plot like this, which
+              // is the goal.
               return [0, datamax * 1.2];
             },
 
@@ -254,7 +256,11 @@
       });
     });
 
-  // https://stackoverflow.com/a/7289880/145400
+  // uPlot uses canvas for plotting. To make sure the fonts asked for in here
+  // are really available before starting to draw in the canvace element use
+  // the technique described in  https://stackoverflow.com/a/7289880/145400,
+  // otherwise there are plenty of race conditions that might or might not hit
+  // in across browser refreshs. Also see
   // https://github.com/typekit/webfontloader
   WebFontConfig = {
       google: {

--- a/conbench/templates/c-benchmarks.html
+++ b/conbench/templates/c-benchmarks.html
@@ -12,22 +12,42 @@
     {{ bmr_cache_meta.newest_result_time_str }}
     (~{{ bmr_cache_meta.covered_timeframe_days_approx }} days).
   </p>
-  <div class="row mt-5">
+  <div class="row row-cols-1 row-cols-md-3 g-4">
     <div class="col">
-      <h4>by name</h4>
-      {% for benchmark_name, results in benchmarks_by_name_sorted_alphabetically.items() %}
-        <strong><a href="{{ url_for('app.show_benchmark_cases', bname=benchmark_name) }}">{{ benchmark_name }}</a></strong>
-        ({{ results|length }} results)
-        <br>
-      {% endfor %}
+      <div class="card">
+        <div class="card-body overflow-auto" style="max-height: 600px;">
+          <h5 class="card-title">by name</h5>
+          {% for benchmark_name, results in benchmarks_by_name_sorted_alphabetically.items() %}
+            <strong><a href="{{ url_for('app.show_benchmark_cases', bname=benchmark_name) }}">{{ benchmark_name }}</a></strong>
+            ({{ results|length }} results)
+            <br>
+          {% endfor %}
+        </div>
+      </div>
     </div>
     <div class="col">
-      <h4>by most recent result</h4>
-      {% for result in newest_result_for_each_benchmark_name_topN %}
-        <strong><a href="{{ url_for('app.show_benchmark_cases', bname=result.benchmark_name) }}">{{ result.benchmark_name }}</a></strong>
-        (<time class="timeago" datetime="{{ result.started_at_iso }}">{{ result.ui_time_started_at }}</time>)
-        <br>
-      {% endfor %}
+      <div class="card">
+        <div class="card-body overflow-auto" style="max-height: 600px;">
+          <h5 class="card-title">by most recent result</h5>
+          {% for result in newest_result_for_each_benchmark_name_topN %}
+            <strong><a href="{{ url_for('app.show_benchmark_cases', bname=result.benchmark_name) }}">{{ result.benchmark_name }}</a></strong>
+            (<time class="timeago" datetime="{{ result.started_at_iso }}">{{ result.ui_time_started_at }}</time>)
+            <br>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+    <div class="col">
+      <div class="card">
+        <div class="card-body overflow-auto" style="max-height: 600px;">
+          <h5 class="card-title">by result count</h5>
+          {% for benchmark_name, results in benchmarks_by_name_sorted_by_resultcount.items() %}
+            <strong><a href="{{ url_for('app.show_benchmark_cases', bname=benchmark_name) }}">{{ benchmark_name }}</a></strong>
+            ({{ results|length }} results)
+            <br>
+          {% endfor %}
+        </div>
+      </div>
     </div>
   </div>
 {% endblock %}

--- a/conbench/templates/c-benchmarks.html
+++ b/conbench/templates/c-benchmarks.html
@@ -1,13 +1,13 @@
 {% extends "app.html" %}
 {% block app_content %}
   <h3>
-    <strong>Benchmarks</strong>
+    <strong>Overview</strong>
   </h3>
   <p>
-    <strong>{{ benchmarks_by_name | length }}</strong> unique benchmark names
-    across the <strong>{{ bmr_cache_meta.n_results }}</strong> most recently submitted results.
+    <strong>{{ benchmarks_by_name | length }}</strong> unique benchmark names seen
+    across the <strong>{{ bmr_cache_meta.n_results }}</strong> most recently submitted results
     <br>
-    Time window:
+    between
     {{ bmr_cache_meta.oldest_result_time_str }} to
     {{ bmr_cache_meta.newest_result_time_str }}
     (~{{ bmr_cache_meta.covered_timeframe_days_approx }} days).

--- a/conbench/templates/c-benchmarks.html
+++ b/conbench/templates/c-benchmarks.html
@@ -15,7 +15,7 @@
   <div class="row row-cols-1 row-cols-md-3 g-4">
     <div class="col">
       <div class="card">
-        <div class="card-body overflow-auto" style="max-height: 600px;">
+        <div class="card-body overflow-auto" style="max-height: 500px;">
           <h5 class="card-title">by name</h5>
           {% for benchmark_name, results in benchmarks_by_name_sorted_alphabetically.items() %}
             <strong><a href="{{ url_for('app.show_benchmark_cases', bname=benchmark_name) }}">{{ benchmark_name }}</a></strong>
@@ -27,7 +27,7 @@
     </div>
     <div class="col">
       <div class="card">
-        <div class="card-body overflow-auto" style="max-height: 600px;">
+        <div class="card-body overflow-auto" style="max-height: 500px;">
           <h5 class="card-title">by most recent result</h5>
           {% for result in newest_result_for_each_benchmark_name_topN %}
             <strong><a href="{{ url_for('app.show_benchmark_cases', bname=result.benchmark_name) }}">{{ result.benchmark_name }}</a></strong>
@@ -39,7 +39,25 @@
     </div>
     <div class="col">
       <div class="card">
-        <div class="card-body overflow-auto" style="max-height: 600px;">
+        <div class="card-body overflow-auto" style="max-height: 500px;">
+          <h5 class="card-title">by results per case
+              <sup><i style="font-size: 12px"
+                class="bi bi-info-circle"
+                data-bs-toggle="tooltip"
+                data-bs-title="average result count per case permutation">
+               </i></sup>
+          </h5>
+          {% for benchmark_name, ratio in benchmark_names_by_results_per_case_sorted.items() %}
+            <strong><a href="{{ url_for('app.show_benchmark_cases', bname=benchmark_name) }}">{{ benchmark_name }}</a></strong>
+            (~{{ ratio }})
+            <br>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+    <div class="col">
+      <div class="card">
+        <div class="card-body overflow-auto" style="max-height: 500px;">
           <h5 class="card-title">by result count</h5>
           {% for benchmark_name, results in benchmarks_by_name_sorted_by_resultcount.items() %}
             <strong><a href="{{ url_for('app.show_benchmark_cases', bname=benchmark_name) }}">{{ benchmark_name }}</a></strong>
@@ -56,7 +74,10 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-timeago/1.6.7/jquery.timeago.min.js"></script>
   <script type="text/javascript">
   $(document).ready(function() {
-     $("time.timeago").timeago();
+    $("time.timeago").timeago();
+    // Enable bootstrap tooltips on this page.
+    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+    const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));
   });
   </script>
 {% endblock %}

--- a/conbench/templates/c-benchmarks.html
+++ b/conbench/templates/c-benchmarks.html
@@ -40,12 +40,13 @@
     <div class="col">
       <div class="card">
         <div class="card-body overflow-auto" style="max-height: 500px;">
-          <h5 class="card-title">by results per case
-              <sup><i style="font-size: 12px"
-                class="bi bi-info-circle"
-                data-bs-toggle="tooltip"
-                data-bs-title="average result count per case permutation">
-               </i></sup>
+          <h5 class="card-title">
+            by results per case
+            <sup><i style="font-size: 12px"
+   class="bi bi-info-circle"
+   data-bs-toggle="tooltip"
+   data-bs-title="average result count per case permutation">
+            </i></sup>
           </h5>
           {% for benchmark_name, ratio in benchmark_names_by_results_per_case_sorted.items() %}
             <strong><a href="{{ url_for('app.show_benchmark_cases', bname=benchmark_name) }}">{{ benchmark_name }}</a></strong>


### PR DESCRIPTION
This adds panels to the c-bench landing page. It adds a new panel, sorting conceptual benchmarks by average "result count per case", as of https://github.com/conbench/conbench/issues/1247.

This patch touches on a number of things. I started using bootstrap 5's gutter for better grid logic. for example.

I also worked on those "small multiples" "tinyplots" a bit, now also using VD color:
![Screenshot from 2023-05-08 15-53-03](https://user-images.githubusercontent.com/265630/236856106-d2712296-c4c6-4af2-afad-2c5e84e0426e.png)

A screenshot of the panels on the landing page as they look with this current patch, using a snapshot of the arrow DB:

![Screenshot from 2023-05-08 16-39-56](https://user-images.githubusercontent.com/265630/236856224-b0130c6e-efe0-48db-8c2f-b1a56c76e5f4.png)


