### PR TITLE
c-bench ui: fix literal "nan" in array (#1263)

### DIFF
--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -357,8 +357,14 @@ def show_benchmark_results(bname: str, caseid: str) -> str:
                 # between invocations. If they do, it's a qualitative problem
                 # and the _precise_ difference does not need to be readable
                 # from these plots. I think sending detail across seven orders
-                # of magnitude is fine.
-                [conbench.numstr.numstr(r.svs, 7) for r in results],
+                # of magnitude is fine. Careful: >>>
+                # np.format_float_positional(float("NaN")) would return 'nan'
+                # (string). But for orjson to emit a `null` ( which is what
+                # uplot wants we should have a `None` in the list).
+                [
+                    conbench.numstr.numstr(r.svs, 7) if not math.isnan(r.svs) else None
+                    for r in results
+                ],
             ],
             # Rely on at least one result being in the list.
             "hwid": hwid,


### PR DESCRIPTION
This fixes #1263. 

Ha! :) It was the new `numstr()`, and in there the `np.format_float_positional(float("NaN"))` that would return the literal string 'nan'.

Confirmed locally that we now have a `null` in the JSON array for uplot to not fail:
![image](https://github.com/conbench/conbench/assets/265630/31b11aea-9a44-4d61-ac60-33a61870b373)
