### PR TITLE
c-bench UI: case permutation overview: add workflow for filtering by case param key/value pairs

### DIFF
--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -1,6 +1,6 @@
+import collections
 import logging
 import time
-import collections
 from typing import Dict, List, Tuple, TypedDict
 
 import flask
@@ -225,7 +225,7 @@ def show_benchmark_results(bname: str, caseid: str) -> str:
 
     results_by_hardware_and_context: Dict[
         Tuple, List[BMRTBenchmarkResult]
-    ] = defaultdict(list)
+    ] = collections.defaultdict(list)
 
     # Build up timeseries of results (group results, don't sort them yet).
     for result in matching_results:

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from collections import defaultdict
+import collections
 from typing import Dict, List, Tuple, TypedDict
 
 import flask
@@ -107,7 +107,9 @@ def show_benchmark_cases(bname: str) -> str:
         return f"benchmark name not known: `{bname}`"
 
     matching_results = bmrt_cache["by_benchmark_name"][bname]
-    results_by_case_id: Dict[str, List[BMRTBenchmarkResult]] = defaultdict(list)
+    results_by_case_id: Dict[str, List[BMRTBenchmarkResult]] = collections.defaultdict(
+        list
+    )
 
     for r in matching_results:
         results_by_case_id[r.case_id].append(r)
@@ -116,13 +118,24 @@ def show_benchmark_cases(bname: str) -> str:
     #     itertools.chain.from_iterable(r.case_dict.keys() for r in matching_results)
     # )
 
-    all_values_per_case_key: Dict[str, set] = defaultdict(set)
+    all_values_per_case_key: Dict[str, collections.Counter] = collections.defaultdict(
+        collections.Counter
+    )
     for r in matching_results:
         # Maybe make this a counter.
-        for k, v in r.case_dict.items():
-            all_values_per_case_key[k].add(v)
+        for case_parm_key, case_parm_value in r.case_dict.items():
+            # Today, there might be any kind of type here for key and value in
+            # the DB. Difficult. See
+            # https://github.com/conbench/conbench/pull/948 and
+            # https://github.com/conbench/conbench/issues/940.
+            # Change both to string here. For example, this might result in
+            # values to be `"None"`.
+            all_values_per_case_key[str(case_parm_key)].update([str(case_parm_value)])
 
-    # Sort by parameter value count.
+    log.info("all_values_per_case_key: %s", all_values_per_case_key)
+
+    # Sort by parameter value count (uniquely different parameter values,
+    # not by how often these individual values are used).
     all_values_per_case_key = dict(
         sorted(
             all_values_per_case_key.items(),
@@ -131,12 +144,18 @@ def show_benchmark_cases(bname: str) -> str:
         )
     )
 
+    log.info("all_values_per_case_key: %s", all_values_per_case_key)
+
     # Each item's value is a set of observed values. Make it a list, sorted
     # alphabetically.
-    all_values_per_case_key_sorted: Dict[str, list] = {}
-    for k, valueset in all_values_per_case_key.items():
-        all_values_per_case_key_sorted[k] = list(sorted(valueset))
+    all_values_per_case_key_sorted: Dict[str, Dict[str, int]] = {}
+    for case_parm_key, value_counter in all_values_per_case_key.items():
+        all_values_per_case_key_sorted[case_parm_key] = dict(
+            value_counter.most_common(None)
+        )
     # log.info("all case parameters seen: %s", all_values_per_case_key)
+
+    log.info("all_values_per_case_key_sorted: %s", all_values_per_case_key_sorted)
 
     t0 = time.monotonic()
 

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -73,6 +73,7 @@ class BMRTBenchmarkResult:
     ui_time_started_at: str
     ui_hardware_short: str
     ui_non_null_sample_count: str
+    run_reason: str
 
     # There is conceptual duplication between the class BenchmarkResult
     # and this class BMRTBenchmarkResult. Fundamentally, it might make sense
@@ -195,6 +196,7 @@ def _fetch_and_cache_most_recent_results() -> None:
         casedict = result.case.to_dict()
         case_text_id = " ".join(get_case_kvpair_strings(casedict))
 
