### PR TITLE
c-bench UI: introduce/tweak results per case per recency metric (RPCR)

### DIFF
--- a/conbench/static/app.css
+++ b/conbench/static/app.css
@@ -57,7 +57,7 @@ div.case-param-panel {
   max-width: 200px;
   width: max-content;
   margin-right: 7px;
-  margin-right: 8px;
+  margin-top: 8px;
   border: 1px solid #e9ecef;
 }
 

--- a/conbench/templates/c-benchmark-cases.html
+++ b/conbench/templates/c-benchmark-cases.html
@@ -19,7 +19,7 @@
           <div class="case-param-title">
             <code>{{ case_param_key }} ({{ case_param_value_count_dict|length }})</code>
           </div>
-          <div class="case-param-values c-bench-scrollbar {% if case_param_value_count_dict|length  == 1 %} one-value {%endif%}">
+          <div class="case-param-values c-bench-scrollbar {% if case_param_value_count_dict|length  == 1 %}one-value{% endif %}">
             {% for v, vcount in case_param_value_count_dict.items() %}
               <span class="case-parm-value"
                     data-cvp-key="{{ case_param_key }}"

--- a/conbench/templates/c-benchmarks.html
+++ b/conbench/templates/c-benchmarks.html
@@ -44,16 +44,16 @@
         <div class="card-body overflow-auto c-bench-scrollbar"
              style="max-height: 450px">
           <h5 class="card-title">
-            by results per case
+            by results per case and recency
             <sup><i style="font-size: 12px"
    class="bi bi-info-circle"
    data-bs-toggle="tooltip"
-   data-bs-title="average result count per case permutation">
+   data-bs-title="results per case permutation, weighted by recency (see issue #1264)">
             </i></sup>
           </h5>
-          {% for benchmark_name, ratio in benchmark_names_by_results_per_case_sorted.items() %}
+          {% for benchmark_name, rpcr in benchmark_names_by_rpcr_sorted.items() %}
             <strong><a href="{{ url_for('app.show_benchmark_cases', bname=benchmark_name) }}">{{ benchmark_name }}</a></strong>
-            (~{{ ratio }})
+            (~{{ rpcr }})
             <br>
           {% endfor %}
         </div>


### PR DESCRIPTION
This is mainly for https://github.com/conbench/conbench/issues/1264.

Arbitrary choices within RPCR calc:
- unit "days" instead of "seconds" so that the metric is more like O(1000) than O(0.1) for common scenarios.
- fraction: 10 % -- played with this quickly with real-world data. The weight should be on the recent fraction of results. If this is for example exclusively the last result then the metric becomes unstable when the result is extremely new. If this is for e.g. the last 50 % of results then the metric is dominated again by too old results.

By writing about this in all detail I don't want to raise the impression that this is overly smart or important or super well thought through. It's meant to be a quick improvement. With #1264 and this description here I just wanted to document what would otherwise be exclusively doddle scribbling scratchy scrawly d00dle on my desk invisible to nobody (probably including myself in a few weeks from now -- where is this piece of paper? :scroll:)  :).
