### PR TITLE
c-bench UI: case permutation view: better contrasts, make better use of spacing

### DIFF
--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -1,4 +1,5 @@
 import collections
+import itertools
 import logging
 import math
 import time
@@ -135,33 +136,54 @@ def show_benchmark_cases(bname: str) -> str:
     if bname not in bmrt_cache["by_benchmark_name"]:
         return f"benchmark name not known: `{bname}`"
 
+    t0 = time.monotonic()
+
     matching_results = bmrt_cache["by_benchmark_name"][bname]
     results_by_case_id: Dict[str, List[BMRTBenchmarkResult]] = collections.defaultdict(
         list
     )
 
+    # First, group results by case.
     for r in matching_results:
         results_by_case_id[r.case_id].append(r)
 
-    # all_case_keys = set(
+    log.info("after first loop: %.5f s", time.monotonic() - t0)
+
+    # Go through all results for this benchmark and keep track of all case
+    # parameter keys seen. This is useful because it is allowed for a result to
+    # _not_ specify a case parameter key in its case dictionary, and that
+    # counts as a special case for a value: "not set".
+    # all_case_keys_seen = set(
     #     itertools.chain.from_iterable(r.case_dict.keys() for r in matching_results)
     # )
+
+    log.info("after second loop: %.5f s", time.monotonic() - t0)
 
     all_values_per_case_key: Dict[str, collections.Counter] = collections.defaultdict(
         collections.Counter
     )
+
     for r in matching_results:
-        # Maybe make this a counter.
+        # Detect when this result's case dict does not specify some keys, and
+        # represent those as special value. This allows for correct
+        # identification of "constant case parameters" across _all_ results
+        # (value count :1); in that case the parameter can be removed / ignored
+        # / treated specially in the UI> Today, there might be any kind of type
+        # here for key and value in the r.case_dict (coming straight from DB).
+        # Difficult. See https://github.com/conbench/conbench/pull/948 and
+        # https://github.com/conbench/conbench/issues/940. Change both to
+        # string here. For example, this might result in values to be `"None"`.
+        # keys_not_specified = all_case_keys_seen - set(r.case_dict.keys())
+        # for k in keys_not_specified:
+        #     # Forcing the type conversion from various types to string: this
+        #     # might be error-prone and a nest of bees, but we will have to see
+        #     all_values_per_case_key[str(k)].update(["_NOT_SET_IN_DICT"])
         for case_parm_key, case_parm_value in r.case_dict.items():
-            # Today, there might be any kind of type here for key and value in
-            # the DB. Difficult. See
-            # https://github.com/conbench/conbench/pull/948 and
-            # https://github.com/conbench/conbench/issues/940.
-            # Change both to string here. For example, this might result in
-            # values to be `"None"`.
             all_values_per_case_key[str(case_parm_key)].update([str(case_parm_value)])
 
-    log.info("all_values_per_case_key: %s", all_values_per_case_key)
+    # log.info("all_values_per_case_key: %s", all_values_per_case_key)
+
+    log.info("after third loop: %.5f s", time.monotonic() - t0)
 
     # Sort by parameter value count (uniquely different parameter values,
     # not by how often these individual values are used).
@@ -173,7 +195,9 @@ def show_benchmark_cases(bname: str) -> str:
         )
     )
 
-    log.info("all_values_per_case_key: %s", all_values_per_case_key)
+    # log.info("all_values_per_case_key: %s", all_values_per_case_key)
+
+    log.info("after sort 1: %.5f s", time.monotonic() - t0)
 
     # Each item's value is a set of observed values. Make it a list, sorted
     # alphabetically.
@@ -184,7 +208,9 @@ def show_benchmark_cases(bname: str) -> str:
         )
     # log.info("all case parameters seen: %s", all_values_per_case_key)
 
-    log.info("all_values_per_case_key_sorted: %s", all_values_per_case_key_sorted)
+    # log.info("all_values_per_case_key_sorted: %s", all_values_per_case_key_sorted)
+
+    log.info("after most common: %.5f s", time.monotonic() - t0)
 
     t0 = time.monotonic()
 
@@ -194,7 +220,9 @@ def show_benchmark_cases(bname: str) -> str:
         # smell I think. This might fetch run dynamically from the DB>
         hardware_count_per_case_id[case_id] = len(set([r.hardware_id for r in results]))
 
-    log.info("building hardware_count_per_case took %.3f s", time.monotonic() - t0)
+    log.info("after hw stuff: %.5f s", time.monotonic() - t0)
+
+    # log.info("building hardware_count_per_case took %.3f s", time.monotonic() - t0)
 
     last_result_per_case_id: Dict[str, BMRTBenchmarkResult] = {}
 
