### PR TITLE
UI: hist plot: add "highlight other" feature, compare two benchmark results: show hist plot and highlight other (& misc)

### DIFF
--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -722,12 +722,12 @@ def time_series_plot(
         if multisample_count:
             label += f" (n={multisample_count})"
 
-        p.line(
-            source=source_min_over_time,
-            legend_label=label,
-            name="min-over-time",
-            color="#222",
-        )
+        # p.line(
+        #     source=source_min_over_time,
+        #     legend_label=label,
+        #     name="min-over-time",
+        #     color="#222",
+        # )
         p.circle(
             source=source_min_over_time,
             legend_label=label,

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -785,10 +785,8 @@ def time_series_plot(
             size=18,
             line_width=2.5,
             color="#A65DE7",
-            legend_label="current benchmark (mean)"
-            if multisample
-            else "current benchmark",
-            name="benchmark",
+            legend_label="current result (mean)" if multisample else "current result",
+            name="result",
         )
 
         if multisample:
@@ -797,8 +795,8 @@ def time_series_plot(
                 source=source_current_bm_min,
                 size=6,
                 color="#000",
-                name="benchmark",
                 legend_label="current result (min)",
+                name="result",
             )
 
     # further visually separate out distribution changes with a vertical line

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -676,9 +676,9 @@ def time_series_plot(
     p.xaxis.axis_label = "date of commit associated with the benchmark result"
 
     multisample, multisample_count = _inspect_for_multisample(samples)
-    label = "benchmark (n=1)"
+    label = "result (n=1)"
     if multisample:
-        label = "benchmark mean"
+        label = "result mean"
         if multisample_count:
             label += f" (n={multisample_count})"
 
@@ -718,7 +718,7 @@ def time_series_plot(
         # Do not show min-over-time when each benchmark reports at most one
         # sample, i.e. when mean and min are the same.
 
-        label = "benchmark min"
+        label = "result min"
         if multisample_count:
             label += f" (n={multisample_count})"
 
@@ -796,8 +796,8 @@ def time_series_plot(
                 source=source_current_bm_min,
                 size=6,
                 color="#000",
-                legend_label="current benchmark (min)",
                 name="benchmark",
+                legend_label="current result (min)",
             )
 
     # further visually separate out distribution changes with a vertical line
@@ -858,7 +858,7 @@ def time_series_plot(
     )
 
     p.legend.title_text_color = "darkgray"
-    p.legend.title = f"benchmark results: {len(samples)}"
+    p.legend.title = f"number of results: {len(samples)}"
     p.legend.location = "top_left"
 
     # Change the number of expected/desired date x ticks. There is otherwise

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -523,7 +523,7 @@ def time_series_plot(
     samples: List[HistorySample],
     current_benchmark_result: BenchmarkResult,
     run,
-    height=380,
+    height=420,
     width=1100,
     highlight_result_in_hist: Optional[Tuple[HistorySample, str]] = None,
 ):
@@ -606,9 +606,9 @@ def time_series_plot(
 
     t_range = t_end - t_start
 
-    # Add padding/buffer to left and right so that newest data point does not
-    # disappear under right plot boundary, and so that the oldest data point
-    # has space from legend.
+    # Add explicit padding/buffer to left and right so that newest data point
+    # does not disappear under right plot boundary, and so that the oldest data
+    # point has space from legend.
     t_start = t_start - (0.4 * t_range)
     t_end = t_end + (0.07 * t_range)
 
@@ -686,7 +686,7 @@ def time_series_plot(
         source=source_unfiltered_mean_over_time,
         legend_label=label,
         name="samples",
-        size=6,
+        size=5,
         color="#ccc",
         line_width=1,
         selection_color="#76bf5a",  # like bootstrap panel dff0d8, but darker
@@ -782,9 +782,9 @@ def time_series_plot(
     if source_current_bm_mean is not None:
         cur_bench_mean_circle = p.x(
             source=source_current_bm_mean,
-            size=18,
-            line_width=2.5,
-            color="#A65DE7",
+            size=20,
+            line_width=2.7,
+            color="#C440C3",  # VD dark magenta
             legend_label="current result (mean)" if multisample else "current result",
             name="result",
         )
@@ -793,8 +793,8 @@ def time_series_plot(
             # do not show this for n=1 (then min equals to mean).
             cur_bench_min_circle = p.circle(
                 source=source_current_bm_min,
-                size=6,
-                color="#000",
+                size=8,
+                color="#C440C3",
                 legend_label="current result (min)",
                 name="result",
             )
@@ -859,6 +859,7 @@ def time_series_plot(
     p.legend.title_text_color = "darkgray"
     p.legend.title = f"number of results: {len(samples)}"
     p.legend.location = "top_left"
+    p.legend.label_text_font_size = "12px"
 
     # Change the number of expected/desired date x ticks. There is otherwise
     # only very few of them (like 4). Also see

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -642,6 +642,13 @@ def time_series_plot(
         toolbar_location="right",
         x_range=(t_start, t_end),
     )
+
+    # Use a built-in method for taking influence on the y-axis/ordinate range,
+    # just don't zoom in as much as bokeh usually would. For now, we don't show
+    # the zero, and that might be fine so that one can focus on the acutal
+    # change happening (losing perspective if that change matters or not :-)
+    # but yeah that's what stock markets also do ¯\_(ツ)_/¯).
+    p.y_range.range_padding = 0.5
     p.toolbar.logo = None  # type: ignore[attr-defined]
 
     # TapTool is not responding to each click event, but but only triggers when

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -17,15 +17,9 @@ from conbench.entities.history import HistorySample, HistorySampleZscoreStats
 
 from ..hacks import sorted_data
 from ..units import formatter_for_unit
+from .types import BokehPlotJSONOrError, HighlightInHistPlot
 
 log = logging.getLogger(__name__)
-
-
-@dataclasses.dataclass
-class BokehPlotJSONOrError:
-    # mutually exclusive
-    jsondoc: Optional[str]
-    reason_why_no_plot: Optional[str]
 
 
 class HistoryUserFacingError(Exception):

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -750,6 +750,25 @@ def time_series_plot(
         current_benchmark_result, run, formatted, unit
     )
 
+    if highlight_result_in_hist is not None:
+        hs = highlight_result_in_hist[0]
+        description = highlight_result_in_hist[1]
+        bokeh_ds_highlight_result = bokeh.models.ColumnDataSource(
+            data={
+                "x": [hs.commit_timestamp],
+                "y": [hs.svs],
+            }
+        )
+
+        p.x(
+            source=bokeh_ds_highlight_result,
+            size=19,
+            line_width=2.5,
+            color="#005050",  # VD magenta
+            legend_label=f"highlighted result:\n{description} ({hs.svs_type})",
+            name="additionally highlighted benchmark result",
+        )
+
     cur_bench_mean_circle = None
     cur_bench_min_circle = None
     if source_current_bm_mean is not None:

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -345,7 +345,7 @@ def _source(
         # List of short commit hashes with hashtag prefix
         "commit_hashes_short": ["#" + s.commit_hash[:8] for s in samples],
         "relative_benchmark_urls": [
-            f"/benchmarks/{s.benchmark_result_id}" for s in samples
+            f"/benchmark-results/{s.benchmark_result_id}" for s in samples
         ],
         # Stringified values (truncated, with unit)
         "values_with_unit": values_with_unit,
@@ -498,11 +498,11 @@ def gen_js_callback_click_on_glyph_show_run_details(repo_string):
 
         // TODO? show run timestamp, not only commit timestamp.
         var newHtml = \
-            '<li>Report: <a href="' + run_report_relurl + '">' + run_report_relurl + '</a></li>' +
+            '<li>Result view: <a href="' + run_report_relurl + '">' + run_report_relurl + '</a></li>' +
             '<li>Commit: ' + commit_repo_string + '</li>' +
             '<li>Commit message (truncated): ' + run_commit_msg_pfx + '</li>' +
             "<li>Commit timestamp: " + run_date_string + "</li>" +
-            "<li>Result value: " + run_result_value_with_unit + "</li>";
+            "<li>Result mean: " + run_result_value_with_unit + "</li>";
 
 
         if (run_samples_with_units) {{

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -739,12 +739,13 @@ def time_series_plot(
     p.line(
         source=source_rolling_mean_over_time,
         color="#ffa600",
-        legend_label="rolling window mean",
+        line_width=2,
+        legend_label="lookback z-score mean",
     )
     p.line(
         source=source_rolling_alert_min_over_time,
         color="Silver",
-        legend_label="rolling window mean +/- 5 σ",
+        legend_label="lookback z-score leeway",
         line_join="round",
         width=1,
     )

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -648,7 +648,7 @@ def time_series_plot(
     # the zero, and that might be fine so that one can focus on the acutal
     # change happening (losing perspective if that change matters or not :-)
     # but yeah that's what stock markets also do ¯\_(ツ)_/¯).
-    p.y_range.range_padding = 0.5
+    p.y_range.range_padding = 0.5  # type: ignore[attr-defined]
     p.toolbar.logo = None  # type: ignore[attr-defined]
 
     # TapTool is not responding to each click event, but but only triggers when

--- a/conbench/app/compare.py
+++ b/conbench/app/compare.py
@@ -11,6 +11,7 @@ from ..app._endpoint import AppEndpoint, authorize_or_terminate
 from ..app._plots import TimeSeriesPlotMixin, simple_bar_plot
 from ..app._util import augment, error_page
 from ..app.results import BenchmarkResultMixin, RunMixin
+from ..app.types import HighlightInHistPlot
 from ..config import Config
 from ..entities.benchmark_result import BenchmarkResult
 from ..entities.run import commit_hardware_run_map

--- a/conbench/app/results.py
+++ b/conbench/app/results.py
@@ -11,11 +11,12 @@ import conbench.util
 
 from ..app import rule
 from ..app._endpoint import AppEndpoint, authorize_or_terminate
-from ..app._plots import BokehPlotJSONOrError, TimeSeriesPlotMixin
+from ..app._plots import TimeSeriesPlotMixin
 from ..app._util import augment, display_time
 from ..config import Config
 from ..entities._entity import NotFound
 from ..entities.benchmark_result import BenchmarkResult
+from .types import BokehPlotJSONOrError, HighlightInHistPlot
 
 log = logging.getLogger(__name__)
 

--- a/conbench/app/results.py
+++ b/conbench/app/results.py
@@ -231,6 +231,7 @@ class BenchmarkResultView(
         run,
         delete_form,
         update_form,
+        highlight_other_result: Optional[HighlightInHistPlot] = None,
     ) -> str:
         if result_dict is None:
             return self.redirect("app.index")
@@ -253,7 +254,11 @@ class BenchmarkResultView(
             delattr(update_form, "toggle_distribution_change")
 
         if result_obj is not None:
-            plotinfo = self.get_history_plot(result_obj, run)
+            plotinfo = self.get_history_plot(
+                result_obj,
+                run,
+                highlight_other_result=highlight_other_result,
+            )
         else:
             plotinfo = BokehPlotJSONOrError(
                 None,
@@ -276,12 +281,24 @@ class BenchmarkResultView(
     @authorize_or_terminate
     def get(self, benchmark_result_id):
         result_dict, run, result_obj = self._get_benchmark_and_run(benchmark_result_id)
+
+        # Read optional query argument
+        highlight_other: Optional[HighlightInHistPlot] = None
+        highlight_other_str: Optional[str] = f.request.args.get("highlight-other")
+        if highlight_other_str:
+            bmrid = highlight_other_str
+            name = "no description"
+            if "," in highlight_other_str:
+                bmrid, name = highlight_other_str.split(",")[:2]
+            highlight_other = HighlightInHistPlot(bmrid=bmrid, highlight_name=name)
+
         return self.page(
             result_dict,
             result_obj,
             run,
             BenchmarkResultDeleteForm(),
             BenchmarkResultUpdateForm(),
+            highlight_other_result=highlight_other,
         )
 
     def post(self, benchmark_result_id):

--- a/conbench/app/types.py
+++ b/conbench/app/types.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class HighlightInHistPlot:
+    # The benchmark result ID
+    bmrid: str
+    # Displayed in the plot as legend item. E.g. "highlight (contender)"
+    # Must be provided.
+    highlight_name: str
+
+
+@dataclass
+class BokehPlotJSONOrError:
+    # The following two properties are meant to be mutually exclusive
+    jsondoc: Optional[str]
+    reason_why_no_plot: Optional[str]

--- a/conbench/entities/history.py
+++ b/conbench/entities/history.py
@@ -119,7 +119,7 @@ class HistorySample:
         return d
 
 
-def get_history_for_benchmark(benchmark_result_id: str):
+def get_history_for_benchmark(benchmark_result_id: str) -> List[HistorySample]:
     # First, find case / context / hardware / repo combination based on the
     # input benchmark result ID. This database lookup may raise the `NotFound`
     # exception.

--- a/conbench/numstr.py
+++ b/conbench/numstr.py
@@ -95,9 +95,9 @@ _conversion_correctness_tests = (
 if __name__ == "__main__":
     # Run tests.
     for nbr, expected in _conversion_correctness_tests:
-        # got = numstr(nbr)
+        got = numstr(nbr)
+        # got = sigfig.round(nbr, sigfigs=5, output_type=str)
         # got = str(sigfig.round(nbr, sigfigs=5))
-        got = str(sigfig.round(nbr, sigfigs=5))
         assert (
             got == expected
         ), f"input: {repr(nbr)} -- expected {expected} but got {got}"

--- a/conbench/numstr.py
+++ b/conbench/numstr.py
@@ -13,7 +13,7 @@ https://github.com/conbench/conbench/issues/1218
 
 Then I found a test case that fails for sigfig.round(), but does not for
 
-    sigfig.round(15272000, 5) produces "15272000.0", i.e. here we have the
+    sigfig.round(15272063, 5) produces "15272000.0", i.e. here we have the
     unnecessary .0 suffix.
 
 Then I researched further options and gladly found np.format_float_positional()
@@ -71,8 +71,10 @@ def numstr(v: Union[float, int], sigfigs: int = 5) -> str:
 
 
 _conversion_correctness_tests = (
-    (15272063, "15272000"),  # Does not add trailing . or even .0
-    (15272063.0, "15272000"),  # Works with float and int input
+    (15272063, "15272000"),  #
+    # Works with float and int input.
+    # Does not add trailing . or even .0
+    (15272063.0, "15272000"),
     (015272063.0, "15272000"),  # Works with leading zero in input
     (1.2345, "1.2345"),  # Keeps things unmodified
     (1.23456, "1.2346"),  # Performs rounding
@@ -93,8 +95,12 @@ _conversion_correctness_tests = (
 if __name__ == "__main__":
     # Run tests.
     for nbr, expected in _conversion_correctness_tests:
-        got = numstr(nbr)
-        assert got == expected, f"exp {expected} but got {got}"
+        # got = numstr(nbr)
+        # got = str(sigfig.round(nbr, sigfigs=5))
+        got = str(sigfig.round(nbr, sigfigs=5))
+        assert (
+            got == expected
+        ), f"input: {repr(nbr)} -- expected {expected} but got {got}"
 
     # Do a bit of a performance comparison:
     for value, figs in (

--- a/conbench/templates/benchmark-result.html
+++ b/conbench/templates/benchmark-result.html
@@ -38,7 +38,7 @@
     </div>
   {% else %}
     <div class="alert alert-info" role="alert">
-      Cannot display history plot for this benchmark result: {{ history_plot_info.reason_why_no_plot }}
+      Cannot display history plot for this benchmark result: {{ history_plot_info.reason_why_no_plot|safe }}
     </div>
   {% endif %}
   <br />

--- a/conbench/templates/compare-entity.html
+++ b/conbench/templates/compare-entity.html
@@ -49,10 +49,18 @@ matching fields between baseline and contender are aligned and mismatched fields
   </nav>
   <div class="row">
     <div class="col-md-6">
+      <!-- what kind of plot is this supposed to be, especially given that
+        this might be displayed for run vs. run, result vs. result? -->
       <div id="plot" align="center"></div>
       <br />
     </div>
     {% if comparisons %}
+      <!--
+         This table is currently broken, see
+         https://github.com/conbench/conbench/issues/1230
+         when comparing two benchmark results I think the history plot
+         and the tabular comparison of the result measurements are sufficient.
+        let's maybe re-activate it when we understand its value better.
       <div class="col-md-5">
         <table id="benchmarks"
                class="table table-striped table-bordered table-hover">
@@ -88,6 +96,7 @@ matching fields between baseline and contender are aligned and mismatched fields
           </tbody>
         </table>
       </div>
+      -->
     {% endif %}
   </div>
   <div align="center">{{ baseline.display_bmname }}, {{ baseline.display_case_perm }}</div>
@@ -105,13 +114,13 @@ matching fields between baseline and contender are aligned and mismatched fields
             </div>
           </li>
           <li class="list-group-item" style="overflow-y: auto;">
-            <b>batch</b>
+            <b>benchmark name</b>
             <div align="right" style="display:inline-block; float: right;">
               <a href="{{ url_for('app.batch', batch_id=baseline.batch_id ) }}">{{ baseline.display_bmname }}</a>
             </div>
           </li>
           <li class="list-group-item" style="overflow-y: auto;">
-            <b>benchmark</b>
+            <b>case permutation</b>
             <div align="right" style="display:inline-block; float: right;">
               <a href="{{ url_for('app.benchmark-result', benchmark_result_id=baseline.id) }}">{{ baseline.display_case_perm }}</a>
             </div>
@@ -202,13 +211,13 @@ matching fields between baseline and contender are aligned and mismatched fields
             </div>
           </li>
           <li class="list-group-item" style="overflow-y: auto;">
-            <b>batch</b>
+            <b>benchmark name</b>
             <div align="right" style="display:inline-block; float: right;">
               <a href="{{ url_for('app.batch', batch_id=contender.batch_id ) }}">{{ contender.display_bmname }}</a>
             </div>
           </li>
           <li class="list-group-item" style="overflow-y: auto;">
-            <b>benchmark</b>
+            <b>case permutation</b>
             <div align="right" style="display:inline-block; float: right;">
               <a href="{{ url_for('app.benchmark-result', benchmark_result_id=contender.id) }}">{{ contender.display_case_perm }}</a>
             </div>
@@ -304,6 +313,12 @@ matching fields between baseline and contender are aligned and mismatched fields
       });
     {% endif %}
 
+
+    {% if benchmark_result_history_plot_info.jsondoc %}
+      $(document).ready(function () {
+        Bokeh.embed.embed_item({{ benchmark_result_history_plot_info.jsondoc | safe }});
+      });
+    {% endif %}
 
   </script>
 {% endblock %}

--- a/conbench/templates/compare-entity.html
+++ b/conbench/templates/compare-entity.html
@@ -54,50 +54,13 @@ matching fields between baseline and contender are aligned and mismatched fields
       <div id="plot" align="center"></div>
       <br />
     </div>
-    {% if comparisons %}
-      <!--
-         This table is currently broken, see
-         https://github.com/conbench/conbench/issues/1230
-         when comparing two benchmark results I think the history plot
-         and the tabular comparison of the result measurements are sufficient.
+    <!--
+        Here was a table, but it was a bit broken, see
+        https://github.com/conbench/conbench/issues/1230
+        when comparing two benchmark results I think the history plot
+        and the tabular comparison of the result measurements are sufficient.
         let's maybe re-activate it when we understand its value better.
-      <div class="col-md-5">
-        <table id="benchmarks"
-               class="table table-striped table-bordered table-hover">
-          <thead>
-            <tr>
-              <th width="25%" scope="col">Z-Score</th>
-              <th width="25%" scope="col">Change</th>
-              <th width="25%" scope="col">Baseline</th>
-              <th width="25%" scope="col">Contender</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for c in comparisons %}
-              <tr>
-                <td>
-                  {% if c.analysis.lookback_z_score.z_score %}{{ c.analysis.lookback_z_score.z_score }} z{% endif %}
-                  {% if c.analysis.lookback_z_score.regression_indicated %}
-                    <span class="glyphicon glyphicon-arrow-down"></span>
-                  {% endif %}
-                  {% if c.analysis.lookback_z_score.improvement_indicated %}
-                    <span class="glyphicon glyphicon-arrow-up"></span>
-                  {% endif %}
-                </td>
-                <td>
-                  {{ c.analysis.pairwise.percent_change }}%
-                  {% if c.analysis.pairwise.regression_indicated %}<span class="glyphicon glyphicon-arrow-down"></span>{% endif %}
-                  {% if c.analysis.pairwise.improvement_indicated %}<span class="glyphicon glyphicon-arrow-up"></span>{% endif %}
-                </td>
-                <td>{{ c.baseline.value }} {{ c.unit }}</td>
-                <td>{{ c.contender.value }} {{ c.unit }}</td>
-              </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
       -->
-    {% endif %}
   </div>
   <div align="center">{{ baseline.display_bmname }}, {{ baseline.display_case_perm }}</div>
   <div id="plot-history-0" align="center"></div>


### PR DESCRIPTION
This is mainly for https://github.com/conbench/conbench/issues/1209.

This adds a feature to the history plot to highlight one specific result in the plot, besides the currently highlighted "current" / most recent result.

This feature is exposed in the benchmark result view (which tries to render the history plot) with a query parameter of the following shape:
```
?highlight-other=<other_benchmark_id>,description
```
Example: `http://localhost:5000/benchmark-results/47efd7474830460b8e7243c02f117ca1/?highlight-other=2d298663e6b942f38695467987a889f0,123-release`

leading to
![image](https://github.com/conbench/conbench/assets/265630/55d2d7a8-fc12-4528-8e36-eec2ff05f36c)

Notice how the `123-release` term ends up in the legend of the plot.

When I started to try to use that in the comparison view (to generate a link to the result view), I realized that the compare view wanted to render the history plot, but it was just broken. I decided to re-activate that, and _also_ use this "highlight other" feature :shrug: 

Keeping the query parameter technique in for now. I think it's useful.

Error handling: when the "other" cannot be found:

![image](https://github.com/conbench/conbench/assets/265630/b308a44c-cb8d-4d32-84ed-db9b2d9f68a3)

Also adjusted the plot style and legend based on recent insights, and me growing more confidence in what is what. See commit messages! Some notes:
* I think that removing the line connecting the min values is a good idea -- it got too busy. Also see https://github.com/conbench/conbench/issues/1252 for an example of that.
* Renamed "benchmark" to "result" where appropriate
* Started using "lookback z-score" instead of "rolling window"

Also: in the view for comparing two results, I don't think we need a bar chart having two bars, comparing two mean values. Even without history plot I find that a little boring when the two mean values are displayed in raw below that. But with history plot I think that we can probably agree that we don't need the bar chart.

Then there's also a table that at least for me in local dev is kind of broken and also @austin3dickey found it broken here and there: https://github.com/conbench/conbench/issues/1230 -- I wanted to get over with this patch, and for now decided to comment the table out. I think the history plot conveys the relevant information even better. Does it? :)

### Comparison view, before:
![image](https://github.com/conbench/conbench/assets/265630/d362078c-8931-4dc0-9bd5-3252050cadea)

### Comparison view, after:
![image](https://github.com/conbench/conbench/assets/265630/a0e129fb-869c-4199-a420-2f2de4db88c7)



