### PR TITLE
api/runs, app/runs: enable latest_default baselines for default branch commits, recommend one in app

### DIFF
--- a/benchalerts/tests/integration_tests/test_alert_pipeline.py
+++ b/benchalerts/tests/integration_tests/test_alert_pipeline.py
@@ -30,12 +30,11 @@ def test_alert_pipeline(monkeypatch: pytest.MonkeyPatch, github_auth: str):
     if github_auth == "pat" and os.getenv("CI"):
         pytest.skip("The CI PAT does not work with this test")
 
-    # note: something *might* go wrong if we go past 1000 statuses on this test commit?
+    # note: something goes wrong if we go past 1000 statuses on this test commit
     # https://docs.github.com/en/rest/commits/statuses#create-a-commit-status
-    test_status_repo = "conbench/benchalerts"
-    # Note: this will start failing after N test executions, see
     # https://github.com/conbench/conbench/issues/945
-    test_status_commit = "9cff2efafa1a44c924310569f576de97e8dc9b57"
+    test_status_repo = "conbench/benchalerts"
+    test_status_commit = "f6e70aeb29ce07c40eed0c0175e9dced488ed6ee"
 
     monkeypatch.setenv("CONBENCH_URL", "https://velox-conbench.voltrondata.run/")
     velox_commit = "c76715c9db1eea7cf3f32dca6fe78fc35c4f3ecd"

--- a/conbench/app/runs.py
+++ b/conbench/app/runs.py
@@ -1,4 +1,5 @@
-from typing import Dict, Optional
+import dataclasses
+from typing import Dict
 
 import bokeh
 import flask as f
@@ -14,6 +15,30 @@ from ..app.results import ContextMixin, RunMixin
 from ..config import Config
 
 
+@dataclasses.dataclass
+class _RunComparisonLinker:
+    # URL comparing the contender run to the baseline run.
+    url: str
+    # Display text to hyperlink the URL.
+    text: str
+    # Whether this is the "recommended" baseline run.
+    recommended: bool
+
+    @property
+    def full_text(self) -> str:
+        if self.recommended:
+            return f"{self.text} (recommended)"
+        else:
+            return self.text
+
+
+_default_hyperlink_text = {
+    "parent": "compare to baseline run from parent commit",
+    "fork_point": "compare to baseline run from fork point commit",
+    "latest_default": "compare to latest comparable baseline run on default branch",
+}
+
+
 # This class had the same name as `entities.Run`. Mypy got confused:
 #   conbench/app/__init__.py:16: error: Incompatible import of "Run"
 #   (imported name has type "Type[conbench.app.runs.Run]", local name has
@@ -23,19 +48,42 @@ class ViewRun(AppEndpoint, ContextMixin, RunMixin, TimeSeriesPlotMixin):
         if not flask_login.current_user.is_authenticated:
             delattr(form, "delete")
 
