### PR TITLE
benchalerts: handle empty runs/results better

### DIFF
--- a/benchalerts/benchalerts/conbench_dataclasses.py
+++ b/benchalerts/benchalerts/conbench_dataclasses.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from typing import List, Optional
 
-from benchclients.logging import fatal_and_log
+from benchclients.logging import fatal_and_log, log
 
 
 @dataclass
@@ -25,6 +25,8 @@ class RunComparisonInfo:
     """Track and organize specific info about a comparison between a contender run and
     its baseline run.
 
+    compare_results and benchmark_results are mutually exclusive.
+
     Parameters
     ----------
     contender_info
@@ -39,11 +41,10 @@ class RunComparisonInfo:
         to its baseline, including the statistics and regression analysis.
     benchmark_results
         The list returned from Conbench when hitting
-        /benchmark-results/?run_id={contender_run_id}, only if the contender run has
-        errors and there is no baseline run. Contains info about each benchmark result
-        in the contender run, including statistics and tracebacks. Only used when a
-        baseline run doesn't exist because otherwise all this information is already in
-        the compare_results.
+        /benchmark-results/?run_id={contender_run_id}, only if there is no baseline run.
+        Contains info about each benchmark result in the contender run, including
+        statistics and tracebacks. Only used when a baseline run doesn't exist because
+        otherwise all this information is already in the compare_results.
     """
 
     contender_info: dict
@@ -140,11 +141,6 @@ class RunComparisonInfo:
         return f"{self.app_url}/benchmark-results/{contender_result_id}"
 
     @property
-    def has_errors(self) -> bool:
-        """Whether this run has any benchmark errors."""
-        return self.contender_info["has_errors"]
-
-    @property
     def contender_id(self) -> str:
         """The contender run_id."""
         return self.contender_info["id"]
@@ -190,14 +186,34 @@ class FullComparisonInfo:
     the comparisons to their baselines.
     """
 
+    # Can be empty.
     run_comparisons: List[RunComparisonInfo]
 
-    def __post_init__(self):
-        # Any code that constructs an instance should ensure run_comparisons is non-empty
-        assert self.run_comparisons
+    @property
+    def has_any_contender_runs(self) -> bool:
+        """Whether there are any contender runs available."""
+        return bool(self.run_comparisons)
 
     @property
-    def benchmarks_with_errors(self) -> List[BenchmarkResultInfo]:
+    def has_any_contender_results(self) -> bool:
+        """Whether there are any contender benchmark results available."""
+        for run_comparison in self.run_comparisons:
+            if run_comparison.contender_benchmark_result_info:
+                return True
+        return False
+
+    @property
+    def has_any_z_analyses(self) -> bool:
+        """Whether there are any lookback z-score analyses available."""
+        for run_comparison in self.run_comparisons:
+            if run_comparison.compare_results:
+                for compare_result in run_comparison.compare_results:
+                    if compare_result["analysis"]["lookback_z_score"]:
+                        return True
+        return False
+
+    @property
+    def results_with_errors(self) -> List[BenchmarkResultInfo]:
         """Get information about all benchmark results with errors across runs."""
         out = []
 
@@ -211,7 +227,7 @@ class FullComparisonInfo:
         return out
 
     @property
-    def benchmarks_with_z_regressions(self) -> List[BenchmarkResultInfo]:
+    def results_with_z_regressions(self) -> List[BenchmarkResultInfo]:
         """Get information about all benchmark results across runs whose z-scores were
         extreme enough to constitute a regression.
         """
@@ -227,14 +243,7 @@ class FullComparisonInfo:
         return out
 
     @property
-    def no_baseline_runs(self) -> bool:
-        """Whether all contender runs are missing a baseline run."""
-        return not any(
-            run_comparison.baseline_id for run_comparison in self.run_comparisons
-        )
-
-    @property
-    def z_score_threshold(self) -> float:
+    def z_score_threshold(self) -> Optional[float]:
         """The z-score threshold used in this analysis."""
         z_score_thresholds = set()
         for run_comparison in self.run_comparisons:
@@ -245,8 +254,10 @@ class FullComparisonInfo:
                             compare["analysis"]["lookback_z_score"]["z_threshold"]
                         )
 
+        if len(z_score_thresholds) == 0:
+            return None
         if len(z_score_thresholds) != 1:
-            fatal_and_log(
+            log.warn(
                 f"There wasn't exactly one z_score_threshold: {z_score_thresholds=}"
             )
         return z_score_thresholds.pop()
@@ -262,10 +273,12 @@ class FullComparisonInfo:
         if len(commit_hashes) == 0:
             return None
         if len(commit_hashes) != 1:
-            fatal_and_log(f"There wasn't exactly one commit_hash: {commit_hashes=}")
+            log.warn(f"There wasn't exactly one commit_hash: {commit_hashes=}")
         return commit_hashes.pop()
 
     @property
-    def app_url(self) -> str:
+    def app_url(self) -> Optional[str]:
         """The base URL to use for links to the webapp, without a trailing slash."""
-        return self.run_comparisons[0].app_url
+        if self.has_any_contender_runs:
+            return self.run_comparisons[0].app_url
+        return None

--- a/benchalerts/benchalerts/conbench_dataclasses.py
+++ b/benchalerts/benchalerts/conbench_dataclasses.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from typing import List, Optional
 
-from benchclients.logging import fatal_and_log, log
+from benchclients.logging import log
 
 
 @dataclass

--- a/benchalerts/benchalerts/message_formatting.py
+++ b/benchalerts/benchalerts/message_formatting.py
@@ -226,8 +226,8 @@ def pr_comment_link_to_check(
         if not full_comparison.has_any_z_analyses:
             comment += _clean(
                 """
