### PR TITLE
api: /benchmark-results/run_reason: fix sort order

### DIFF
--- a/conbench/api/results.py
+++ b/conbench/api/results.py
@@ -189,7 +189,10 @@ class BenchmarkListAPI(ApiEndpoint, BenchmarkValidationMixin):
 
         elif run_reason_arg := f.request.args.get("run_reason"):
             benchmark_results = BenchmarkResult.search(
-                filters=[Run.reason == run_reason_arg], joins=[Run], limit=35000
+                filters=[Run.reason == run_reason_arg],
+                joins=[Run],
+                order_by=BenchmarkResult.timestamp.desc(),
+                limit=55000,
             )
 
         else:


### PR DESCRIPTION
This fixes https://github.com/conbench/conbench/issues/1276.
```
curl localhost:5000/api/benchmark-results/?run_reason=nightly | python checkthis.py after
```
results in

![results_over_time-after](https://github.com/conbench/conbench/assets/265630/57915e37-7307-4308-adb0-fa61f8c8fce7)

I have increased N so that in this case we go back up to ~December last year.