@@ -202,6 +230,8 @@ def show_benchmark_cases(bname: str) -> str:
     for case_id, results in results_by_case_id.items():
         context_count_per_case_id[case_id] = len(set([r.context_id for r in results]))
         last_result_per_case_id[case_id] = newest_of_many_results(results)
+
+    log.info("after case stuff: %.5f s", time.monotonic() - t0)
 
     return flask.render_template(
         "c-benchmark-cases.html",

--- a/conbench/static/app.css
+++ b/conbench/static/app.css
@@ -14,51 +14,67 @@ html {
 
 .c-bench-scrollbar {
   /* Foreground, Background */
-  scrollbar-color: #812570 #f3f3f3;
+  scrollbar-color: #201D38aa #f3f3f3;
   scrollbar-width: thin;
 }
 .c-bench-scrollbar::-webkit-scrollbar {
-  width: 5px; /* Mostly for vertical scrollbars */
+  width: 4px; /* Mostly for vertical scrollbars */
   height: 7px; /* Mostly for horizontal scrollbars */
 }
 .c-bench-scrollbar::-webkit-scrollbar-thumb { /* Foreground */
-  background: #81257088;
-  border-radius: 2px;
+  background: #201D38aa;
+  border-radius: 1px;
 }
 .c-bench-scrollbar::-webkit-scrollbar-track { /* Background */
   background: #f3f3f3;
-  border-radius: 3px;
+  border-radius: 1px;
+}
+
+div.case-param-title code {
+  color: #fff;
 }
 
 div.case-param-title {
   /*border-bottom: 1px solid #81257022;*/
-  padding-bottom: 2px;
-  padding-left: 3px;
-  background-color: #e9ecef;
+  padding: 0 3px 2px 5px;
+  background-color: #812570BB;/* #47509E;*/
+  margin-bottom: 1px;
 }
 
 div.case-param-values {
-  height: 70px;
+  color: #000000bb;
+  max-height: 60px;
   overflow: auto;
   overflow-wrap: break-word;
+  line-height: 110%;
+  padding-left: 4px;
+  padding-right: 5px;
+  padding-bottom: 3px;
 }
 
+/*
 .case-param-values.one-value {
-  height: 35px !important;
-}
+  height: 25px !important;
+}*/
 
 div.case-param-panel {
-  /*width: 125px;*/
+  /* width: 125px; */
   /*
    explicit max-content instead of not setting width
    but with an upper bound. note that  this here now looks a bit like
    masonry.
+
+   Note that the max-width here is a really interesting parameter that can be
+   varied with the goal to maximize vertical space usage, try it out using
+   the browser devtools (mouse over this value, use mouse wheel to vary it --
+   with the flexbox grid setup everything else dynamically adjusts in a really
+   interesting way!
   */
-  max-width: 200px;
+  max-width: 185px;
   width: max-content;
-  margin-right: 7px;
-  margin-top: 8px;
-  border: 1px solid #e9ecef;
+  margin-right: 6px;
+  margin-top: 6px;
+  border: 1px solid #4981C8aa;
 }
 
 table.c-bench-caseperm-table tbody tr td {
@@ -67,7 +83,7 @@ table.c-bench-caseperm-table tbody tr td {
 }
 
 table.c-bench-caseperm-table td.casepermstring {
-  font-size: 11px;
+  font-size: 12px;
 }
 
 table.c-bench-caseperm-table th {
@@ -76,14 +92,18 @@ table.c-bench-caseperm-table th {
 
 span.case-parm-value {
   font-family: monospace;
-  font-size: 11px;
-  padding: 1px;
-  margin: 2px
+  font-size: 12px;
+  padding: 0px;
+  padding-left: 2px;
+  margin-left: 0px;
+  margin-top: 2px;
+  width:100%;
+  display: block;
 }
 
 span.case-parm-value.selected {
   font-family: monospace;
-  background-color: #38BDD166;
+  background-color: #7bffff;
 }
 
 div.offcanvas-cb-context pre {

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -121,7 +121,7 @@
                 {% endif %}
               {% endwith %}
               {# application content needs to be provided in the app_content block #}
-              <div style="margin-top: 15px"></div>
+              <div style="margin-top: 5px"></div>
               {% block app_content %}{% endblock %}
               <br>
               <hr>

--- a/conbench/templates/c-benchmark-cases.html
+++ b/conbench/templates/c-benchmark-cases.html
@@ -23,8 +23,7 @@
             {% for v, vcount in case_param_value_count_dict.items() %}
               <span class="case-parm-value"
                     data-cvp-key="{{ case_param_key }}"
-                    data-cvp-value="{{v}}">{{ v }} ({{ vcount }})
-              </span>
+                    data-cvp-value="{{v}}">{{ v }} ({{ vcount }})</span>
             {% endfor %}
           </div>
         </div>
@@ -33,9 +32,7 @@
   </div>
 </div>
 <div class="mt-2">
-  <p>
-    Filter the permutations shown in the table below selecting case parameter key/value pairs in the panels above.
-  </p>
+  <p>Filter the permutations shown in the table below selecting case parameter key/value pairs in the panels above.</p>
 </div>
 <div class="mt-3">
   <table class="table table-hover conbench-datatable c-bench-caseperm-table"
@@ -67,17 +64,15 @@
     </tbody>
   </table>
 </div>
-
 <p>
-Found <strong>{{ results_by_case_id|length }}</strong> unique case permutation(s)
-across <strong>{{ benchmark_result_count }}</strong> result(s). The table below
-shows one row per case permutation.
+  Found <strong>{{ results_by_case_id|length }}</strong> unique case permutation(s)
+  across <strong>{{ benchmark_result_count }}</strong> result(s). The table below
+  shows one row per case permutation.
 </p>
-
 <p>
-Report based on {{ bmr_cache_meta.n_results }} results reported in
-total between {{ bmr_cache_meta.oldest_result_time_str }} and
-{{ bmr_cache_meta.newest_result_time_str }}.
+  Report based on {{ bmr_cache_meta.n_results }} results reported in
+  total between {{ bmr_cache_meta.oldest_result_time_str }} and
+  {{ bmr_cache_meta.newest_result_time_str }}.
 </p>
 {% endblock %}
 {% block scripts %}

--- a/conbench/templates/c-benchmark-cases.html
+++ b/conbench/templates/c-benchmark-cases.html
@@ -19,12 +19,12 @@
           <div class="case-param-title">
             <code>{{ case_param_key }} ({{ case_param_value_count_dict|length }})</code>
           </div>
-          <div class="case-param-values c-bench-scrollbar {% if case_param_value_count_dict|length  == 1 %}one-value{% endif %}">
+          <div class="case-param-values c-bench-scrollbar">
             {% for v, vcount in case_param_value_count_dict.items() %}
               <span class="case-parm-value"
                     data-cvp-key="{{ case_param_key }}"
-                    data-cvp-value="{{v}}">{{ v }} ({{ vcount }})</span>
-              <br>
+                    data-cvp-value="{{v}}">{{ v }} ({{ vcount }})
+              </span>
             {% endfor %}
           </div>
         </div>
@@ -32,15 +32,12 @@
     </div>
   </div>
 </div>
-<div class="mt-5">
+<div class="mt-2">
   <p>
-    Found <strong>{{ results_by_case_id|length }}</strong> unique case permutation(s)
-    across <strong>{{ benchmark_result_count }}</strong> result(s). The table below
-    shows one row per case permutation. You can limit the permutations shown by
-    selecting case parameter key/value pairs in the panels above.
+    Filter the permutations shown in the table below selecting case parameter key/value pairs in the panels above.
   </p>
 </div>
-<div class="mt-4">
+<div class="mt-3">
   <table class="table table-hover conbench-datatable c-bench-caseperm-table"
          style="width:100%;
                 display: none">
@@ -70,9 +67,18 @@
     </tbody>
   </table>
 </div>
+
+<p>
+Found <strong>{{ results_by_case_id|length }}</strong> unique case permutation(s)
+across <strong>{{ benchmark_result_count }}</strong> result(s). The table below
+shows one row per case permutation.
+</p>
+
+<p>
 Report based on {{ bmr_cache_meta.n_results }} results reported in
 total between {{ bmr_cache_meta.oldest_result_time_str }} and
-{{ bmr_cache_meta.newest_result_time_str }}
+{{ bmr_cache_meta.newest_result_time_str }}.
+</p>
 {% endblock %}
 {% block scripts %}
   {{ super() }}


### PR DESCRIPTION
Major goals:
- make better use of macro spacing, overall optimization target is to use vertical space more efficiently
- make better use of micro spacing: tiny padding/margin optimizations for much better readability/tidiness
- make better use of font spacing and color contrast to show _dense_ information (always a little ugly) with an OKish appearance.

No screenshots here, sadly, because I tested against a prod DB snapshot and don't want to show DB contents here.