### PR TITLE
API/UI: remove misleading version number; require buildinfo (always show commit hash)

### DIFF
--- a/conbench/api/index.py
+++ b/conbench/api/index.py
@@ -6,7 +6,6 @@ import flask_login
 import marshmallow
 from sqlalchemy.sql import text
 
-from .. import __version__
 from ..api import api, rule
 from ..api._docs import api_server_url, spec
 from ..api._endpoint import ApiEndpoint
@@ -181,8 +180,8 @@ class PingAPI(ApiEndpoint):
                 alembic_version = "err"
 
         return {
+            # This is largely a legacy structure.
             "date": now.strftime("%a, %d %b %Y %H:%M:%S %Z"),
-            "conbench_version": __version__,
             "alembic_version": alembic_version,
             "commit": BUILD_INFO.commit,
         }

--- a/conbench/app/_endpoint.py
+++ b/conbench/app/_endpoint.py
@@ -8,20 +8,12 @@ import flask.views
 import flask_login
 import werkzeug
 
-from .. import __version__
 from ..buildinfo import BUILD_INFO
 
 log = logging.getLogger(__name__)
 
 
-# Default to importlib_metadata version string.
-VERSION_STRING_FOOTER = __version__
-
-
-# Enrich with short commit hash, if available.
-# Also see https://github.com/conbench/conbench/issues/461
-if BUILD_INFO is not None:
-    VERSION_STRING_FOOTER = f"{__version__}-{BUILD_INFO.commit[:9]}"
+VERSION_STRING_FOOTER = f"{BUILD_INFO.commit[:9]}"
 
 
 def authorize_or_terminate(func):

--- a/conbench/buildinfo.py
+++ b/conbench/buildinfo.py
@@ -1,7 +1,6 @@
 import json
 import logging
 from dataclasses import dataclass
-from typing import Optional
 
 import dacite
 
@@ -23,9 +22,8 @@ class Buildinfo:
     version_string: str
 
 
-# TODO: require this, remove ambiguity (crash if file not there or in
-# unexpected shape)
-BUILD_INFO: Optional[Buildinfo] = None
+# Require this, remove ambiguity (crash if file not there or in unexpected shape)
+
 try:
     # Try to discover additional build information at well-known path. For now,
     # do not crash the application upon: file not found, file having unexpected
@@ -36,6 +34,6 @@ try:
 
     # `dacite.from_dict()` validates against dataclass types, rendering the
     # type info on the dataclass reliable.
-    BUILD_INFO = dacite.from_dict(data_class=Buildinfo, data=data)
+    BUILD_INFO: Buildinfo = dacite.from_dict(data_class=Buildinfo, data=data)
 except Exception as exc:
-    log.info("graceful degradation, could not read/parse buildinfo: %s", exc)
+    log.exception("graceful degradation, could not read/parse buildinfo: %s", exc)

--- a/conbench/tests/api/test_index.py
+++ b/conbench/tests/api/test_index.py
@@ -26,9 +26,8 @@ class TestAPI(_asserts.ApiEndpointTest):
         data = response.json
         assert response.status_code == 200
         assert response.content_type == "application/json"
-        assert set(data) == {"date", "conbench_version", "alembic_version", "commit"}
+        assert set(data) == {"date", "alembic_version", "commit"}
         assert str(datetime.datetime.today().year) in data["date"]
-        assert data["conbench_version"] == __version__
         # full git commit hashes can be expected to be 40 characters long.
         # if/when this ever changes then this test can change, too.
         assert len(data["commit"]) == 40


### PR DESCRIPTION
This is for #1271.