### PR TITLE
c-bench UI: increase BMRT cache size, show context (offcanvas), work on tinyplot

### DIFF
--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -190,7 +190,10 @@ def show_benchmark_cases(bname: str) -> str:
 
 
 class TypeUIPlotInfo(TypedDict):
-    title: str
+    hwid: str
+    ctxid: str
+    hwname: str
+    n_results: int
     url_to_newest_result: str
     data_for_uplot: List[List]
     unit: str

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -127,7 +127,7 @@ bmrt_cache: CacheDict = {
 SHUTDOWN = False
 _STARTED = False
 
-BMRT_CACHE_SIZE = 0.2 * 10**6
+BMRT_CACHE_SIZE = 0.3 * 10**6
 if Config.TESTING:
     # quicker update in testing
     BMRT_CACHE_SIZE = 0.2 * 10**6

--- a/conbench/static/app.css
+++ b/conbench/static/app.css
@@ -56,10 +56,9 @@ table.c-bench-caseperm-table td.casepermstring {
   font-size: 11px;
 }
 
-table.c-bench-caseperm-table th{
+table.c-bench-caseperm-table th {
   font-size: 12px;
 }
-
 
 span.case-parm-value {
   font-family: monospace;
@@ -72,6 +71,15 @@ span.case-parm-value.selected {
   font-family: monospace;
   background-color: #38BDD166;
 }
+
+div.offcanvas-cb-context pre {
+  /* do not overflow horizontally: word wrap in pre.
+    kudos to https://stackoverflow.com/a/45783868/145400 */
+  white-space: pre-wrap;
+  word-break: keep-all;
+  font-size: 13px;
+}
+
 
 /* select.caseparm-select {
   overflow: auto !important;
@@ -87,6 +95,26 @@ div.dataTables_filter label {
   margin-left: 10px;
  }
 
+div.cb-tinyplot div.hardware {
+  font-family: var(--bs-font-monospace);
+  font-size: 11px;
+  padding-left: 5px;
+}
+
+div.cb-tinyplot div.context {
+  font-family: var(--bs-font-monospace);
+  font-size: 11px;
+  padding-left: 15px;
+}
+
+div.cb-tinyplot div.results {
+  font-family: var(--bs-font-monospace);
+  font-size: 11px;
+}
+
+div.cb-tinyplot a {
+  color: #812570
+}
 
 div.cb-tinyplot {
   background-color: #f3f3f3;

--- a/conbench/templates/c-benchmark-results-for-case.html
+++ b/conbench/templates/c-benchmark-results-for-case.html
@@ -16,10 +16,7 @@
       <sup><i style="font-size: 12px"
    class="bi bi-info-circle"
    data-bs-toggle="tooltip"
-   data-bs-title="Benchmark results, grouped by unique (hardware, context) combinations.
-   Ordinate: the benchmarked metric. Mean value, if multisample.
-   Time axis: benchmark result start time (associated commit data is not used).
-   A plot is only shown for at least three data points.">
+   data-bs-title="Benchmark results, grouped by unique (hardware, context) combinations. Ordinate: the benchmarked metric. Mean value, if multisample. Time axis: benchmark result start time (associated commit data is not used). A plot is only shown for at least three data points.">
       </i></sup>
     </h5>
     <!--  Strategy: BS gutters, see https://getbootstrap.com/docs/5.2/layout/gutters/  -->
@@ -29,15 +26,24 @@
           <div class="cb-tinyplot pt-1 shadow">
             <!--https://getbootstrap.com/docs/5.3/utilities/flex/#auto-margins-->
             <div class="d-flex">
-              <div class="hardware" data-bs-toggle="tooltip" data-bs-title="Hardware" data-bs-delay='{"show":700,"hide":150}'>
+              <div class="hardware"
+                   data-bs-toggle="tooltip"
+                   data-bs-title="Hardware"
+                   data-bs-delay='{"show":700,"hide":150}'>
                 <i class="bi bi-cpu"></i> {{ plotinfo.hwname[:25] }}
               </div>
-              <div class="context" data-bs-toggle="tooltip" data-bs-title="Context" data-bs-delay='{"show":700,"hide":150}'>
-                <i class="bi bi-sliders2"></i> <a href="#" data-bs-toggle="offcanvas" data-bs-target="#offcanvasContextDict-{{plotinfo.ctxid}}" aria-controls="offcanvasContextDict-{{plotinfo.ctxid}}">
-                    {{ plotinfo.ctxid[:7] }}
-                  </a>
+              <div class="context"
+                   data-bs-toggle="tooltip"
+                   data-bs-title="Context"
+                   data-bs-delay='{"show":700,"hide":150}'>
+                <i class="bi bi-sliders2"></i> <a href="#"
+    data-bs-toggle="offcanvas"
+    data-bs-target="#offcanvasContextDict-{{ plotinfo.ctxid }}"
+    aria-controls="offcanvasContextDict-{{ plotinfo.ctxid }}">{{ plotinfo.ctxid[:7] }}</a>
               </div>
-              <div class="ms-auto ps-2 results">{{plotinfo.n_results}} results <a href="{{ plotinfo.url_to_newest_result }}"> (newest)</a></div>
+              <div class="ms-auto ps-2 results">
+                {{ plotinfo.n_results }} results <a href="{{ plotinfo.url_to_newest_result }}">(newest)</a>
+              </div>
             </div>
             <div class="cb-plot-{{ hwctx }}" style="width: 550px"></div>
           </div>
@@ -46,9 +52,8 @@
     </div>
     <div style="font-family: 'Roboto Mono';">.</div>
   </div>
-
   <div class="mt-5">
-    <p> All {{ benchmark_results_for_table|length }} individual benchmark results:</p>
+    <p>All {{ benchmark_results_for_table|length }} individual benchmark results:</p>
     <table class="table table-hover conbench-datatable"
            style="width:100%;
                   display: none">
@@ -86,23 +91,26 @@
       </tbody>
     </table>
   </div>
-
   {% for ctxid, context_json in context_json_by_context_id.items() %}
-  <div class="offcanvas offcanvas-start" data-bs-scroll="true" tabindex="-1" id="offcanvasContextDict-{{ctxid}}" aria-labelledby="offcanvasContextDictLabel-{{ctxid}}">
-    <div class="offcanvas-header">
-      <span class="offcanvas-title" id="offcanvasContextDictLabel-{{ctxid}}">Context {{ctxid}}</span>
-      <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+    <div class="offcanvas offcanvas-start"
+         data-bs-scroll="true"
+         tabindex="-1"
+         id="offcanvasContextDict-{{ ctxid }}"
+         aria-labelledby="offcanvasContextDictLabel-{{ ctxid }}">
+      <div class="offcanvas-header">
+        <span class="offcanvas-title" id="offcanvasContextDictLabel-{{ ctxid }}">Context {{ ctxid }}</span>
+        <button type="button"
+                class="btn-close"
+                data-bs-dismiss="offcanvas"
+                aria-label="Close"></button>
+      </div>
+      <div class="offcanvas-body offcanvas-cb-context">
+        <code>
+          <pre style="">{{context_json}}</pre>
+        </code>
+      </div>
     </div>
-    <div class="offcanvas-body offcanvas-cb-context">
-      <code>
-        <pre style="">{{context_json}}</pre>
-      </code>
-    </div>
-  </div>
   {% endfor %}
-
-
-
 {% endblock %}
 {% block scripts %}
   {{ super() }}

--- a/conbench/templates/c-benchmark-results-for-case.html
+++ b/conbench/templates/c-benchmark-results-for-case.html
@@ -17,7 +17,7 @@
                   display: none">
       <thead>
         <tr>
-          <th scope="col" style="width: 21%">time</th>
+          <th scope="col" style="width: 21%">benchmark start time</th>
           <th scope="col">result</th>
           <th scope="col">hardware</th>
           <th scope="col">ctx id</th>

--- a/conbench/templates/c-benchmark-results-for-case.html
+++ b/conbench/templates/c-benchmark-results-for-case.html
@@ -177,7 +177,7 @@
         ],
         axes: [
           {
-            label: "benchmark time",
+            label: "date",
             labelFont: "bold 12px 'Roboto Mono'",
             font: "11px 'Roboto Mono'",
             stroke: "#812570", // dark magenta
@@ -255,7 +255,7 @@
           "pageLength": 10,
             // Take rather precise control of layouting elements, put bottom elements
             // into a mult-col single row, using BS's grid system.
-          "dom": 'lfrt<"row"<"col-6"i><".col-6"p>>',
+          "dom": '<"row"<"d-flex flex-row-reverse p-0"fl>>rt<"row p-2"<"col-6"i><".col-6"p>>',
           "order": [[0, 'desc']],
           "columnDefs": [{ "orderable": true }],
           initComplete: function () {

--- a/conbench/templates/c-benchmark-results-for-case.html
+++ b/conbench/templates/c-benchmark-results-for-case.html
@@ -12,6 +12,30 @@
   </p>
   <p>Showing {{ benchmark_results_for_table|length }} of {{ matching_benchmark_result_count }} results:</p>
   <div class="mt-5">
+    <!--  Strategy: BS gutters, see https://getbootstrap.com/docs/5.2/layout/gutters/  -->
+    <div class="row gy-5">
+      {% for hwctx, plotinfo in infos_for_uplots.items() %}
+        <div class="col-6" style="width: 600px">
+          <div class="cb-tinyplot pt-1 shadow">
+            <!--https://getbootstrap.com/docs/5.3/utilities/flex/#auto-margins-->
+            <div class="d-flex">
+              <div class="hardware" data-bs-toggle="tooltip" data-bs-title="Hardware" data-bs-delay='{"show":700,"hide":150}'>
+                <i class="bi bi-cpu"></i> {{ plotinfo.hwname[:25] }}
+              </div>
+              <div class="context" data-bs-toggle="tooltip" data-bs-title="Context" data-bs-delay='{"show":700,"hide":150}'>
+                <i class="bi bi-sliders2"></i> <a href="#" data-bs-toggle="offcanvas" data-bs-target="#offcanvasContextDict-{{plotinfo.ctxid}}" aria-controls="offcanvasContextDict-{{plotinfo.ctxid}}">
+                    {{ plotinfo.ctxid[:7] }}
+                  </a>
+              </div>
+              <div class="ms-auto ps-2 results">{{plotinfo.n_results}} results <a href="{{ plotinfo.url_to_newest_result }}"> (newest)</a></div>
+            </div>
+            <div class="cb-plot-{{ hwctx }}" style="width: 550px"></div>
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+    <div style="font-family: 'Roboto Mono';">.</div>
+  </div>
     <table class="table table-hover conbench-datatable"
            style="width:100%;
                   display: none">
@@ -49,27 +73,7 @@
       </tbody>
     </table>
   </div>
-  <div class="mt-5">
-    <h3 class="mb-3">
-      History plots
-      <sup><i style="font-size: 12px"
-   class="bi bi-info-circle"
-   data-bs-toggle="tooltip"
-   data-bs-title="Benchmark results, grouped by unique (hardware, context) combinations. Time axis: benchmark result start time (associated commit data is not used), ordinate: mean value, if multisample. A plot is only shown for at least three data points. ">
-      </i></sup>
-    </h3>
-    <!--  Strategy: BS gutters, see https://getbootstrap.com/docs/5.2/layout/gutters/  -->
-    <div class="row gy-5">
-      {% for hwctx, plotinfo in infos_for_uplots.items() %}
-        <div class="col-6" style="width: 600px">
-          <div class="cb-tinyplot pt-4 shadow">
-            <div class="text-center">
-              {{ plotinfo.title }}, <a href="{{ plotinfo.url_to_newest_result }}">newest result</a>
-            </div>
-            <div class="cb-plot-{{ hwctx }}" style="width: 550px"></div>
-          </div>
-        </div>
-  {% for ctxid, context_dict in context_dicts_by_context_id.items() %}
+
   {% for ctxid, context_json in context_json_by_context_id.items() %}
   <div class="offcanvas offcanvas-start" data-bs-scroll="true" tabindex="-1" id="offcanvasContextDict-{{ctxid}}" aria-labelledby="offcanvasContextDictLabel-{{ctxid}}">
     <div class="offcanvas-header">

--- a/conbench/templates/c-benchmark-results-for-case.html
+++ b/conbench/templates/c-benchmark-results-for-case.html
@@ -69,10 +69,21 @@
             <div class="cb-plot-{{ hwctx }}" style="width: 550px"></div>
           </div>
         </div>
-      {% endfor %}
+  {% for ctxid, context_dict in context_dicts_by_context_id.items() %}
+  <div class="offcanvas offcanvas-start" data-bs-scroll="true" tabindex="-1" id="offcanvasContextDict-{{ctxid}}" aria-labelledby="offcanvasContextDictLabel-{{ctxid}}">
+    <div class="offcanvas-header">
+      <span class="offcanvas-title" id="offcanvasContextDictLabel-{{ctxid}}">Context <code>{{ctxid}}</code></span>
+      <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
     </div>
-    <div style="font-family: 'Roboto Mono';">.</div>
+    <div class="offcanvas-body">
+      <ul>
+      {% for key, value in context_dict.items() %}
+      <li><code>{{key}}</code>: <code>{{value}}</code></li>
+      {% endfor %}
+      </ul>
+    </div>
   </div>
+  {% endfor %}
 {% endblock %}
 {% block scripts %}
   {{ super() }}

--- a/conbench/templates/c-benchmark-results-for-case.html
+++ b/conbench/templates/c-benchmark-results-for-case.html
@@ -70,17 +70,16 @@
           </div>
         </div>
   {% for ctxid, context_dict in context_dicts_by_context_id.items() %}
+  {% for ctxid, context_json in context_json_by_context_id.items() %}
   <div class="offcanvas offcanvas-start" data-bs-scroll="true" tabindex="-1" id="offcanvasContextDict-{{ctxid}}" aria-labelledby="offcanvasContextDictLabel-{{ctxid}}">
     <div class="offcanvas-header">
-      <span class="offcanvas-title" id="offcanvasContextDictLabel-{{ctxid}}">Context <code>{{ctxid}}</code></span>
+      <span class="offcanvas-title" id="offcanvasContextDictLabel-{{ctxid}}">Context {{ctxid}}</span>
       <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
     </div>
-    <div class="offcanvas-body">
-      <ul>
-      {% for key, value in context_dict.items() %}
-      <li><code>{{key}}</code>: <code>{{value}}</code></li>
-      {% endfor %}
-      </ul>
+    <div class="offcanvas-body offcanvas-cb-context">
+      <code>
+        <pre style="">{{context_json}}</pre>
+      </code>
     </div>
   </div>
   {% endfor %}

--- a/conbench/templates/c-benchmark-results-for-case.html
+++ b/conbench/templates/c-benchmark-results-for-case.html
@@ -1,17 +1,27 @@
 {% extends "app.html" %}
 {% block app_content %}
   <h3>
-    <strong>{{ benchmark_name }}</strong> / case {{ this_case_id[:7] }}
+    benchmark <strong>'{{ benchmark_name }}'</strong> / case {{ this_case_id[:7] }}
   </h3>
   <span class="fs-4"><code>{{ this_case_text_id }}</code></span>
   <p>
-    Identified {{ matching_benchmark_result_count }} result(s) matching this case permutation.
-    Based on {{ bmr_cache_meta.n_results }} results reported in
+    Found {{ matching_benchmark_result_count }} benchmark result(s) matching this
+    case permutation. Based on {{ bmr_cache_meta.n_results }} results reported in
     total between {{ bmr_cache_meta.oldest_result_time_str }} and
     {{ bmr_cache_meta.newest_result_time_str }}.
   </p>
-  <p>Showing {{ benchmark_results_for_table|length }} of {{ matching_benchmark_result_count }} results:</p>
   <div class="mt-5">
+    <h5 class="mb-3">
+      History for unique hardware/context combinations
+      <sup><i style="font-size: 12px"
+   class="bi bi-info-circle"
+   data-bs-toggle="tooltip"
+   data-bs-title="Benchmark results, grouped by unique (hardware, context) combinations.
+   Ordinate: the benchmarked metric. Mean value, if multisample.
+   Time axis: benchmark result start time (associated commit data is not used).
+   A plot is only shown for at least three data points.">
+      </i></sup>
+    </h5>
     <!--  Strategy: BS gutters, see https://getbootstrap.com/docs/5.2/layout/gutters/  -->
     <div class="row gy-5">
       {% for hwctx, plotinfo in infos_for_uplots.items() %}
@@ -36,6 +46,9 @@
     </div>
     <div style="font-family: 'Roboto Mono';">.</div>
   </div>
+
+  <div class="mt-5">
+    <p> All {{ benchmark_results_for_table|length }} individual benchmark results:</p>
     <table class="table table-hover conbench-datatable"
            style="width:100%;
                   display: none">
@@ -87,6 +100,9 @@
     </div>
   </div>
   {% endfor %}
+
+
+
 {% endblock %}
 {% block scripts %}
   {{ super() }}


### PR DESCRIPTION
Among others, this addresses https://github.com/conbench/conbench/issues/1242.

I worked on those what I call 'tinyplots'. Added cute icons for hardware/platform, and context. Made context clickable. Context JSON doc opens up in so-called 'offcanvas':

![Screenshot from 2023-05-12 12-59-11](https://github.com/conbench/conbench/assets/265630/b7c32636-09b3-4703-a0e2-0534546f87c9)

![Screenshot from 2023-05-12 12-59-24](https://github.com/conbench/conbench/assets/265630/99cbbe0d-638b-4d68-b97c-753f079530c9)

This also 
- incorporates @boshek's feedback on the time axis label. 
- tweaks a number of details. It's too much work to summarize here for now. I continue to iterate on it.
