### PR TITLE
c-bench UI: case permutations: use space more wisely

### DIFF
--- a/conbench/static/app.css
+++ b/conbench/static/app.css
@@ -7,8 +7,44 @@ html {
   font-size: 14px;
 }
 
+.c-bench-scrollbar {
+  /* Foreground, Background */
+  scrollbar-color: #812570 #f3f3f3;
+  scrollbar-width: thin;
+}
+.c-bench-scrollbar::-webkit-scrollbar {
+  width: 5px; /* Mostly for vertical scrollbars */
+  height: 7px; /* Mostly for horizontal scrollbars */
+}
+.c-bench-scrollbar::-webkit-scrollbar-thumb { /* Foreground */
+  background: #81257088;
+  border-radius: 2px;
+}
+.c-bench-scrollbar::-webkit-scrollbar-track { /* Background */
+  background: #f3f3f3;
+  border-radius: 3px;
+}
+
+div.case-param-title {
+  border-bottom: 1px solid #81257022;
+  padding-bottom: 2px;
+  padding-left: 2px;
+  background-color: #f3f3f3;
+}
+
+div.case-param-values {
+  height: 70px;
+  overflow: auto;
+}
+
+div.case-param-panel {
+  width: 125px;
+  margin-right: 7px;
+}
+
 span.case-parm-value {
   font-family: monospace;
+  font-size: 11px;
   padding: 1px;
   margin: 2px
 }

--- a/conbench/static/app.css
+++ b/conbench/static/app.css
@@ -7,6 +7,11 @@ html {
   font-size: 14px;
 }
 
