### PR TITLE
c-bench UI: case perms per benchmark: show each case param with observed values

### DIFF
--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -1,6 +1,5 @@
 import logging
 import time
-import itertools
 from collections import defaultdict
 from typing import Dict, List, Tuple, TypedDict
 

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -116,7 +116,7 @@ def show_benchmark_cases(bname: str) -> str:
     #     itertools.chain.from_iterable(r.case_dict.keys() for r in matching_results)
     # )
 
-    all_values_per_case_key = defaultdict(set)
+    all_values_per_case_key: Dict[str, set] = defaultdict(set)
     for r in matching_results:
         # Maybe make this a counter.
         for k, v in r.case_dict.items():
@@ -133,8 +133,9 @@ def show_benchmark_cases(bname: str) -> str:
 
     # Each item's value is a set of observed values. Make it a list, sorted
     # alphabetically.
+    all_values_per_case_key_sorted: Dict[str, list] = {}
     for k, valueset in all_values_per_case_key.items():
-        all_values_per_case_key[k] = list(sorted(valueset))
+        all_values_per_case_key_sorted[k] = list(sorted(valueset))
     # log.info("all case parameters seen: %s", all_values_per_case_key)
 
     t0 = time.monotonic()
@@ -163,7 +164,7 @@ def show_benchmark_cases(bname: str) -> str:
         last_result_per_case_id=last_result_per_case_id,
         context_count_per_case_id=context_count_per_case_id,
         benchmark_result_count=len(matching_results),
-        all_values_per_case_key=all_values_per_case_key,
+        all_values_per_case_key_sorted=all_values_per_case_key_sorted,
         application=Config.APPLICATION_NAME,
         title=Config.APPLICATION_NAME,  # type: ignore
     )

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -116,7 +116,7 @@ def show_benchmark_cases(bname: str) -> str:
     #     itertools.chain.from_iterable(r.case_dict.keys() for r in matching_results)
     # )
 
-    all_values_per_case_key: Dict[str, set] = defaultdict(set)
+    all_values_per_case_key = defaultdict(set)
     for r in matching_results:
         # Maybe make this a counter.
         for k, v in r.case_dict.items():

--- a/conbench/entities/case.py
+++ b/conbench/entities/case.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import sqlalchemy as s
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import Mapped
@@ -11,6 +13,16 @@ class Case(Base, EntityMixin["Case"]):
     # The name of the conceptual benchmark (store on BenchmarkResult directly)?
     name: Mapped[str] = NotNull(s.Text)
     tags: Mapped[dict] = NotNull(postgresql.JSONB)
+
+    def to_dict(self) -> Dict:
+        """
+        Be sure to return `self.tags` directly so that we do not need to keep a
+        huge amount of copies of this in memory (this may be shared across many
+        benchmark result objects). This here is basically just an indirection
+        from the name "tags" to "to_dict()" which I think is more intuitive to
+        work with. Think "case dictionary".
+        """
+        return self.tags
 
 
 s.Index("case_index", Case.name, Case.tags, unique=True)

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -68,6 +68,7 @@ class BMRTBenchmarkResult:
     hardware_id: str
     hardware_name: str
     case_text_id: str
+    case_dict: Dict[str, str]
     context_dict: Dict
     ui_time_started_at: str
     ui_hardware_short: str
@@ -191,7 +192,8 @@ def _fetch_and_cache_most_recent_results() -> None:
 
         # A textual representation of the case permutation. As it is 'complete'
         # it should also work as a proper identifier (like primary key).
-        case_text_id = " ".join(get_case_kvpair_strings(result.case.tags))
+        casedict = result.case.to_dict()
+        case_text_id = " ".join(get_case_kvpair_strings(casedict))
 
         bmr = BMRTBenchmarkResult(
             id=str(result.id),
@@ -214,6 +216,7 @@ def _fetch_and_cache_most_recent_results() -> None:
             # shared across potentially many BMRTBenchmarkResult objects.
             context_dict=result.context.to_dict(),
             case_text_id=case_text_id,
+            case_dict=casedict,
             ui_hardware_short=str(result.ui_hardware_short),
             ui_time_started_at=str(result.ui_time_started_at),
             ui_non_null_sample_count=result.ui_non_null_sample_count,

--- a/conbench/templates/c-benchmark-cases.html
+++ b/conbench/templates/c-benchmark-cases.html
@@ -8,29 +8,30 @@
     across <strong>{{ benchmark_result_count }}</strong> result(s).
     <br>
   </p>
-
-
-
   <div class="mt-5">
-    <h5><strong>case parameters</strong></h5>
+    <h5>
+      <strong>case parameters</strong>
+    </h5>
     <div class="row mt-2 row-cols-2 row-cols-lg-5 g-2 g-lg-3">
-      {% for case_param_key, case_param_values in all_values_per_case_key.items() %}
+      {% for case_param_key, case_param_values in all_values_per_case_key_sorted.items() %}
         <div class="col">
-          <div class="p-3 border bg-light overflow-auto" style="height: 160px;"">
-            <code>{{case_param_key}} ({{case_param_values|length}})</code><br>
+          <div class="p-3 border bg-light overflow-auto" style="height: 170px;">
+            <code>{{ case_param_key }} ({{ case_param_values|length }})</code>
+            <br>
             <hr>
             {% for v in case_param_values %}
-            {{v}}<br>
+              {{v}}
+              <br>
             {% endfor %}
           </div>
         </div>
       {% endfor %}
     </div>
   </div>
-
-
   <div class="mt-5">
-    <h5><strong>case permutations</strong></h5>
+    <h5>
+      <strong>case permutations</strong>
+    </h5>
     <table class="table table-hover conbench-datatable"
            style="width:100%;
                   display: none">

--- a/conbench/templates/c-benchmark-cases.html
+++ b/conbench/templates/c-benchmark-cases.html
@@ -8,7 +8,29 @@
     across <strong>{{ benchmark_result_count }}</strong> result(s).
     <br>
   </p>
-  <div class="mt-3">
+
+
+
+  <div class="mt-5">
+    <h5><strong>case parameters</strong></h5>
+    <div class="row mt-2 row-cols-2 row-cols-lg-5 g-2 g-lg-3">
+      {% for case_param_key, case_param_values in all_values_per_case_key.items() %}
+        <div class="col">
+          <div class="p-3 border bg-light overflow-auto" style="height: 160px;"">
+            <code>{{case_param_key}} ({{case_param_values|length}})</code><br>
+            <hr>
+            {% for v in case_param_values %}
+            {{v}}<br>
+            {% endfor %}
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+  </div>
+
+
+  <div class="mt-5">
+    <h5><strong>case permutations</strong></h5>
     <table class="table table-hover conbench-datatable"
            style="width:100%;
                   display: none">


### PR DESCRIPTION
Just a tiny step, but an important one:
![image](https://github.com/conbench/conbench/assets/265630/02121aa2-e4db-4754-9bfc-bdc6a184a658)


From here, we can make individual entries clickable / toggleable, and then filter the contents in the table! :)
