### PR TITLE
benchalerts: don't use compare link if contender has error

### DIFF
--- a/benchalerts/benchalerts/conbench_dataclasses.py
+++ b/benchalerts/benchalerts/conbench_dataclasses.py
@@ -68,6 +68,7 @@ class RunComparisonInfo:
                         ],
                         baseline_result_id=comparison["baseline"]["benchmark_result_id"]
                         if comparison["baseline"]
+                        and not comparison["contender"]["error"]
                         else None,
                     ),
                     has_error=bool(comparison["contender"]["error"]),

--- a/benchalerts/tests/unit_tests/expected_md/comment_errors_baselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_errors_baselines.md
@@ -3,8 +3,8 @@ Conbench analyzed the 3 benchmark runs on commit `abc`.
 There were 3 benchmark results with an error:
 
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
-  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-2...some-benchmark-uuid-4)
-  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-2...some-benchmark-uuid-4)
+  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmark-results/some-benchmark-uuid-4)
+  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmark-results/some-benchmark-uuid-4)
 - and 1 more (see the report linked below)
 
 There were 3 benchmark results indicating a performance regression:

--- a/benchalerts/tests/unit_tests/expected_md/summary_errors_baselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_errors_baselines.md
@@ -5,9 +5,9 @@ Conbench analyzed the 3 benchmark runs on commit `abc`.
 These are errors that were caught while running the benchmarks. You can click each link to go to the Conbench entry for that benchmark, which might have more information about what the error was.
 
 - Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
-  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-2...some-benchmark-uuid-4)
-  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-2...some-benchmark-uuid-4)
-  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-2...some-benchmark-uuid-4)
+  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmark-results/some-benchmark-uuid-4)
+  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmark-results/some-benchmark-uuid-4)
+  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmark-results/some-benchmark-uuid-4)
 
 ## Benchmarks with performance regressions
 


### PR DESCRIPTION
A small request from @jonkeane: when linking to contender results with errors, don't link to the compare page, even if they have baselines; instead link to the result page.