+        bmrrun = result.run
         bmr = BMRTBenchmarkResult(
             id=str(result.id),
             benchmark_name=benchmark_name,
@@ -202,8 +204,8 @@ def _fetch_and_cache_most_recent_results() -> None:
             data=result.measurements,
             svs=result.svs,  # float(result.mean) if result.mean else None,
             unit=str(result.unit) if result.unit else "n/a",
-            hardware_id=str(result.run.hardware.id),
-            hardware_name=str(result.run.hardware.name),
+            hardware_id=str(bmrrun.hardware.id),
+            hardware_name=str(bmrrun.run.hardware.name),
             case_id=str(result.case_id),
             context_id=str(result.context_id),
             # These context dictionaries are often the largest part of these
@@ -220,6 +222,7 @@ def _fetch_and_cache_most_recent_results() -> None:
             ui_hardware_short=str(result.ui_hardware_short),
             ui_time_started_at=str(result.ui_time_started_at),
             ui_non_null_sample_count=result.ui_non_null_sample_count,
+            run_reason=bmrrun.reason,
         )
 
         # The str() indirections below (and above) are here to quickly make

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -205,7 +205,7 @@ def _fetch_and_cache_most_recent_results() -> None:
             svs=result.svs,  # float(result.mean) if result.mean else None,
             unit=str(result.unit) if result.unit else "n/a",
             hardware_id=str(bmrrun.hardware.id),
-            hardware_name=str(bmrrun.run.hardware.name),
+            hardware_name=str(bmrrun.hardware.name),
             case_id=str(result.case_id),
             context_id=str(result.context_id),
             # These context dictionaries are often the largest part of these

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -222,7 +222,7 @@ def _fetch_and_cache_most_recent_results() -> None:
             ui_hardware_short=str(result.ui_hardware_short),
             ui_time_started_at=str(result.ui_time_started_at),
             ui_non_null_sample_count=result.ui_non_null_sample_count,
-            run_reason=bmrrun.reason,
+            run_reason=bmrrun.reason if bmrrun.reason else "n/a",
         )
 
         # The str() indirections below (and above) are here to quickly make

--- a/conbench/static/app.css
+++ b/conbench/static/app.css
@@ -7,6 +7,25 @@ html {
   font-size: 14px;
 }
 
