### PR TITLE
webapp runs page: add links to baselines

### DIFF
--- a/conbench/app/compare.py
+++ b/conbench/app/compare.py
@@ -75,7 +75,9 @@ class Compare(AppEndpoint, BenchmarkResultMixin, RunMixin, TimeSeriesPlotMixin):
 
         if comparisons and self.type != "benchmark-result":
             comparisons_by_id = {
-                c["contender"]["benchmark_result_id"]: c for c in comparisons
+                c["contender"]["benchmark_result_id"]: c
+                for c in comparisons
+                if c["contender"]
             }
             if self.type == "run":
                 benchmarks, response = self._get_benchmarks(run_id=contender_id)
@@ -272,8 +274,11 @@ class Compare(AppEndpoint, BenchmarkResultMixin, RunMixin, TimeSeriesPlotMixin):
         # Mutate comparison objs (dictionaries) on the fly
         for c in comparisons:
             view = "app.compare-benchmark-results"
-            compare = f'{c["baseline"]["benchmark_result_id"]}...{c["contender"]["benchmark_result_id"]}'
-            c["compare_benchmarks_url"] = f.url_for(view, compare_ids=compare)
+            if c["baseline"] and c["contender"]:
+                compare = f'{c["baseline"]["benchmark_result_id"]}...{c["contender"]["benchmark_result_id"]}'
+                c["compare_benchmarks_url"] = f.url_for(view, compare_ids=compare)
+            else:
+                c["compare_benchmarks_url"] = None
 
             if (
                 c["analysis"]["lookback_z_score"]

--- a/conbench/app/results.py
+++ b/conbench/app/results.py
@@ -134,16 +134,6 @@ class RunMixin:
         self._augment(run)
         return run
 
-    def get_display_baseline_run(self, run_url):
-        run, response = self._get_run_by_url(run_url)
-        if response.status_code != 200:
-            # "RunMixin" has no attribute "flash"
-            self.flash("Error getting run.")  # type: ignore
-            return None
-
-        self._augment(run)
-        return run
-
     def get_display_runs(self):
         runs, response = self._get_runs()
         if response.status_code != 200:
@@ -210,10 +200,6 @@ class RunMixin:
 
     def _get_run(self, run_id):
         response = self.api_get("api.run", run_id=run_id)
-        return response.json, response
-
-    def _get_run_by_url(self, run_url):
-        response = self.api_get_url(run_url)
         return response.json, response
 
     def _get_runs(self):

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -7,9 +7,22 @@
       {% if run_id %}<li class="breadcrumb-item active" aria-current="page">{{ run_id }}</li>{% endif %}
     </ol>
   </nav>
-  {% if compare_runs_url %}
+  {% if compare_to_baseline_urls['parent'] %}
     <p class="fs-5">
-      <i class="bi bi-file-diff"></i> <a href="{{ compare_runs_url }}">compare to baseline</a>
+      <i class="bi bi-file-diff"></i> <a href="{{ compare_to_baseline_urls['parent'] }}">compare to baseline run from
+      parent commit</a>
+    </p>
+  {% endif %}
+  {% if compare_to_baseline_urls['fork_point'] %}
+    <p class="fs-5">
+      <i class="bi bi-file-diff"></i> <a href="{{ compare_to_baseline_urls['fork_point'] }}">compare to baseline run from
+      fork point commit</a>
+    </p>
+  {% endif %}
+  {% if compare_to_baseline_urls['latest_default'] %}
+    <p class="fs-5">
+      <i class="bi bi-file-diff"></i> <a href="{{ compare_to_baseline_urls['latest_default'] }}">compare to latest
+      baseline run on default branch</a>
     </p>
   {% endif %}
   {% if plot_history %}
@@ -73,7 +86,8 @@
               <a href="{{ url_for('app.batch', batch_id=benchmark.batch_id) }}">{{ benchmark.display_bmname }}</a>
             </td>
             <td>
-              <a href="{{ url_for('app.benchmark-result', benchmark_result_id=benchmark.id) }}">{{ benchmark.display_case_perm }}</a>
+              <a href="{{ url_for('app.benchmark-result', benchmark_result_id=benchmark.id) }}">{{
+              benchmark.display_case_perm }}</a>
             </td>
             <td style="white-space: nowrap;">{{ benchmark.display_mean }}</td>
             {% if benchmark.stats.z_score is not none %}
@@ -88,7 +102,7 @@
               <td></td>
             {% endif %}
             <td>
-              {%  if benchmark.error %}
+              {% if benchmark.error %}
                 <a href="{{ url_for('app.benchmark-result', benchmark_result_id=benchmark.id) }}">
                   <i class="glyphicon glyphicon-exclamation-sign text-danger"
                      data-toggle="tooltip"
@@ -139,7 +153,10 @@
             {% for k,v in run.error_info.items() %}
               <li class="list-group-item" style="overflow-y: auto;">
                 <b>{{ k }}</b>
-                {% if v is not none %}<div align="right" style="display:inline-block; float: right;">{{ v }}</div>{% endif %}
+                {% if v is not none %}
+                  <div align="right" style="display:inline-block; float: right;">{{ v }}</div>
+                {% endif
+                %}
               </li>
             {% endfor %}
           {% endif %}
@@ -148,7 +165,10 @@
             {% for k,v in run.info.items() %}
               <li class="list-group-item" style="overflow-y: auto;">
                 <b>{{ k }}</b>
-                {% if v is not none %}<div align="right" style="display:inline-block; float: right;">{{ v }}</div>{% endif %}
+                {% if v is not none %}
+                  <div align="right" style="display:inline-block; float: right;">{{ v }}</div>
+                {% endif
+                %}
               </li>
             {% endfor %}
           {% endif %}
@@ -160,36 +180,36 @@
     {{ super() }}
     {{ resources | safe }}
     <script type="text/javascript">
-    var table = $('#benchmarks').dataTable( {
-      "responsive": true,
-    // Take rather precise control of layouting elements, put bottom elements
-    // into a mult-col single row, using BS's grid system.
-      "dom": 'lfrt<"row"<"col-6"i><".col-6"p>>',
-      "order": [[5, 'asc']],
-      "columnDefs": [{ "orderable": false, "targets": [4] }],
-      initComplete: function () {
-        var api = this.api();
-      //api.columns.adjust();
-        $('.pagination').addClass('pagination-sm'); // add BS class for smaller pagination bar
-      },
-    } );
+    var table = $('#benchmarks').dataTable({
+        "responsive": true,
+        // Take rather precise control of layouting elements, put bottom elements
+        // into a mult-col single row, using BS's grid system.
+        "dom": 'lfrt<"row"<"col-6"i><".col-6"p>>',
+        "order": [[5, 'asc']],
+        "columnDefs": [{ "orderable": false, "targets": [4] }],
+        initComplete: function () {
+            var api = this.api();
+            //api.columns.adjust();
+            $('.pagination').addClass('pagination-sm'); // add BS class for smaller pagination bar
+        },
+    });
 
     column_search_implementation($('#benchmarks'));
 
-    $(document).ready(function() {
-      {% if run_id %}
+    $(document).ready(function () {
+        {% if run_id %}
         $("#run-form").find("#delete").attr("type", "button");
         $("#run-form").find("#delete").attr("data-bs-toggle", "modal");
         $("#run-form").find("#delete").attr("data-bs-target", "#confirm-delete");
         $("#run-form").find("#delete").attr("data-cbcustom-form-id", "#run-form");
         $("#run-form").find("#delete").attr("data-cbcustom-href", "{{ url_for('app.run', run_id=run_id) }}");
         $("#run-form").find("#delete").attr("data-cbcustom-message", "<ul><li>Delete run: <strong>{{ run_id }}</strong></li></ul>");
-      {% endif %}
+        {% endif %}
     });
 
-    $(document).ready(function() {
-      {% for plot in plot_history %}Bokeh.embed.embed_item({{ plot | safe }});{% endfor %}
-      document.getElementById("bokeh-carousel").style.visibility = "visible";
+    $(document).ready(function () {
+        {% for plot in plot_history %}Bokeh.embed.embed_item({{ plot | safe }});{% endfor %}
+    document.getElementById("bokeh-carousel").style.visibility = "visible";
     });
     </script>
   {% endblock %}

--- a/conbench/tests/app/test_compare.py
+++ b/conbench/tests/app/test_compare.py
@@ -1,11 +1,7 @@
-import logging
-
 import copy
+
 from ...tests.api import _fixtures
 from ...tests.app import _asserts
-
-
-log = logging.getLogger(__name__)
 
 
 def _emsg_needle(thing, thingid):
@@ -118,8 +114,6 @@ class TestCompareRuns(_asserts.GetEnforcer):
         self._post_result(client, "run2", "python")
         self._post_result(client, "run2", "C++")
 
-        # Ensure the run page looks as expected
+        # Ensure the run page returns a 200 and HTML, not a traceback
         response = client.get("/compare/runs/run1...run2/")
         self.assert_page(response, "Compare Runs")
-        log.info(response.text)
-        assert not response.text

--- a/conbench/tests/app/test_compare.py
+++ b/conbench/tests/app/test_compare.py
@@ -1,5 +1,11 @@
+import logging
+
+import copy
 from ...tests.api import _fixtures
 from ...tests.app import _asserts
+
+
+log = logging.getLogger(__name__)
 
 
 def _emsg_needle(thing, thingid):
@@ -94,3 +100,26 @@ class TestCompareRuns(_asserts.GetEnforcer):
         response = client.get("/compare/runs/foo...bar/", follow_redirects=True)
         self.assert_page(response, "Compare Runs")
         assert _emsg_needle("run", "foo") in response.text
+
+    @staticmethod
+    def _post_result(client, run_id, language) -> None:
+        payload = copy.deepcopy(_fixtures.VALID_RESULT_PAYLOAD)
+        payload["run_id"] = run_id
+        payload["context"]["benchmark_language"] = language
+        response = client.post("/api/benchmarks/", json=payload)
+        assert response.status_code == 201, response.text
+
+    def test_mismatching_runs(self, client):
+        self.authenticate(client)
+
+        # Some benchmark results are comparable, some aren't
+        self._post_result(client, "run1", "python")
+        self._post_result(client, "run1", "R")
+        self._post_result(client, "run2", "python")
+        self._post_result(client, "run2", "C++")
+
+        # Ensure the run page looks as expected
+        response = client.get("/compare/runs/run1...run2/")
+        self.assert_page(response, "Compare Runs")
+        log.info(response.text)
+        assert not response.text

--- a/conbench/tests/app/test_runs.py
+++ b/conbench/tests/app/test_runs.py
@@ -1,5 +1,6 @@
 import copy
 import re
+from typing import Optional
 
 from ...tests.api import _fixtures
 from ...tests.app import _asserts
@@ -13,6 +14,33 @@ class TestRunGet(_asserts.GetEnforcer):
     def _create(self, client):
         self.create_benchmark(client)
         return _fixtures.VALID_RESULT_PAYLOAD["run_id"]
+
+    @staticmethod
+    def _assert_baseline_link(
+        response_text: str,
+        candidate_baseline_type: str,
+        baseline_id: Optional[str],
+        contender_id: Optional[str],
+    ) -> None:
+        """Assert that a link to compare runs exists in the HTML, or doesn't exist if
+        the run IDs aren't provided.
+        """
+        response_text = " ".join(response_text.split())
+
+        if candidate_baseline_type == "parent":
+            text = "compare to baseline run from parent commit"
+        elif candidate_baseline_type == "fork_point":
+            text = "compare to baseline run from fork point commit"
+        elif candidate_baseline_type == "latest_default":
+            text = "compare to latest baseline run on default branch"
+
+        if baseline_id and contender_id:
+            assert (
+                f'/compare/runs/{baseline_id}...{contender_id}/">{text}'
+                in response_text
+            )
+        else:
+            assert text not in response_text
 
     def test_get_run_without_commit(self, client):
         self.authenticate(client)
@@ -30,6 +58,57 @@ class TestRunGet(_asserts.GetEnforcer):
 
         # Ensure the run page looks as expected
         self._assert_view(client, payload["run_id"])
+
+        # Ensure there are no baseline run links
+        self._assert_baseline_link(response.text, "parent", None, None)
+        self._assert_baseline_link(response.text, "fork_point", None, None)
+        self._assert_baseline_link(response.text, "latest_default", None, None)
+
+    def test_baseline_run_links(self, client):
+        _, benchmark_results = _fixtures.gen_fake_data()
+        self.authenticate(client)
+
+        # Ensure all the pages return 200 and at least contain an expected title in the HTML
+        for benchmark_result in benchmark_results:
+            self._assert_view(client, benchmark_result.run_id)
+
+        # 0 (first in history) should not have any links
+        response = client.get(self.url.format(benchmark_results[0].run_id))
+        self._assert_baseline_link(response.text, "parent", None, None)
+        self._assert_baseline_link(response.text, "fork_point", None, None)
+        self._assert_baseline_link(response.text, "latest_default", None, None)
+
+        # 1 (also on default branch) should only link to 0
+        response = client.get(self.url.format(benchmark_results[1].run_id))
+        self._assert_baseline_link(
+            response.text,
+            "parent",
+            benchmark_results[0].run_id,
+            benchmark_results[1].run_id,
+        )
+        self._assert_baseline_link(response.text, "fork_point", None, None)
+        self._assert_baseline_link(response.text, "latest_default", None, None)
+
+        # 3 is a PR run forked from 1
+        response = client.get(self.url.format(benchmark_results[3].run_id))
+        self._assert_baseline_link(
+            response.text,
+            "parent",
+            benchmark_results[2].run_id,
+            benchmark_results[3].run_id,
+        )
+        self._assert_baseline_link(
+            response.text,
+            "fork_point",
+            benchmark_results[1].run_id,
+            benchmark_results[3].run_id,
+        )
+        self._assert_baseline_link(
+            response.text,
+            "latest_default",
+            benchmark_results[15].run_id,  # the latest default branch run
+            benchmark_results[3].run_id,
+        )
 
 
 class TestRunDelete(_asserts.DeleteEnforcer):

--- a/conbench/tests/populate_local_conbench.py
+++ b/conbench/tests/populate_local_conbench.py
@@ -678,5 +678,10 @@ CONBENCH_COMMIT_HASH_LINES_50 = """
     4e7441d72f1d14cf9a40525eca8993f7713937a7
     """
 
+# Add a PR commit to the Conbench commits.
+CONBENCH_COMMIT_HASH_LINES_50 = (
+    "9da0b7a68ea3003eb5431f1a5708222f1c15efa6" + CONBENCH_COMMIT_HASH_LINES_50
+)
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Fixes #1175.

This PR adds back the capability to compare contender Runs to their candidate baseline runs by clicking a link at the top of the Run page. Now there are a few options, thanks to the new API structure.

Examples:

Run on the default branch:
<img width="1330" alt="image" src="https://github.com/conbench/conbench/assets/16600275/955bc92f-1968-46f8-ba88-9343f1e1a863">

Run on a PR branch:
<img width="1346" alt="image" src="https://github.com/conbench/conbench/assets/16600275/3174cd20-8f49-4d20-87e4-f7eff6115acc">