-        compare_to_baseline_urls: Dict[str, Optional[str]] = {}
-        for key in ["parent", "fork_point", "latest_default"]:
-            if contender_run and (
-                baseline_id := contender_run["candidate_baseline_runs"][key][
+        # For each candidate baseline type, if a baseline run exists for this contender
+        # run, store information to fill in the HTML hyperlink for that comparison.
+        comparison_info: Dict[str, _RunComparisonLinker] = {}
+        if contender_run:
+            for key in ["parent", "fork_point", "latest_default"]:
+                baseline_id = contender_run["candidate_baseline_runs"][key][
                     "baseline_run_id"
                 ]
+                if baseline_id:
+                    comparison_info[key] = _RunComparisonLinker(
+                        url=f.url_for(
+                            "app.compare-runs",
+                            compare_ids=f"{baseline_id}...{contender_run['id']}",
+                        ),
+                        text=_default_hyperlink_text[key],
+                        recommended=False,
+                    )
+
+        if len(comparison_info) > 1:
+            # Figure out which baseline is "recommended".
+            # (The run will definitely have a commit in this case.)
+            if (
+                contender_run["commit"]["sha"]
+                == contender_run["commit"]["fork_point_sha"]
             ):
-                compare_to_baseline_urls[key] = f.url_for(
-                    "app.compare-runs",
-                    compare_ids=f"{baseline_id}...{contender_run['id']}",
-                )
+                # On the default branch, so the parent run is recommended.
+                comparison_info["parent"].recommended = True
+            elif "fork_point" in comparison_info:
+                # On a non-default branch, so the fork point run is recommended.
+                comparison_info["fork_point"].recommended = True
             else:
-                compare_to_baseline_urls[key] = None
+                # On a non-default branch with an error finding the fork point baseline
+                # run, so the latest default run is recommended. I can't think of any
+                # feasible scenario where this might happen but it's important not to
+                # error out just trying to display a word.
+                comparison_info["latest_default"].recommended = True
 
         (
             biggest_changes,
@@ -52,7 +100,9 @@ class ViewRun(AppEndpoint, ContextMixin, RunMixin, TimeSeriesPlotMixin):
             application=Config.APPLICATION_NAME,
             title="Run",
             benchmarks=benchmarks,
-            compare_to_baseline_urls=compare_to_baseline_urls,
+            comparisons=sorted(
+                comparison_info.values(), key=lambda x: x.recommended, reverse=True
+            ),
             run_id=run_id,
             run=contender_run,
             form=form,

--- a/conbench/app/runs.py
+++ b/conbench/app/runs.py
@@ -25,11 +25,11 @@ class _RunComparisonLinker:
     recommended: bool
 
     @property
-    def full_text(self) -> str:
+    def badge(self) -> str:
         if self.recommended:
-            return f"{self.text} (recommended)"
+            return '<span class="badge bg-primary">Recommended</span>'
         else:
-            return self.text
+            return ""
 
 
 _default_hyperlink_text = {

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -264,23 +264,17 @@ class Run(Base, EntityMixin):
             )
 
         # The latest commit on the default branch that Conbench knows about
-        if self.commit and self.commit.sha == self.commit.fork_point_sha:
-            candidates["latest_default"] = _CandidateBaselineSearchResult(
-                error="the contender run is already on the default branch"
-            )
-        else:
-            # Query the DB for the latest commit
-            query = s.select(Commit).filter(Commit.sha == Commit.fork_point_sha)
+        query = s.select(Commit).filter(Commit.sha == Commit.fork_point_sha)
 
-            # TODO: how do we filter by repository if there's no commit?
-            # (For now we just choose the latest commit of any repository.)
-            if self.commit:
-                query = query.filter(Commit.repository == self.commit.repository)
+        # TODO: how do we filter by repository if there's no commit?
+        # (For now we just choose the latest commit of any repository.)
+        if self.commit:
+            query = query.filter(Commit.repository == self.commit.repository)
 
-            latest_commit = Session.scalars(
-                query.order_by(s.desc(Commit.timestamp)).limit(1)
-            ).first()
-            candidates["latest_default"] = self._search_for_baseline_run(latest_commit)
+        latest_commit = Session.scalars(
+            query.order_by(s.desc(Commit.timestamp)).limit(1)
+        ).first()
+        candidates["latest_default"] = self._search_for_baseline_run(latest_commit)
 
         return {
             candidate_type: candidate._dict_for_api_json()

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -188,7 +188,7 @@ class Run(Base, EntityMixin):
             .join(Hardware, Hardware.id == Run.hardware_id)
             .join(Commit, Commit.id == Run.commit_id)
             .join(ancestor_commits, ancestor_commits.c.ancestor_id == Commit.id)
-            .filter(Hardware.hash == self.hardware.hash)
+            .filter(Hardware.hash == self.hardware.hash, Run.id != self.id)
             .order_by(
                 s.desc(Run.reason == self.reason),  # Prefer this Run's run_reason,
                 ancestor_commits.c.commit_order.desc(),  # then latest commit,

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -9,7 +9,7 @@
   </nav>
   {% for link in comparisons %}
     <p class="fs-6">
-      <i class="bi bi-file-diff"></i> <a href="{{ link.url }}">{{ link.full_text }}</a>
+      <i class="bi bi-file-diff"></i> <a href="{{ link.url }}">{{ link.text }}</a> {{ link.badge | safe }}
     </p>
   {% endfor %}
   {% if plot_history %}

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -7,24 +7,11 @@
       {% if run_id %}<li class="breadcrumb-item active" aria-current="page">{{ run_id }}</li>{% endif %}
     </ol>
   </nav>
-  {% if compare_to_baseline_urls['parent'] %}
-    <p class="fs-5">
-      <i class="bi bi-file-diff"></i> <a href="{{ compare_to_baseline_urls['parent'] }}">compare to baseline run from
-      parent commit</a>
+  {% for link in comparisons %}
+    <p class="fs-6">
+      <i class="bi bi-file-diff"></i> <a href="{{ link.url }}">{{ link.full_text }}</a>
     </p>
-  {% endif %}
-  {% if compare_to_baseline_urls['fork_point'] %}
-    <p class="fs-5">
-      <i class="bi bi-file-diff"></i> <a href="{{ compare_to_baseline_urls['fork_point'] }}">compare to baseline run from
-      fork point commit</a>
-    </p>
-  {% endif %}
-  {% if compare_to_baseline_urls['latest_default'] %}
-    <p class="fs-5">
-      <i class="bi bi-file-diff"></i> <a href="{{ compare_to_baseline_urls['latest_default'] }}">compare to latest
-      baseline run on default branch</a>
-    </p>
-  {% endif %}
+  {% endfor %}
   {% if plot_history %}
     <div class="col-md-12">
       <h6>Top Outliers</h6>

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -80,8 +80,8 @@ class TestRunGet(_asserts.GetEnforcer):
                 candidate_baseline_runs={
                     "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
                     "latest_default": {
-                        "baseline_run_id": run.id,
-                        "commits_skipped": [],
+                        "baseline_run_id": baseline.id,
+                        "commits_skipped": [run.commit.sha],
                         "error": None,
                     },
                     "parent": {
@@ -141,8 +141,8 @@ class TestRunGet(_asserts.GetEnforcer):
                 candidate_baseline_runs={
                     "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
                     "latest_default": {
-                        "baseline_run_id": run.id,
-                        "commits_skipped": [],
+                        "baseline_run_id": baseline.id,
+                        "commits_skipped": [run.commit.sha],
                         "error": None,
                     },
                     "parent": {
@@ -169,8 +169,8 @@ class TestRunGet(_asserts.GetEnforcer):
                 candidate_baseline_runs={
                     "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
                     "latest_default": {
-                        "baseline_run_id": run_2.id,
-                        "commits_skipped": [],
+                        "baseline_run_id": baseline_1.id,
+                        "commits_skipped": [run_1.commit.sha],
                         "error": None,
                     },
                     "parent": {
@@ -189,8 +189,8 @@ class TestRunGet(_asserts.GetEnforcer):
                 candidate_baseline_runs={
                     "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
                     "latest_default": {
-                        "baseline_run_id": run_2.id,
-                        "commits_skipped": [],
+                        "baseline_run_id": baseline_2.id,
+                        "commits_skipped": [run_2.commit.sha],
                         "error": None,
                     },
                     "parent": {
@@ -212,7 +212,7 @@ class TestRunGet(_asserts.GetEnforcer):
 
         self.authenticate(client)
         # Create contender run with two benchmark results
-        _fixtures.benchmark_result(
+        a_contender_result = _fixtures.benchmark_result(
             name=name_1,
             sha=_fixtures.CHILD,
             language=language_1,
@@ -242,8 +242,8 @@ class TestRunGet(_asserts.GetEnforcer):
         assert response.json["candidate_baseline_runs"] == {
             "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
             "latest_default": {
-                "baseline_run_id": contender_run_id,
-                "commits_skipped": [],
+                "baseline_run_id": baseline_run_id_1,
+                "commits_skipped": [a_contender_result.run.commit.sha],
                 "error": None,
             },
             "parent": {
@@ -278,9 +278,9 @@ class TestRunGet(_asserts.GetEnforcer):
         assert response.json["candidate_baseline_runs"] == {
             "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
             "latest_default": {
-                "baseline_run_id": contender_run_id,
-                "commits_skipped": [],
-                "error": None,
+                "baseline_run_id": None,
+                "commits_skipped": None,
+                "error": "no matching baseline run was found",
             },
             "parent": {
                 "baseline_run_id": None,
@@ -326,8 +326,11 @@ class TestRunGet(_asserts.GetEnforcer):
                 candidate_baseline_runs={
                     "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
                     "latest_default": {
-                        "baseline_run_id": contender_run.id,
-                        "commits_skipped": [],
+                        "baseline_run_id": baseline_run.id,
+                        "commits_skipped": [
+                            contender.run.commit.sha,
+                            parent.run.commit.sha,
+                        ],
                         "error": None,
                     },
                     "parent": {
@@ -385,8 +388,12 @@ class TestRunGet(_asserts.GetEnforcer):
                 candidate_baseline_runs={
                     "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
                     "latest_default": {
-                        "baseline_run_id": contender_run.id,
-                        "commits_skipped": [],
+                        "baseline_run_id": baseline_run.id,
+                        "commits_skipped": [
+                            contender.run.commit.sha,
+                            parent.run.commit.sha,
+                            testing.run.commit.sha,
+                        ],
                         "error": None,
                     },
                     "parent": {

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -79,7 +79,11 @@ class TestRunGet(_asserts.GetEnforcer):
                 run,
                 candidate_baseline_runs={
                     "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
-                    "latest_default": DEFAULT_BRANCH_PLACEHOLDER,
+                    "latest_default": {
+                        "baseline_run_id": run.id,
+                        "commits_skipped": [],
+                        "error": None,
+                    },
                     "parent": {
                         "baseline_run_id": baseline.id,
                         "commits_skipped": [],
@@ -136,7 +140,11 @@ class TestRunGet(_asserts.GetEnforcer):
                 run,
                 candidate_baseline_runs={
                     "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
-                    "latest_default": DEFAULT_BRANCH_PLACEHOLDER,
+                    "latest_default": {
+                        "baseline_run_id": run.id,
+                        "commits_skipped": [],
+                        "error": None,
+                    },
                     "parent": {
                         "baseline_run_id": baseline.id,
                         "commits_skipped": [],
@@ -160,7 +168,11 @@ class TestRunGet(_asserts.GetEnforcer):
                 run_1,
                 candidate_baseline_runs={
                     "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
-                    "latest_default": DEFAULT_BRANCH_PLACEHOLDER,
+                    "latest_default": {
+                        "baseline_run_id": run_2.id,
+                        "commits_skipped": [],
+                        "error": None,
+                    },
                     "parent": {
                         "baseline_run_id": baseline_1.id,
                         "commits_skipped": [],
@@ -176,7 +188,11 @@ class TestRunGet(_asserts.GetEnforcer):
                 run_2,
                 candidate_baseline_runs={
                     "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
-                    "latest_default": DEFAULT_BRANCH_PLACEHOLDER,
+                    "latest_default": {
+                        "baseline_run_id": run_2.id,
+                        "commits_skipped": [],
+                        "error": None,
+                    },
                     "parent": {
                         "baseline_run_id": baseline_2.id,
                         "commits_skipped": [],
@@ -225,7 +241,11 @@ class TestRunGet(_asserts.GetEnforcer):
         response = client.get(f"/api/runs/{contender_run_id}/")
         assert response.json["candidate_baseline_runs"] == {
             "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
-            "latest_default": DEFAULT_BRANCH_PLACEHOLDER,
+            "latest_default": {
+                "baseline_run_id": contender_run_id,
+                "commits_skipped": [],
+                "error": None,
+            },
             "parent": {
                 "baseline_run_id": baseline_run_id_1,
                 "commits_skipped": [],
@@ -257,7 +277,11 @@ class TestRunGet(_asserts.GetEnforcer):
         response = client.get(f"/api/runs/{contender_run_id}/")
         assert response.json["candidate_baseline_runs"] == {
             "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
-            "latest_default": DEFAULT_BRANCH_PLACEHOLDER,
+            "latest_default": {
+                "baseline_run_id": contender_run_id,
+                "commits_skipped": [],
+                "error": None,
+            },
             "parent": {
                 "baseline_run_id": None,
                 "commits_skipped": None,
@@ -301,7 +325,11 @@ class TestRunGet(_asserts.GetEnforcer):
                 contender_run,
                 candidate_baseline_runs={
                     "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
-                    "latest_default": DEFAULT_BRANCH_PLACEHOLDER,
+                    "latest_default": {
+                        "baseline_run_id": contender_run.id,
+                        "commits_skipped": [],
+                        "error": None,
+                    },
                     "parent": {
                         "baseline_run_id": baseline_run.id,
                         "commits_skipped": [parent.run.commit.sha],
@@ -356,7 +384,11 @@ class TestRunGet(_asserts.GetEnforcer):
                 contender_run,
                 candidate_baseline_runs={
                     "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
-                    "latest_default": DEFAULT_BRANCH_PLACEHOLDER,
+                    "latest_default": {
+                        "baseline_run_id": contender_run.id,
+                        "commits_skipped": [],
+                        "error": None,
+                    },
                     "parent": {
                         "baseline_run_id": baseline_run.id,
                         "commits_skipped": [

--- a/conbench/tests/app/test_runs.py
+++ b/conbench/tests/app/test_runs.py
@@ -2,6 +2,7 @@ import copy
 import re
 from typing import Optional
 
+from ...app.runs import _default_hyperlink_text
 from ...tests.api import _fixtures
 from ...tests.app import _asserts
 
@@ -21,26 +22,23 @@ class TestRunGet(_asserts.GetEnforcer):
         candidate_baseline_type: str,
         baseline_id: Optional[str],
         contender_id: Optional[str],
+        recommended: bool = False,
     ) -> None:
         """Assert that a link to compare runs exists in the HTML, or doesn't exist if
         the run IDs aren't provided.
         """
         response_text = " ".join(response_text.split())
-
-        if candidate_baseline_type == "parent":
-            text = "compare to baseline run from parent commit"
-        elif candidate_baseline_type == "fork_point":
-            text = "compare to baseline run from fork point commit"
-        elif candidate_baseline_type == "latest_default":
-            text = "compare to latest baseline run on default branch"
+        expected_text = _default_hyperlink_text[candidate_baseline_type]
+        if recommended:
+            expected_text = f"{expected_text} (recommended)"
 
         if baseline_id and contender_id:
             assert (
-                f'/compare/runs/{baseline_id}...{contender_id}/">{text}'
+                f'/compare/runs/{baseline_id}...{contender_id}/">{expected_text}'
                 in response_text
             )
         else:
-            assert text not in response_text
+            assert expected_text not in response_text
 
     def test_get_run_without_commit(self, client):
         self.authenticate(client)
@@ -72,22 +70,35 @@ class TestRunGet(_asserts.GetEnforcer):
         for benchmark_result in benchmark_results:
             self._assert_view(client, benchmark_result.run_id)
 
-        # 0 (first in history) should not have any links
+        # 0 (first in history) should only have the latest_default link
         response = client.get(self.url.format(benchmark_results[0].run_id))
         self._assert_baseline_link(response.text, "parent", None, None)
         self._assert_baseline_link(response.text, "fork_point", None, None)
-        self._assert_baseline_link(response.text, "latest_default", None, None)
+        self._assert_baseline_link(
+            response.text,
+            "latest_default",
+            # the latest default branch run with same reason (commit)
+            benchmark_results[9].run_id,
+            benchmark_results[0].run_id,
+        )
 
-        # 1 (also on default branch) should only link to 0
+        # 1 (also on default branch) should link to 0 for parent
         response = client.get(self.url.format(benchmark_results[1].run_id))
         self._assert_baseline_link(
             response.text,
             "parent",
             benchmark_results[0].run_id,
             benchmark_results[1].run_id,
+            recommended=True,
         )
         self._assert_baseline_link(response.text, "fork_point", None, None)
-        self._assert_baseline_link(response.text, "latest_default", None, None)
+        self._assert_baseline_link(
+            response.text,
+            "latest_default",
+            # the latest default branch run with same reason (commit)
+            benchmark_results[9].run_id,
+            benchmark_results[1].run_id,
+        )
 
         # 3 is a PR run forked from 1
         response = client.get(self.url.format(benchmark_results[3].run_id))
@@ -102,11 +113,12 @@ class TestRunGet(_asserts.GetEnforcer):
             "fork_point",
             benchmark_results[1].run_id,
             benchmark_results[3].run_id,
+            recommended=True,
         )
         self._assert_baseline_link(
             response.text,
             "latest_default",
-            benchmark_results[15].run_id,  # the latest default branch run
+            benchmark_results[15].run_id,  # the latest default branch run in general
             benchmark_results[3].run_id,
         )
 

--- a/conbench/tests/app/test_runs.py
+++ b/conbench/tests/app/test_runs.py
@@ -28,9 +28,11 @@ class TestRunGet(_asserts.GetEnforcer):
         the run IDs aren't provided.
         """
         response_text = " ".join(response_text.split())
-        expected_text = _default_hyperlink_text[candidate_baseline_type]
+        expected_text = _default_hyperlink_text[candidate_baseline_type] + "</a>"
         if recommended:
-            expected_text = f"{expected_text} (recommended)"
+            expected_text = (
+                expected_text + ' <span class="badge bg-primary">Recommended</span>'
+            )
 
         if baseline_id and contender_id:
             assert (

--- a/conbench/tests/entities/test_run.py
+++ b/conbench/tests/entities/test_run.py
@@ -25,7 +25,11 @@ def test_get_candidate_baseline_runs():
                 "commits_skipped": None,
             },
             "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
-            "latest_default": DEFAULT_BRANCH_PLACEHOLDER,
+            "latest_default": {
+                "error": None,
+                "baseline_run_id": runs[9].id,
+                "commits_skipped": [],
+            },
         },
         # run 1, commit 22222
         {
@@ -35,7 +39,11 @@ def test_get_candidate_baseline_runs():
                 "commits_skipped": [],
             },
             "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
-            "latest_default": DEFAULT_BRANCH_PLACEHOLDER,
+            "latest_default": {
+                "error": None,
+                "baseline_run_id": runs[9].id,
+                "commits_skipped": [],
+            },
         },
         # run 2, commit aaaaa
         {
@@ -99,7 +107,11 @@ def test_get_candidate_baseline_runs():
                 "commits_skipped": ["33333"],
             },
             "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
-            "latest_default": DEFAULT_BRANCH_PLACEHOLDER,
+            "latest_default": {
+                "error": None,
+                "baseline_run_id": runs[9].id,
+                "commits_skipped": [],
+            },
         },
         # run 6, commit fffff
         {
@@ -145,7 +157,11 @@ def test_get_candidate_baseline_runs():
                 "commits_skipped": ["55555"],
             },
             "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
-            "latest_default": DEFAULT_BRANCH_PLACEHOLDER,
+            "latest_default": {
+                "error": None,
+                "baseline_run_id": runs[9].id,
+                "commits_skipped": [],
+            },
         },
         # run 9, commit 66666
         {
@@ -155,7 +171,11 @@ def test_get_candidate_baseline_runs():
                 "commits_skipped": ["55555"],
             },
             "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
-            "latest_default": DEFAULT_BRANCH_PLACEHOLDER,
+            "latest_default": {
+                "error": None,
+                "baseline_run_id": runs[9].id,
+                "commits_skipped": [],
+            },
         },
         # run 10, commit abcde (different repo)
         {
@@ -165,7 +185,11 @@ def test_get_candidate_baseline_runs():
                 "commits_skipped": None,
             },
             "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
-            "latest_default": DEFAULT_BRANCH_PLACEHOLDER,
+            "latest_default": {
+                "error": None,
+                "baseline_run_id": runs[10].id,
+                "commits_skipped": [],
+            },
         },
         # run 11, commit 'sha' (no detailed commit info)
         {
@@ -193,7 +217,11 @@ def test_get_candidate_baseline_runs():
                 "commits_skipped": None,
             },
             "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
-            "latest_default": DEFAULT_BRANCH_PLACEHOLDER,
+            "latest_default": {
+                "error": None,
+                "baseline_run_id": runs[12].id,
+                "commits_skipped": [],
+            },
         },
         # run 13, commit 66666 (different context)
         {
@@ -203,7 +231,11 @@ def test_get_candidate_baseline_runs():
                 "commits_skipped": None,
             },
             "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
-            "latest_default": DEFAULT_BRANCH_PLACEHOLDER,
+            "latest_default": {
+                "error": None,
+                "baseline_run_id": runs[13].id,
+                "commits_skipped": [],
+            },
         },
         # run 14, commit 66666 (different hardware)
         {
@@ -213,7 +245,11 @@ def test_get_candidate_baseline_runs():
                 "commits_skipped": None,
             },
             "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
-            "latest_default": DEFAULT_BRANCH_PLACEHOLDER,
+            "latest_default": {
+                "error": None,
+                "baseline_run_id": runs[14].id,
+                "commits_skipped": [],
+            },
         },
         # run 15, commit 66666 (nightly reason)
         {
@@ -223,7 +259,11 @@ def test_get_candidate_baseline_runs():
                 "commits_skipped": ["55555"],
             },
             "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
-            "latest_default": DEFAULT_BRANCH_PLACEHOLDER,
+            "latest_default": {
+                "error": None,
+                "baseline_run_id": runs[15].id,
+                "commits_skipped": [],
+            },
         },
     ]
     assert len(runs) == len(expected_baseline_run_dicts), "you should test all runs"
@@ -259,7 +299,11 @@ def test_get_candidate_baseline_runs():
             "commits_skipped": ["55555"],
         },
         "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
-        "latest_default": DEFAULT_BRANCH_PLACEHOLDER,
+        "latest_default": {
+            "error": None,
+            "baseline_run_id": runs[-1].id,
+            "commits_skipped": [],
+        },
     }
 
     # test a run with no commit that can still find a latest_default baseline

--- a/conbench/tests/entities/test_run.py
+++ b/conbench/tests/entities/test_run.py
@@ -173,7 +173,7 @@ def test_get_candidate_baseline_runs():
             "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
             "latest_default": {
                 "error": None,
-                "baseline_run_id": runs[9].id,
+                "baseline_run_id": runs[8].id,
                 "commits_skipped": [],
             },
         },
@@ -186,9 +186,9 @@ def test_get_candidate_baseline_runs():
             },
             "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
             "latest_default": {
-                "error": None,
-                "baseline_run_id": runs[10].id,
-                "commits_skipped": [],
+                "error": "no matching baseline run was found",
+                "baseline_run_id": None,
+                "commits_skipped": None,
             },
         },
         # run 11, commit 'sha' (no detailed commit info)
@@ -218,9 +218,9 @@ def test_get_candidate_baseline_runs():
             },
             "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
             "latest_default": {
-                "error": None,
-                "baseline_run_id": runs[12].id,
-                "commits_skipped": [],
+                "error": "no matching baseline run was found",
+                "baseline_run_id": None,
+                "commits_skipped": None,
             },
         },
         # run 13, commit 66666 (different context)
@@ -232,9 +232,9 @@ def test_get_candidate_baseline_runs():
             },
             "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
             "latest_default": {
-                "error": None,
-                "baseline_run_id": runs[13].id,
-                "commits_skipped": [],
+                "error": "no matching baseline run was found",
+                "baseline_run_id": None,
+                "commits_skipped": None,
             },
         },
         # run 14, commit 66666 (different hardware)
@@ -246,9 +246,9 @@ def test_get_candidate_baseline_runs():
             },
             "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
             "latest_default": {
-                "error": None,
-                "baseline_run_id": runs[14].id,
-                "commits_skipped": [],
+                "error": "no matching baseline run was found",
+                "baseline_run_id": None,
+                "commits_skipped": None,
             },
         },
         # run 15, commit 66666 (nightly reason)
@@ -261,7 +261,7 @@ def test_get_candidate_baseline_runs():
             "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
             "latest_default": {
                 "error": None,
-                "baseline_run_id": runs[15].id,
+                "baseline_run_id": runs[9].id,
                 "commits_skipped": [],
             },
         },
@@ -301,8 +301,8 @@ def test_get_candidate_baseline_runs():
         "fork_point": DEFAULT_BRANCH_PLACEHOLDER,
         "latest_default": {
             "error": None,
-            "baseline_run_id": runs[-1].id,
-            "commits_skipped": [],
+            "baseline_run_id": new_benchmark_result.run.id,
+            "commits_skipped": ["66666", "55555"],
         },
     }
 


### PR DESCRIPTION
This PR addresses @jonkeane's feedback in https://github.com/conbench/conbench/pull/1274#discussion_r1197953929. It:

- enables the `latest_default` candidate baseline run type coming from the `/api/runs/{run_id}` endpoint for contender runs that are on the default branch
- enables those in the webapp too
- labels the "recommended" baseline run in the webapp and moves it to the top of the list

Screenshots:

Run on a PR branch:
<img width="1329" alt="image" src="https://github.com/conbench/conbench/assets/16600275/39c2843b-7fb1-4850-a8af-6b48c0a33d3b">

Run on the default branch:
<img width="1326" alt="image" src="https://github.com/conbench/conbench/assets/16600275/4a1b1b53-fc69-4270-b3b5-fb7bb63a46ca">