+span.case-parm-value {
+  font-family: monospace;
+  padding: 1px;
+  margin: 2px
+}
+
+span.case-parm-value.selected {
+  font-family: monospace;
+  background-color: #38BDD155;
+}
+
+/* select.caseparm-select {
+  overflow: auto !important;
+  border: none;
+  background: none;
+  font-family: monospace;
+} */
+
+
 /* spacing between DT items */
 div.dataTables_filter label {
   font-size: 12px;

--- a/conbench/templates/c-benchmark-cases.html
+++ b/conbench/templates/c-benchmark-cases.html
@@ -15,7 +15,7 @@
    data-bs-toggle="tooltip"
    data-bs-title="Each panel represents one case parameter, and lists all known values as well as the number of benchmark results per value. Clicking a value applies a filter to the table below. Current limitation: two selected values per parameter are not yet supported.">
       </i>
-      </sup>
+    </sup>
   </h5>
   <div class="row mt-2 row-cols-2 row-cols-lg-5 g-2 g-lg-3">
     {% for case_param_key, case_param_value_count_dict in all_values_per_case_key_sorted.items() %}
@@ -27,7 +27,7 @@
           {% for v, vcount in case_param_value_count_dict.items() %}
             <span class="case-parm-value"
                   data-cvp-key="{{ case_param_key }}"
-                  data-cvp-value="{{v}}">{{v }} ({{ vcount }})</span>
+                  data-cvp-value="{{v}}">{{ v }} ({{ vcount }})</span>
             <br>
           {% endfor %}
         </div>

--- a/conbench/templates/c-benchmark-cases.html
+++ b/conbench/templates/c-benchmark-cases.html
@@ -11,59 +11,66 @@
   <div class="mt-5">
     <h5>
       <strong>case parameters</strong>
-    </h5>
-    <div class="row mt-2 row-cols-2 row-cols-lg-5 g-2 g-lg-3">
-      {% for case_param_key, case_param_values in all_values_per_case_key_sorted.items() %}
-        <div class="col">
-          <div class="p-3 border bg-light overflow-auto" style="height: 170px;">
-            <code>{{ case_param_key }} ({{ case_param_values|length }})</code>
+      <sup><i class="bi bi-info-circle"
+   data-bs-toggle="tooltip"
+   data-bs-title="Each panel represents one case parameter, and lists all known values as well as the number of benchmark results per value. Clicking a value applies a filter to the table below. Current limitation: two selected values per parameter are not yet supported.">
+      </i>
+      </sup>
+  </h5>
+  <div class="row mt-2 row-cols-2 row-cols-lg-5 g-2 g-lg-3">
+    {% for case_param_key, case_param_value_count_dict in all_values_per_case_key_sorted.items() %}
+      <div class="col">
+        <div class="p-3 border bg-light overflow-auto" style="height: 190px;">
+          <code>{{ case_param_key }} ({{ case_param_value_count_dict|length }})</code>
+          <br>
+          <hr>
+          {% for v, vcount in case_param_value_count_dict.items() %}
+            <span class="case-parm-value"
+                  data-cvp-key="{{ case_param_key }}"
+                  data-cvp-value="{{v}}">{{v }} ({{ vcount }})</span>
             <br>
-            <hr>
-            {% for v in case_param_values %}
-              {{v}}
-              <br>
-            {% endfor %}
-          </div>
+          {% endfor %}
         </div>
-      {% endfor %}
-    </div>
+      </div>
+    {% endfor %}
   </div>
-  <div class="mt-5">
-    <h5>
-      <strong>case permutations</strong>
-    </h5>
-    <table class="table table-hover conbench-datatable"
-           style="width:100%;
-                  display: none">
-      <thead>
+</div>
+<div class="mt-5">
+  <h5>
+    <strong>case permutations</strong>
+  </h5>
+  <table class="table table-hover conbench-datatable"
+         style="width:100%;
+                display: none">
+    <thead>
+      <tr>
+        <th scope="col" style="width: 7%">case id</th>
+        <th scope="col" style="width: 35%">case permutation</th>
+        <th scope="col" style="width: 13%">last result</th>
+        <th scope="col" style="width: 6%"># results</th>
+        <th scope="col" style="width: 8%"># hardwares</th>
+        <th scope="col" style="width: 6%"># contexts</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for case_id, results in results_by_case_id.items() %}
         <tr>
-          <th scope="col" style="width: 7%">case id</th>
-          <th scope="col" style="width: 35%">case permutation</th>
-          <th scope="col" style="width: 13%">last result</th>
-          <th scope="col" style="width: 6%"># results</th>
-          <th scope="col" style="width: 8%"># hardwares</th>
-          <th scope="col" style="width: 6%"># contexts</th>
+          <td class="font-monospace">
+            <a href="{{ url_for('app.show_benchmark_results', bname=benchmark_name, caseid=case_id) }}">{{ case_id[:10] }}</a>
+          </td>
+          <td class="font-monospace">{{ results[0].case_text_id }}</td>
+          <td class="font-monospace">{{ last_result_per_case_id[case_id].ui_time_started_at }}</td>
+          <td class="font-monospace">{{ results|length }}</td>
+          <td class="font-monospace">{{ hardware_count_per_case_id[case_id] }}</td>
+          <td class="font-monospace">{{ context_count_per_case_id[case_id] }}</td>
         </tr>
-      </thead>
-      <tbody>
-        {% for case_id, results in results_by_case_id.items() %}
-          <tr>
-            <td class="font-monospace">
-              <a href="{{ url_for('app.show_benchmark_results', bname=benchmark_name, caseid=case_id) }}">{{ case_id[:10] }}</a>
-            </td>
-            <td class="font-monospace">{{ results[0].case_text_id }}</td>
-            <td class="font-monospace">{{ last_result_per_case_id[case_id].ui_time_started_at }}</td>
-            <td class="font-monospace">{{ results|length }}</td>
-            <td class="font-monospace">{{ hardware_count_per_case_id[case_id] }}</td>
-            <td class="font-monospace">{{ context_count_per_case_id[case_id] }}</td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
-  Report based on {{ bmr_cache_meta.n_results }} results reported in
-  total between {{ bmr_cache_meta.oldest_result_time_str }} and
-  {{ bmr_cache_meta.newest_result_time_str }}
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+Report based on {{ bmr_cache_meta.n_results }} results reported in
+total between {{ bmr_cache_meta.oldest_result_time_str }} and
+{{ bmr_cache_meta.newest_result_time_str }}
 {% endblock %}
 {% block scripts %}
   {{ super() }}
@@ -74,15 +81,15 @@
       const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
       const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
 
-      $('table.conbench-datatable').each(function() {
-        $(this).DataTable({
+
+      let table = $('table.conbench-datatable').DataTable({
             // Note(JP): this enables a special, simple plugin called
             // `conditionalPaging` which must be included, e.g. via the dist URLs
             // published in https://cdn.datatables.net/plug-ins/1.13.3/features/.
             // kudos to https://stackoverflow.com/a/29639664/145400
           "conditionalPaging": true,
           // hide the "Showing 1 to 12 of 12 entries" element
-          "bInfo" : false,
+          "bInfo" : true,
           "responsive": true,
             // the default default seems to be the first item in lengthMenu.
           "lengthMenu": [ 5, 10, 50, 75, 100, 250, 750 ],
@@ -109,9 +116,80 @@
             $('.pagination').addClass('pagination-sm'); // add BS class for smaller pagination bar
           },
         });
+
+
+      // table.column(1).data().filter(function(value, index) {
+      //   if (value.includes("query_id=TPCH-03")) {
+      //     return true;
+      //   }
+      //   return false;
+      // });
+      // this works! but the search is not customizable, it takes only
+      // a string as an arg
+      // table.column(1).search("query_id=TPCH-03").draw();
+
+      // key: parameter name
+      // value: list of selected values.
+      // no, prepare strings!
+      let selectedGlobal = {};
+
+      // https://datatables.net/manual/plug-ins/search
+      $.fn.dataTable.ext.search.push(function(settings, searchData, index, rowData, counter) {
+        //console.log('hello from custom search, settings:', settings)
+        // It's horrible that this is the stringified version of the
+        // case params! But well, I think it works! :)
+        // Rely on this being a key=value format.
+        let currentRowCasePermString = rowData[1];
+
+        // Now this is an explosion of l00pyl00ps and certainly not an
+        // efficient way to search in general, but JS is fast, and the amount
+        // of data is small.
+
+        // The approach here is to test this row against all currently known
+        // criteria. If one of the tests fails: bail out. At the end of the
+        // function: return true.
+        for (let needle in selectedGlobal) {
+          // Each of the keys in selectedGlobal is a 'needle', i.e. a
+          // substring that must be part of the haystack.
+          if (! currentRowCasePermString.includes(needle)) {
+            return false;
+          }
+          // console.log(key, yourobject[key]);
+        }
+
+        return true;
+      });
+
+      // Now, perform a search, to make the custom search function apply.
+      // Input is noop.
+      table.search("").draw();
+
+
+      $('.case-parm-value').click(function() {
+        console.log('i got clicked: ', $(this));
+
+        $(this).toggleClass('selected');
+
+        let dataattrs = $(this).data();
+        console.log('dataattrs:',dataattrs);
+        kvpair = dataattrs['cvpKey'] + "=" + dataattrs['cvpValue']
+
+        console.log('kvpair:', kvpair);
+
+        if (kvpair in selectedGlobal) {
+          delete selectedGlobal[kvpair];
+        }
+        else {
+          // want to have a hash map type data struct for simple key lookup,
+          // value shrug.
+          selectedGlobal[kvpair] = true;
+        }
+
+        console.log('updated selectedGlobal: ', selectedGlobal)
+        // now update the table: test each row against search criteria.
+        table.search("").draw();
+
       });
     });
-
-
   </script>
 {% endblock %}


### PR DESCRIPTION
Relates to https://github.com/conbench/conbench/issues/1154.
This was discussed quite a bit, we need a workflow/UX for browsing case permutations. The [previous patch](https://github.com/conbench/conbench/pull/1254) proposed:

![image](https://github.com/conbench/conbench/assets/265630/86a6e97e-b92e-4ae6-b1e8-ad865df0fb01)

I took inspiration from the Grafana UI query builder here. See [this screenshot](https://github.com/conbench/conbench/assets/265630/66e97128-d386-4c92-aa70-c3ab99051fb1). That is: one panel per parameter. Each panel shows the parameter name, the "key". And all observed values, including the value count. I added another count, the number of individual benchmark results submitted that have this key/value pair set.

------

Here, I went a little further and added logic for selecting individual key/value pairs. Upon toggle (select/unselect), the table below these panels automatically updates. It only shows those rows (case permutations) that have the selected case parameter key/value pairs set. A video:

https://github.com/conbench/conbench/assets/265630/4bb36922-a480-4ff5-9b63-293d3274c9a2

Work in progress, that I'd like to test out in staging. 

With two known limitations/bugs:
- Based on string.includes() search, i.e. a `foo=1` matches a `foo=10`. Easy to fix, just not today.
- Multiple selections in the same panel are interpreted as `AND` which never applies to any row. Must be `OR`. Fixable, just not today.


