### PR TITLE
benchmark result compare page: Rename to benchmark-results and redirect

### DIFF
--- a/conbench/app/compare.py
+++ b/conbench/app/compare.py
@@ -285,8 +285,15 @@ class CompareRuns(Compare):
 
 
 rule(
-    "/compare/benchmarks/<compare_ids>/",
+    "/compare/benchmark-results/<compare_ids>/",
     view_func=CompareBenchmarkResults.as_view("compare-benchmark-results"),
+    methods=["GET"],
+)
+# legacy route
+rule(
+    "/compare/benchmarks/<compare_ids>/",
+    endpoint="compare-benchmarks",
+    redirect_to="/compare/benchmark-results/<compare_ids>/",
     methods=["GET"],
 )
 rule(

--- a/conbench/tests/app/test_compare.py
+++ b/conbench/tests/app/test_compare.py
@@ -16,7 +16,7 @@ def _emsg_needle(thing, thingid):
 
 
 class TestCompareBenchmarkResults(_asserts.GetEnforcer):
-    url = "/compare/benchmarks/{}/"
+    url = "/compare/benchmark-results/{}/"
     title = "Compare Benchmark Results"
     redirect_on_unknown = False
 
@@ -36,6 +36,41 @@ class TestCompareBenchmarkResults(_asserts.GetEnforcer):
 
         response = client.get("/compare/benchmarks/foo...bar/", follow_redirects=True)
         self.assert_page(response, "Compare Benchmark Results")
+        assert "cannot perform comparison:" in response.text
+
+
+class TestCompareBenchmarks(_asserts.AppEndpointTest):
+    url = "/compare/benchmarks/{}/"
+    title = "Compare Benchmark Results"
+    redirect_on_unknown = False
+
+    def _create(self, client):
+        benchmark_result_id = self.create_benchmark(client)
+        return f"{benchmark_result_id}...{benchmark_result_id}"
+
+    def test_redirects(self, client):
+        self.authenticate(client)
+
+        response = client.get(
+            "/compare/benchmarks/unknown...unknown2/", follow_redirects=True
+        )
+        assert "/compare/benchmark-results/unknown...unknown2/" in response.request.url
+        assert any(
+            [
+                "/compare/benchmarks/unknown...unknown2/" == res.request.path
+                for res in response.history
+            ]
+        )
+        assert "cannot perform comparison:" in response.text, response.text
+
+        response = client.get("/compare/benchmarks/foo...bar/", follow_redirects=True)
+        assert "/compare/benchmark-results/foo...bar/" in response.request.url
+        assert any(
+            [
+                "/compare/benchmarks/foo...bar/" == res.request.path
+                for res in response.history
+            ]
+        )
         assert "cannot perform comparison:" in response.text
 
 


### PR DESCRIPTION
Closes #1229. Renames the page to `/compare/benchmark-results/<compare_ids>`, and redirects `/compare/benchmarks/<compare_ids>` to it so existing links will continue to work. Adds some basic tests to ensure the redirect is working. Both the new path and the redirect work in a local instance.

Learned a bit about flask and our testing framework along the way.