-                There weren't enough matching historic benchmark runs to make a call on
-                whether there were regressions.
+                There weren't enough matching historic benchmark results to make a call
+                on whether there were regressions.
                 """
             )
             comment += "\n\n"

--- a/benchalerts/benchalerts/message_formatting.py
+++ b/benchalerts/benchalerts/message_formatting.py
@@ -82,11 +82,35 @@ def _intro_sentence(full_comparison: FullComparisonInfo) -> str:
     return intro + "\n\n"
 
 
-def github_check_summary(full_comparison: FullComparisonInfo) -> str:
+def github_check_summary(
+    full_comparison: FullComparisonInfo, build_url: Optional[str]
+) -> str:
     """Generate a Markdown summary of what happened regarding errors and regressions."""
     summary = _intro_sentence(full_comparison)
 
-    if full_comparison.benchmarks_with_errors:
+    if not full_comparison.has_any_contender_runs:
+        summary += _clean(
+            """
+            None of the specified runs were found on the Conbench server.
+            """
+        )
+        if build_url:
+            summary += f" See the [build logs]({build_url}) for more information."
+        # exit early
+        return summary
+
+    if not full_comparison.has_any_contender_results:
+        summary += _clean(
+            """
+            None of the specified runs had any associated benchmark results.
+            """
+        )
+        if build_url:
+            summary += f" See the [build logs]({build_url}) for more information."
+        # exit early
+        return summary
+
+    if full_comparison.results_with_errors:
         summary += _clean(
             """
             ## Benchmarks with errors
@@ -96,11 +120,11 @@ def github_check_summary(full_comparison: FullComparisonInfo) -> str:
             have more information about what the error was.
             """
         )
-        summary += _list_results(full_comparison.benchmarks_with_errors)
+        summary += _list_results(full_comparison.results_with_errors)
 
     summary += "## Benchmarks with performance regressions\n\n"
 
-    if full_comparison.no_baseline_runs:
+    if not full_comparison.has_any_z_analyses:
         summary += _clean(
             """
             There weren't enough matching historic runs in Conbench to make a call on
@@ -115,20 +139,20 @@ def github_check_summary(full_comparison: FullComparisonInfo) -> str:
         # exit early
         return summary
 
-    pluralizer = _Pluralizer(full_comparison.benchmarks_with_z_regressions)
+    pluralizer = _Pluralizer(full_comparison.results_with_z_regressions)
     were = pluralizer.were
     s = pluralizer.s
     summary += _clean(
         f"""
-        There {were} {len(full_comparison.benchmarks_with_z_regressions)} possible
+        There {were} {len(full_comparison.results_with_z_regressions)} possible
         performance regression{s}, according to the lookback z-score method.
         """
     )
     summary += "\n\n"
 
-    if full_comparison.benchmarks_with_z_regressions:
+    if full_comparison.results_with_z_regressions:
         summary += "### Benchmarks with regressions:"
-        summary += _list_results(full_comparison.benchmarks_with_z_regressions)
+        summary += _list_results(full_comparison.results_with_z_regressions)
 
     summary += "## All benchmark runs analyzed:\n"
     for comparison in full_comparison.run_comparisons:
@@ -155,7 +179,7 @@ def github_check_details(full_comparison: FullComparisonInfo) -> Optional[str]:
         )
         details += "\n\n"
 
-    if not full_comparison.no_baseline_runs:
+    if full_comparison.has_any_z_analyses:
         details += _clean(
             f"""
             This report was generated using the lookback z-score method with a z-score
@@ -172,44 +196,61 @@ def pr_comment_link_to_check(
     """Generate a GitHub PR comment that summarizes and links to a GitHub Check."""
     comment = _intro_sentence(full_comparison)
 
-    if full_comparison.benchmarks_with_errors:
-        pluralizer = _Pluralizer(full_comparison.benchmarks_with_errors)
-        were = pluralizer.were
-        s = pluralizer.s
-        comment += _clean(
-            f"""
-            There {were} {len(full_comparison.benchmarks_with_errors)} benchmark
-            result{s} with an error:
-            """
-        )
-        comment += _list_results(full_comparison.benchmarks_with_errors, limit=2)
-
-    if full_comparison.no_baseline_runs:
+    if not full_comparison.has_any_contender_runs:
         comment += _clean(
             """
-            There weren't enough matching historic benchmark runs to make a call on
-            whether there were regressions.
+            None of the specified runs were found on the Conbench server.
             """
         )
         comment += "\n\n"
-    elif full_comparison.benchmarks_with_z_regressions:
-        pluralizer = _Pluralizer(full_comparison.benchmarks_with_z_regressions)
-        were = pluralizer.were
-        s = pluralizer.s
+    elif not full_comparison.has_any_contender_results:
         comment += _clean(
-            f"""
-            There {were} {len(full_comparison.benchmarks_with_z_regressions)} benchmark
-            result{s} indicating a performance regression:
+            """
+            None of the specified runs had any associated benchmark results.
             """
         )
-        comment += _list_results(full_comparison.benchmarks_with_z_regressions, limit=2)
+        comment += "\n\n"
     else:
-        comment += _clean(
-            """
-            There were no benchmark performance regressions. 🎉
-            """
-        )
-        comment += "\n\n"
+        if full_comparison.results_with_errors:
+            pluralizer = _Pluralizer(full_comparison.results_with_errors)
+            were = pluralizer.were
+            s = pluralizer.s
+            comment += _clean(
+                f"""
+                There {were} {len(full_comparison.results_with_errors)} benchmark
+                result{s} with an error:
+                """
+            )
+            comment += _list_results(full_comparison.results_with_errors, limit=2)
+
+        if not full_comparison.has_any_z_analyses:
+            comment += _clean(
+                """
+                There weren't enough matching historic benchmark runs to make a call on
+                whether there were regressions.
+                """
+            )
+            comment += "\n\n"
+        elif full_comparison.results_with_z_regressions:
+            pluralizer = _Pluralizer(full_comparison.results_with_z_regressions)
+            were = pluralizer.were
+            s = pluralizer.s
+            comment += _clean(
+                f"""
+                There {were} {len(full_comparison.results_with_z_regressions)} benchmark
+                result{s} indicating a performance regression:
+                """
+            )
+            comment += _list_results(
+                full_comparison.results_with_z_regressions, limit=2
+            )
+        else:
+            comment += _clean(
+                """
+                There were no benchmark performance regressions. 🎉
+                """
+            )
+            comment += "\n\n"
 
     comment += _clean(
         f"""

--- a/benchalerts/benchalerts/pipeline_steps/conbench.py
+++ b/benchalerts/benchalerts/pipeline_steps/conbench.py
@@ -3,9 +3,9 @@
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
+import requests
 from benchclients.conbench import LegacyConbenchClient
 from benchclients.logging import log
-import requests
 
 from ..alert_pipeline import AlertPipelineStep
 from ..conbench_dataclasses import FullComparisonInfo, RunComparisonInfo

--- a/benchalerts/tests/unit_tests/conftest.py
+++ b/benchalerts/tests/unit_tests/conftest.py
@@ -81,6 +81,8 @@ def mock_comparison_info(request: SubRequest) -> FullComparisonInfo:
             "regressions",
             "noregressions",
             "nocommit",
+            "noruns",
+            "noresults",
         ],
         indirect=["mock_comparison_info"],
     )
@@ -117,9 +119,13 @@ def mock_comparison_info(request: SubRequest) -> FullComparisonInfo:
                 result["contender"]["error"] = None
         return res
 
-    benchmark_results = _response(
-        "GET_conbench_benchmark-results_run_id_contender_wo_base"
-    )
+    def _results(has_errors: bool):
+        """Get a mocked benchmark results response."""
+        res = _response("GET_conbench_benchmark-results_run_id_contender_wo_base")
+        if not has_errors:
+            for result in res:
+                result["error"] = None
+        return res
 
     if how == "errors_baselines":
         return FullComparisonInfo(
@@ -144,7 +150,7 @@ def mock_comparison_info(request: SubRequest) -> FullComparisonInfo:
                     ),
                     baseline_run_type="parent",
                     compare_results=None,
-                    benchmark_results=benchmark_results,
+                    benchmark_results=_results(has_errors=True),
                 )
             ]
             * 2
@@ -158,7 +164,7 @@ def mock_comparison_info(request: SubRequest) -> FullComparisonInfo:
                     ),
                     baseline_run_type="parent",
                     compare_results=None,
-                    benchmark_results=None,
+                    benchmark_results=_results(has_errors=False),
                 )
             ]
             * 2
@@ -172,7 +178,7 @@ def mock_comparison_info(request: SubRequest) -> FullComparisonInfo:
                     ),
                     baseline_run_type="parent",
                     compare_results=None,
-                    benchmark_results=None,
+                    benchmark_results=_results(has_errors=False),
                 ),
                 RunComparisonInfo(
                     contender_info=_run(
@@ -219,4 +225,19 @@ def mock_comparison_info(request: SubRequest) -> FullComparisonInfo:
                 )
             ]
             * 2
+        )
+    if how == "noruns":
+        return FullComparisonInfo([])
+    if how == "noresults":
+        return FullComparisonInfo(
+            [
+                RunComparisonInfo(
+                    contender_info=_run(
+                        has_errors=False, has_baseline=False, has_commit=True
+                    ),
+                    baseline_run_type="parent",
+                    compare_results=None,
+                    benchmark_results=[],
+                )
+            ]
         )

--- a/benchalerts/tests/unit_tests/expected_md/comment_errors_nobaselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_errors_nobaselines.md
@@ -6,6 +6,6 @@ There were 2 benchmark results with an error:
   - [file-write](http://localhost/benchmark-results/some-benchmark-uuid-2)
   - [file-write](http://localhost/benchmark-results/some-benchmark-uuid-2)
 
-There weren't enough matching historic benchmark runs to make a call on whether there were regressions.
+There weren't enough matching historic benchmark results to make a call on whether there were regressions.
 
 The [full Conbench report](https://github.com/github/hello-world/runs/4) has more details.

--- a/benchalerts/tests/unit_tests/expected_md/comment_noerrors_nobaselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_noerrors_nobaselines.md
@@ -1,5 +1,5 @@
 Conbench analyzed the 2 benchmark runs on commit `abc`.
 
-There weren't enough matching historic benchmark runs to make a call on whether there were regressions.
+There weren't enough matching historic benchmark results to make a call on whether there were regressions.
 
 The [full Conbench report](https://github.com/github/hello-world/runs/4) has more details.

--- a/benchalerts/tests/unit_tests/expected_md/comment_noresults.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_noresults.md
@@ -1,0 +1,5 @@
+Conbench analyzed the 1 benchmark run on commit `abc`.
+
+None of the specified runs had any associated benchmark results.
+
+The [full Conbench report](https://github.com/github/hello-world/runs/4) has more details.

--- a/benchalerts/tests/unit_tests/expected_md/comment_noruns.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_noruns.md
@@ -1,0 +1,5 @@
+Conbench analyzed the 0 benchmark runs that triggered this notification.
+
+None of the specified runs were found on the Conbench server.
+
+The [full Conbench report](https://github.com/github/hello-world/runs/4) has more details.

--- a/benchalerts/tests/unit_tests/expected_md/details_noruns.md
+++ b/benchalerts/tests/unit_tests/expected_md/details_noruns.md
@@ -1,0 +1,1 @@
+This report was not associated with any commit connected to the git graph. This probably means that benchmarks were run on a transient merge-commit.

--- a/benchalerts/tests/unit_tests/expected_md/summary_noresults.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_noresults.md
@@ -1,0 +1,3 @@
+Conbench analyzed the 1 benchmark run on commit `abc`.
+
+None of the specified runs had any associated benchmark results. See the [build logs](https://austin.something) for more information.

--- a/benchalerts/tests/unit_tests/expected_md/summary_noruns.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_noruns.md
@@ -1,0 +1,3 @@
+Conbench analyzed the 0 benchmark runs that triggered this notification.
+
+None of the specified runs were found on the Conbench server. See the [build logs](https://austin.something) for more information.

--- a/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_not_found.json
+++ b/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_not_found.json
@@ -1,0 +1,8 @@
+{
+    "status_code": 404,
+    "data": {
+        "code": 404,
+        "description": "The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.",
+        "name": "Not Found"
+    }
+}

--- a/benchalerts/tests/unit_tests/test_pipeline_steps/test_conbench.py
+++ b/benchalerts/tests/unit_tests/test_pipeline_steps/test_conbench.py
@@ -46,6 +46,16 @@ def test_runs_comparison_without_commit(conbench_env, caplog: pytest.LogCaptureF
     assert res
 
 
+def test_runs_comparison_skips_runs_not_found(conbench_env):
+    step = GetConbenchZComparisonForRunsStep(
+        run_ids=["contender_wo_base", "not_found"],
+        baseline_run_type=BaselineRunCandidates.latest_default,
+        conbench_client=ConbenchClient(adapter=MockAdapter()),
+    )
+    res = step.run_step(previous_outputs={})
+    assert len(res.run_comparisons) == 1
+
+
 def test_GetConbenchZComparisonStep(conbench_env):
     step = GetConbenchZComparisonStep(
         commit_hash="abc",
@@ -57,14 +67,14 @@ def test_GetConbenchZComparisonStep(conbench_env):
     assert res
 
 
-def test_comparison_fails_when_no_runs(conbench_env):
+def test_comparison_doesnt_fail_when_no_runs(conbench_env):
     step = GetConbenchZComparisonStep(
         commit_hash="no_runs",
         baseline_run_type=BaselineRunCandidates.fork_point,
         conbench_client=ConbenchClient(adapter=MockAdapter()),
     )
-    with pytest.raises(ValueError, match="runs"):
-        step.run_step(previous_outputs={})
+    res = step.run_step(previous_outputs={})
+    assert res
 
 
 def test_comparison_warns_when_no_baseline(

--- a/benchalerts/tests/unit_tests/test_pipeline_steps/test_github.py
+++ b/benchalerts/tests/unit_tests/test_pipeline_steps/test_github.py
@@ -30,6 +30,8 @@ from ..mocks import (
         ("regressions", "summary_regressions", "details_regressions"),
         ("noregressions", "summary_noregressions", "details_noregressions"),
         ("nocommit", "summary_nocommit", "details_nocommit"),
+        ("noruns", "summary_noruns", "details_noruns"),
+        ("noresults", "summary_noresults", None),
     ],
     indirect=["mock_comparison_info"],
 )
@@ -48,6 +50,7 @@ def test_GitHubCheckStep(
                 github_client=GitHubRepoClient(repo="some/repo", adapter=MockAdapter()),
                 comparison_step_name="comparison_step",
                 external_id="123",
+                build_url="https://austin.something",
             )
         return
 
@@ -56,6 +59,7 @@ def test_GitHubCheckStep(
         github_client=GitHubRepoClient(repo="some/repo", adapter=MockAdapter()),
         comparison_step_name="comparison_step",
         external_id="123",
+        build_url="https://austin.something",
     )
     gh_res, full_comparison = step.run_step({"comparison_step": mock_comparison_info})
     assert gh_res
@@ -72,6 +76,8 @@ def test_GitHubCheckStep(
         "regressions",
         "noregressions",
         "nocommit",
+        "noruns",
+        "noresults",
     ],
     indirect=["mock_comparison_info"],
 )
@@ -95,6 +101,8 @@ def test_GitHubStatusStep(mock_comparison_info: FullComparisonInfo, github_auth:
         ("regressions", "comment_regressions"),
         ("noregressions", "comment_noregressions"),
         ("nocommit", "comment_nocommit"),
+        ("noruns", "comment_noruns"),
+        ("noresults", "comment_noresults"),
     ],
     indirect=["mock_comparison_info"],
 )


### PR DESCRIPTION
Fixes #1191 and some other issues I've noticed while looking through the code.

To sum up this PR, the original stance of `benchalerts` was "if the analysis can't find any contender runs or any contender benchmark results, raise an error." That's turned out to hide some complexities that could be surfaced to consumers of the alerts so that they could take action. This PR makes it so it's okay if we can't find contender runs or results, as long as we surface that detail to the user.