### PR TITLE
HTTP API: /benchmark-results: add run_reason filter (first step, no time filter, limit to ~35000 results)

### DIFF
--- a/conbench/api/results.py
+++ b/conbench/api/results.py
@@ -6,13 +6,11 @@ import orjson
 from sqlalchemy import select
 
 import conbench.metrics
-from conbench.job import BMRTBenchmarkResult, bmrt_cache
 
 from ..api import rule
 from ..api._docs import spec
 from ..api._endpoint import ApiEndpoint, maybe_login_required
 from ..db import Session
-
 from ..entities._entity import NotFound
 from ..entities.benchmark_result import (
     BenchmarkResult,

--- a/conbench/api/results.py
+++ b/conbench/api/results.py
@@ -191,7 +191,7 @@ class BenchmarkListAPI(ApiEndpoint, BenchmarkValidationMixin):
 
         elif run_reason_arg := f.request.args.get("run_reason"):
             benchmark_results = BenchmarkResult.search(
-                filters=[Run.reason == run_reason_arg], joins=[Run], limit=15000
+                filters=[Run.reason == run_reason_arg], joins=[Run], limit=35000
             )
 
         else:

--- a/conbench/entities/_entity.py
+++ b/conbench/entities/_entity.py
@@ -83,14 +83,18 @@ class EntityMixin(Generic[T]):
         return q.filter(*filters).all()
 
     @classmethod
-    def search(cls, filters, joins=None, order_by=None):
+    def search(cls, filters, joins=None, order_by=None, limit=None):
         q = Session.query(cls)
         if joins:
             for join in joins:
                 q = q.join(join)
         if order_by is not None:
             q = q.order_by(order_by)
-        return q.filter(*filters).all()
+
+        if limit is None:
+            return q.filter(*filters).all()
+
+        return q.filter(*filters).limit(limit).all()
 
     @classmethod
     def all(cls, limit=None, order_by=None, filter_args=None, **kwargs):

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -669,7 +669,7 @@ def validate_and_aggregate_samples(stats_usergiven: Any):
             # aggregates.
             if key in stats_usergiven:
                 try:
-                    if not floatcomp_with_leeway(stats_usergiven[key], value):
+                    if not floatcomp_with_leeway(float(stats_usergiven[key]), value):
                         log.warning(
                             "key %s, user-given val %s vs. calculated %s",
                             key,
@@ -717,8 +717,7 @@ def validate_and_aggregate_samples(stats_usergiven: Any):
     return result_data_for_db
 
 
-def floatcomp_with_leeway(v1, v2, sigfigs=5):
-    # TODO: review
+def floatcomp_with_leeway(v1: float, v2: float, sigfigs=5):
     v1s = numstr(v1, sigfigs=sigfigs)
     v2s = numstr(v2, sigfigs=sigfigs)
     return abs(float(v1s) - float(v2s)) < 10**-10

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -60,8 +60,10 @@ class BMRTBenchmarkResult:
     id: str
     case_id: str
     context_id: str
+    run_id: str
     data: List[float]
     svs: float
+    svs_type: str
     unit: str
     benchmark_name: str
     started_at: float
@@ -203,11 +205,13 @@ def _fetch_and_cache_most_recent_results() -> None:
             started_at=result.timestamp.timestamp(),
             data=result.measurements,
             svs=result.svs,  # float(result.mean) if result.mean else None,
+            svs_type=result.svs_type,
             unit=str(result.unit) if result.unit else "n/a",
             hardware_id=str(bmrrun.hardware.id),
             hardware_name=str(bmrrun.hardware.name),
             case_id=str(result.case_id),
             context_id=str(result.context_id),
+            run_id=str(result.run_id),
             # These context dictionaries are often the largest part of these
             # BMRTBenchmarkResult object (in terms of memory usage) -- they can
             # be a rather big collection of strings. However, by the nature of

--- a/conbench/tests/api/test_results.py
+++ b/conbench/tests/api/test_results.py
@@ -349,8 +349,11 @@ class TestBenchmarkList(_asserts.ListEnforcer):
         thisresult = _fixtures.benchmark_result(run_id="100", reason="rolf")
         resp = client.get("/api/benchmark-results/?run_reason=rolf")
         assert resp.status_code == 200, resp.text
-        assert resp.json[0]["run_reason"]
         self.assert_200_ok(resp[_expected_entity(thisresult)])
+
+        resp = client.get("/api/benchmark-results/?run_reason=foo")
+        assert resp.status_code == 200, resp.text
+        assert resp.json == []
 
     def test_benchmark_list_filter_by_multiple_run_id(self, client):
         self.authenticate(client)

--- a/conbench/tests/api/test_results.py
+++ b/conbench/tests/api/test_results.py
@@ -344,6 +344,13 @@ class TestBenchmarkList(_asserts.ListEnforcer):
         response = client.get("/api/benchmarks/?run_id=200")
         self.assert_200_ok(response, [_expected_entity(benchmark_result)])
 
+    def test_benchmark_list_filter_by_run_reason(self, client):
+        self.authenticate(client)
+        _fixtures.benchmark_result(run_id="100", reason="rolf")
+        benchmark_result = _fixtures.benchmark_result(run_id="100")
+        response = client.get("/api/benchmarks/?run_reason=rolf")
+        self.assert_200_ok(response, [_expected_entity(benchmark_result)])
+
     def test_benchmark_list_filter_by_multiple_run_id(self, client):
         self.authenticate(client)
         benchmark_result_1 = _fixtures.benchmark_result()

--- a/conbench/tests/api/test_results.py
+++ b/conbench/tests/api/test_results.py
@@ -349,7 +349,7 @@ class TestBenchmarkList(_asserts.ListEnforcer):
         thisresult = _fixtures.benchmark_result(run_id="100", reason="rolf")
         resp = client.get("/api/benchmark-results/?run_reason=rolf")
         assert resp.status_code == 200, resp.text
-        self.assert_200_ok(resp[_expected_entity(thisresult)])
+        self.assert_200_ok(resp, [_expected_entity(thisresult)])
 
         resp = client.get("/api/benchmark-results/?run_reason=foo")
         assert resp.status_code == 200, resp.text

--- a/conbench/tests/api/test_results.py
+++ b/conbench/tests/api/test_results.py
@@ -346,10 +346,11 @@ class TestBenchmarkList(_asserts.ListEnforcer):
 
     def test_benchmark_list_filter_by_run_reason(self, client):
         self.authenticate(client)
-        _fixtures.benchmark_result(run_id="100", reason="rolf")
-        benchmark_result = _fixtures.benchmark_result(run_id="100")
-        response = client.get("/api/benchmarks/?run_reason=rolf")
-        self.assert_200_ok(response, [_expected_entity(benchmark_result)])
+        thisresult = _fixtures.benchmark_result(run_id="100", reason="rolf")
+        resp = client.get("/api/benchmark-results/?run_reason=rolf")
+        assert resp.status_code == 200, resp.text
+        assert resp.json[0]["run_reason"]
+        self.assert_200_ok(resp[_expected_entity(thisresult)])
 
     def test_benchmark_list_filter_by_multiple_run_id(self, client):
         self.authenticate(client)


### PR DESCRIPTION
A quick first step for https://github.com/conbench/conbench/issues/1231 -- no time window support yet.

But with an Arrow DB snapshot in local dev, I played with the rather extreme scenario of trying to output max 35000 results in one response.

We see:
```
± time curl -H 'Accept-Encoding: br,gzip,deflate' http://localhost:5000/api/benchmark-results/?run_reason=commit > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 3013k  100 3013k    0     0  1017k      0  0:00:02  0:00:02 --:--:-- 1017k

real	0m2.969s
user	0m0.003s
sys	0m0.005s
```

About ~three megabyte response body (compressed, in this case via brotli).

Raw response body would be about 50 MB in this case.

This creates quite a bit of load on the system, i.e. clients are advised to use with care (rarely).