+.c-bench-landing div.card {
+  font-size: 12px;
+}
+
+
 .c-bench-scrollbar {
   /* Foreground, Background */
   scrollbar-color: #812570 #f3f3f3;

--- a/conbench/static/app.css
+++ b/conbench/static/app.css
@@ -47,6 +47,20 @@ div.case-param-panel {
   margin-right: 7px;
 }
 
+table.c-bench-caseperm-table tbody tr td {
+  font-family: var(--bs-font-monospace);
+  font-size: 12px;
+}
+
+table.c-bench-caseperm-table td.casepermstring {
+  font-size: 11px;
+}
+
+table.c-bench-caseperm-table th{
+  font-size: 12px;
+}
+
+
 span.case-parm-value {
   font-family: monospace;
   font-size: 11px;
@@ -56,7 +70,7 @@ span.case-parm-value {
 
 span.case-parm-value.selected {
   font-family: monospace;
-  background-color: #38BDD155;
+  background-color: #38BDD166;
 }
 
 /* select.caseparm-select {

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -121,7 +121,7 @@
                 {% endif %}
               {% endwith %}
               {# application content needs to be provided in the app_content block #}
-              <div style="margin-top: 30px"></div>
+              <div style="margin-top: 15px"></div>
               {% block app_content %}{% endblock %}
               <br>
               <hr>

--- a/conbench/templates/c-benchmark-cases.html
+++ b/conbench/templates/c-benchmark-cases.html
@@ -1,16 +1,11 @@
 {% extends "app.html" %}
 {% block app_content %}
   <h3>
-    Case permutations for benchmark <strong>{{ benchmark_name }}</strong>
+    benchmark <strong>{{ benchmark_name }}</strong>: case permutations
   </h3>
-  <p>
-    Found <strong>{{ results_by_case_id|length }}</strong> unique case permutation(s)
-    across <strong>{{ benchmark_result_count }}</strong> result(s).
-    <br>
-  </p>
-  <div class="mt-5">
+  <div class="mt-3">
     <h5>
-      <strong>case parameters</strong>
+      known case parameters
       <sup><i class="bi bi-info-circle"
    data-bs-toggle="tooltip"
    data-bs-title="Each panel represents one case parameter, and lists all known values as well as the number of benchmark results per value. Clicking a value applies a filter to the table below. Current limitation: two selected values per parameter are not yet supported.">

--- a/conbench/templates/c-benchmark-cases.html
+++ b/conbench/templates/c-benchmark-cases.html
@@ -48,7 +48,7 @@
         <th scope="col" style="">case permutation</th>
         <th scope="col" style="width: 12%">last result (UTC)</th>
         <th scope="col" style="width: 7%"># results</th>
-        <th scope="col" style="width: 8%""># hardwares</th>
+        <th scope="col" style="width: 8%"># hardwares</th>
         <th scope="col" style="width: 7%"># contexts</th>
       </tr>
     </thead>

--- a/conbench/templates/c-benchmark-cases.html
+++ b/conbench/templates/c-benchmark-cases.html
@@ -16,27 +16,29 @@
     <div class="d-flex flex-wrap">
       {% for case_param_key, case_param_value_count_dict in all_values_per_case_key_sorted.items() %}
         <div class="bg-light case-param-panel">
-          <div class="case-param-title"><code>{{ case_param_key }} ({{ case_param_value_count_dict|length }})</code></div>
-            <div class="case-param-values c-bench-scrollbar">
-              {% for v, vcount in case_param_value_count_dict.items() %}
-                <span class="case-parm-value"
-                      data-cvp-key="{{ case_param_key }}"
-                      data-cvp-value="{{v}}">{{ v }} ({{ vcount }})</span>
-                <br>
-              {% endfor %}
-            </div>
+          <div class="case-param-title">
+            <code>{{ case_param_key }} ({{ case_param_value_count_dict|length }})</code>
+          </div>
+          <div class="case-param-values c-bench-scrollbar">
+            {% for v, vcount in case_param_value_count_dict.items() %}
+              <span class="case-parm-value"
+                    data-cvp-key="{{ case_param_key }}"
+                    data-cvp-value="{{v}}">{{ v }} ({{ vcount }})</span>
+              <br>
+            {% endfor %}
+          </div>
         </div>
       {% endfor %}
     </div>
   </div>
 </div>
 <div class="mt-5">
-<p>
-  Found <strong>{{ results_by_case_id|length }}</strong> unique case permutation(s)
-  across <strong>{{ benchmark_result_count }}</strong> result(s). The table below
-  shows one row per case permutation. You can limit the permutations shown by
-  selecting case parameter key/value pairs in the panels above.
-</p>
+  <p>
+    Found <strong>{{ results_by_case_id|length }}</strong> unique case permutation(s)
+    across <strong>{{ benchmark_result_count }}</strong> result(s). The table below
+    shows one row per case permutation. You can limit the permutations shown by
+    selecting case parameter key/value pairs in the panels above.
+  </p>
 </div>
 <div class="mt-4">
   <table class="table table-hover conbench-datatable c-bench-caseperm-table"

--- a/conbench/templates/c-benchmark-cases.html
+++ b/conbench/templates/c-benchmark-cases.html
@@ -31,33 +31,38 @@
   </div>
 </div>
 <div class="mt-5">
-  <h5>
-    <strong>case permutations</strong>
-  </h5>
-  <table class="table table-hover conbench-datatable"
+<p>
+  Found <strong>{{ results_by_case_id|length }}</strong> unique case permutation(s)
+  across <strong>{{ benchmark_result_count }}</strong> result(s). The table below
+  shows one row per case permutation. You can limit the permutations shown by
+  selecting case parameter key/value pairs in the panels above.
+</p>
+</div>
+<div class="mt-4">
+  <table class="table table-hover conbench-datatable c-bench-caseperm-table"
          style="width:100%;
                 display: none">
     <thead>
       <tr>
         <th scope="col" style="width: 7%">case id</th>
-        <th scope="col" style="width: 35%">case permutation</th>
-        <th scope="col" style="width: 13%">last result</th>
-        <th scope="col" style="width: 6%"># results</th>
-        <th scope="col" style="width: 8%"># hardwares</th>
-        <th scope="col" style="width: 6%"># contexts</th>
+        <th scope="col" style="">case permutation</th>
+        <th scope="col" style="width: 12%">last result (UTC)</th>
+        <th scope="col" style="width: 7%"># results</th>
+        <th scope="col" style="width: 8%""># hardwares</th>
+        <th scope="col" style="width: 7%"># contexts</th>
       </tr>
     </thead>
     <tbody>
       {% for case_id, results in results_by_case_id.items() %}
         <tr>
-          <td class="font-monospace">
+          <td>
             <a href="{{ url_for('app.show_benchmark_results', bname=benchmark_name, caseid=case_id) }}">{{ case_id[:10] }}</a>
           </td>
-          <td class="font-monospace">{{ results[0].case_text_id }}</td>
-          <td class="font-monospace">{{ last_result_per_case_id[case_id].ui_time_started_at }}</td>
-          <td class="font-monospace">{{ results|length }}</td>
-          <td class="font-monospace">{{ hardware_count_per_case_id[case_id] }}</td>
-          <td class="font-monospace">{{ context_count_per_case_id[case_id] }}</td>
+          <td class="casepermstring">{{ results[0].case_text_id }}</td>
+          <td>{{ last_result_per_case_id[case_id].ui_time_started_at[:-4] }}</td>
+          <td class="text-end">{{ results|length }}</td>
+          <td class="text-end">{{ hardware_count_per_case_id[case_id] }}</td>
+          <td class="text-end">{{ context_count_per_case_id[case_id] }}</td>
         </tr>
       {% endfor %}
     </tbody>

--- a/conbench/templates/c-benchmark-cases.html
+++ b/conbench/templates/c-benchmark-cases.html
@@ -17,22 +17,22 @@
       </i>
     </sup>
   </h5>
-  <div class="row mt-2 row-cols-2 row-cols-lg-5 g-2 g-lg-3">
-    {% for case_param_key, case_param_value_count_dict in all_values_per_case_key_sorted.items() %}
-      <div class="col">
-        <div class="p-3 border bg-light overflow-auto" style="height: 190px;">
-          <code>{{ case_param_key }} ({{ case_param_value_count_dict|length }})</code>
-          <br>
-          <hr>
-          {% for v, vcount in case_param_value_count_dict.items() %}
-            <span class="case-parm-value"
-                  data-cvp-key="{{ case_param_key }}"
-                  data-cvp-value="{{v}}">{{ v }} ({{ vcount }})</span>
-            <br>
-          {% endfor %}
+  <div class="row mt-2">
+    <div class="d-flex flex-wrap">
+      {% for case_param_key, case_param_value_count_dict in all_values_per_case_key_sorted.items() %}
+        <div class="bg-light case-param-panel">
+          <div class="case-param-title"><code>{{ case_param_key }} ({{ case_param_value_count_dict|length }})</code></div>
+            <div class="case-param-values c-bench-scrollbar">
+              {% for v, vcount in case_param_value_count_dict.items() %}
+                <span class="case-parm-value"
+                      data-cvp-key="{{ case_param_key }}"
+                      data-cvp-value="{{v}}">{{ v }} ({{ vcount }})</span>
+                <br>
+              {% endfor %}
+            </div>
         </div>
-      </div>
-    {% endfor %}
+      {% endfor %}
+    </div>
   </div>
 </div>
 <div class="mt-5">

--- a/conbench/templates/c-benchmarks.html
+++ b/conbench/templates/c-benchmarks.html
@@ -12,10 +12,10 @@
     {{ bmr_cache_meta.newest_result_time_str }}
     (~{{ bmr_cache_meta.covered_timeframe_days_approx }} days).
   </p>
-  <div class="row row-cols-1 row-cols-md-3 g-4">
+  <div class="c-bench-landing row row-cols-1 row-cols-md-3 g-4">
     <div class="col">
       <div class="card">
-        <div class="card-body overflow-auto" style="max-height: 500px;">
+        <div class="card-body overflow-auto c-bench-scrollbar" style="max-height: 450px;">
           <h5 class="card-title">by name</h5>
           {% for benchmark_name, results in benchmarks_by_name_sorted_alphabetically.items() %}
             <strong><a href="{{ url_for('app.show_benchmark_cases', bname=benchmark_name) }}">{{ benchmark_name }}</a></strong>
@@ -27,7 +27,7 @@
     </div>
     <div class="col">
       <div class="card">
-        <div class="card-body overflow-auto" style="max-height: 500px;">
+        <div class="card-body overflow-auto c-bench-scrollbar" style="max-height: 450px;">
           <h5 class="card-title">by most recent result</h5>
           {% for result in newest_result_for_each_benchmark_name_topN %}
             <strong><a href="{{ url_for('app.show_benchmark_cases', bname=result.benchmark_name) }}">{{ result.benchmark_name }}</a></strong>
@@ -39,7 +39,7 @@
     </div>
     <div class="col">
       <div class="card">
-        <div class="card-body overflow-auto" style="max-height: 500px;">
+        <div class="card-body overflow-auto c-bench-scrollbar" style="max-height: 450px;">
           <h5 class="card-title">
             by results per case
             <sup><i style="font-size: 12px"
@@ -58,7 +58,7 @@
     </div>
     <div class="col">
       <div class="card">
-        <div class="card-body overflow-auto" style="max-height: 500px;">
+        <div class="card-body overflow-auto c-bench-scrollbar" style="max-height: 450px;">
           <h5 class="card-title">by result count</h5>
           {% for benchmark_name, results in benchmarks_by_name_sorted_by_resultcount.items() %}
             <strong><a href="{{ url_for('app.show_benchmark_cases', bname=benchmark_name) }}">{{ benchmark_name }}</a></strong>

--- a/conbench/templates/c-benchmarks.html
+++ b/conbench/templates/c-benchmarks.html
@@ -15,7 +15,8 @@
   <div class="c-bench-landing row row-cols-1 row-cols-md-3 g-4">
     <div class="col">
       <div class="card">
-        <div class="card-body overflow-auto c-bench-scrollbar" style="max-height: 450px;">
+        <div class="card-body overflow-auto c-bench-scrollbar"
+             style="max-height: 450px">
           <h5 class="card-title">by name</h5>
           {% for benchmark_name, results in benchmarks_by_name_sorted_alphabetically.items() %}
             <strong><a href="{{ url_for('app.show_benchmark_cases', bname=benchmark_name) }}">{{ benchmark_name }}</a></strong>
@@ -27,7 +28,8 @@
     </div>
     <div class="col">
       <div class="card">
-        <div class="card-body overflow-auto c-bench-scrollbar" style="max-height: 450px;">
+        <div class="card-body overflow-auto c-bench-scrollbar"
+             style="max-height: 450px">
           <h5 class="card-title">by most recent result</h5>
           {% for result in newest_result_for_each_benchmark_name_topN %}
             <strong><a href="{{ url_for('app.show_benchmark_cases', bname=result.benchmark_name) }}">{{ result.benchmark_name }}</a></strong>
@@ -39,7 +41,8 @@
     </div>
     <div class="col">
       <div class="card">
-        <div class="card-body overflow-auto c-bench-scrollbar" style="max-height: 450px;">
+        <div class="card-body overflow-auto c-bench-scrollbar"
+             style="max-height: 450px">
           <h5 class="card-title">
             by results per case
             <sup><i style="font-size: 12px"
@@ -58,7 +61,8 @@
     </div>
     <div class="col">
       <div class="card">
-        <div class="card-body overflow-auto c-bench-scrollbar" style="max-height: 450px;">
+        <div class="card-body overflow-auto c-bench-scrollbar"
+             style="max-height: 450px">
           <h5 class="card-title">by result count</h5>
           {% for benchmark_name, results in benchmarks_by_name_sorted_by_resultcount.items() %}
             <strong><a href="{{ url_for('app.show_benchmark_cases', bname=benchmark_name) }}">{{ benchmark_name }}</a></strong>


### PR DESCRIPTION
This patch is mainly about using UI space more wisely, mainly in the "case permutation" view of the conceptual benchmark UI section.

This uses the Bootstrap 5 flex wrap system with fixed width 'panels'. Used the typical incredients to save space: padding, font size, margin, ... also scrollbar in this case. Also worked on wasting less vertical space, i.e. getting 'right to business' below the navbar (pulled misc info to bottom).

### Before

This is a sanitized screenshot from a prod system benchmark with a largish number of case parameters, showing how much space this can currently consume:

![Screenshot from 2023-05-11 15-10-16](https://github.com/conbench/conbench/assets/265630/392e320a-c96f-4bb1-866b-02f1f845657b)

### After

This is a local dev screenshot (not the same state of data as above, but still demonstrating the change quite vividly I think:
![Screenshot from 2023-05-11 15-02-55](https://github.com/conbench/conbench/assets/265630/afa91515-2222-4aa8-aa4e-b60a4c6dd1a6)

