### PR TITLE
c-bench UI: /<bname>/trends -- timeseries analysis on BMRT cache, display conspicious canditates

### DIFF
--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -2,7 +2,7 @@ import collections
 import logging
 import math
 import time
-from typing import Dict, List, Tuple, TypedDict
+from typing import Dict, List, Tuple, TypedDict, TypeVar
 
 import flask
 import numpy as np
@@ -27,7 +27,12 @@ def time_of_newest_of_many_results(results: List[BMRTBenchmarkResult]) -> float:
     return max(r.started_at for r in results)
 
 
-def get_first_n_dict_subset(d: Dict, n: int) -> Dict:
+# Make this function's return type precisely be the type of input `d`, which is
+# often more specific than just Dict.
+GenDict = TypeVar("GenDict")  # the variable name must coincide with the string
+
+
+def get_first_n_dict_subset(d: GenDict, n: int) -> GenDict:
     # A bit of discussion here:
     # https://stackoverflow.com/a/12980510/145400
     return {k: d[k] for k in list(d)[:n]}

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -137,6 +137,11 @@ def show_trends_for_benchmark(bname: TBenchmarkName) -> str:
         if ibname == bname:
             dfs_by_t3[(case_id, context_id, hardware_id)] = df
 
+    # Do this trend analysis only for those timeseries that are recent.
+    # Criterion here for now: simple cutoff relative to _now_. TODO:
+    # relative to newest result for this conceptual benchmark.
+
+    now = time.time()
     relchange_by_t3: Dict[Tuple[str, str, str], float] = {}
     for t3, df in dfs_by_t3.items():
         # Note(JP): make a linear regression: derive a slope value. this is
@@ -154,6 +159,11 @@ def show_trends_for_benchmark(bname: TBenchmarkName) -> str:
 
         if len(df) < 10:
             # do this only when we have some history.
+            continue
+
+        # Recency criterion.
+        newest_timestamp = df.index[-1].timestamp()
+        if now - newest_timestamp > 86400 * 30:
             continue
 
         # did some of that before here:

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -6,15 +6,15 @@ from typing import Dict, List, Tuple, TypedDict, TypeVar
 
 import flask
 import numpy as np
+import numpy.polynomial
 import orjson
 import pandas as pd
-import numpy.polynomial
 
 import conbench.numstr
 from conbench.app import app
 from conbench.app._endpoint import authorize_or_terminate
 from conbench.config import Config
-from conbench.job import BMRTBenchmarkResult, bmrt_cache, TBenchmarkName
+from conbench.job import BMRTBenchmarkResult, TBenchmarkName, bmrt_cache
 
 log = logging.getLogger(__name__)
 

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -169,7 +169,11 @@ def show_trends_for_benchmark(bname: TBenchmarkName) -> str:
         if now - newest_timestamp > 86400 * 30:
             continue
 
-        # did some of that before here:
+        # TODO: basic outlier detection before the fit.
+        # Either rolling window median based, or maybe
+        # huber loss https://stackoverflow.com/a/61144766
+
+        # Did some of that before here:
         # https://github.com/jgehrcke/covid-19-analysis/blob/4950649a27c51c2bf36baba258757249385f2808/process.py#L227
         # it's a bit of a seemingly complex(?) converstion from pd
         # datetimeindex back to float values. Remove 10^15 from these
@@ -180,6 +184,7 @@ def show_trends_for_benchmark(bname: TBenchmarkName) -> str:
             / 10**15
         )
         yfloats = df["svs"].values
+
         fitted_series = numpy.polynomial.Polynomial.fit(tfloats, yfloats, 1)
 
         # print(fitted_series)

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -415,6 +415,7 @@ def show_benchmark_cases(bname: TBenchmarkName) -> str:
 class TypeUIPlotInfo(TypedDict):
     hwid: str
     ctxid: str
+    caseid: str
     hwname: str
     n_results: int
     url_to_newest_result: str
@@ -535,6 +536,7 @@ def show_benchmark_results(bname: TBenchmarkName, caseid: str) -> str:
             # Rely on at least one result being in the list.
             "hwid": hwid,
             "ctxid": ctxid,
+            "caseid": caseid,
             "hwname": results[0].hardware_name,
             "n_results": len(results),
             "url_to_newest_result": flask.url_for(

--- a/conbench/app/benchmarks.py
+++ b/conbench/app/benchmarks.py
@@ -35,7 +35,8 @@ GenDict = TypeVar("GenDict")  # the variable name must coincide with the string
 def get_first_n_dict_subset(d: GenDict, n: int) -> GenDict:
     # A bit of discussion here:
     # https://stackoverflow.com/a/12980510/145400
-    return {k: d[k] for k in list(d)[:n]}
+    assert isinstance(d, dict)
+    return {k: d[k] for k in list(d)[:n]}  # type: ignore
 
 
 @app.route("/c-benchmarks/", methods=["GET"])  # type: ignore

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -7,10 +7,9 @@ from collections import defaultdict
 from datetime import datetime
 from typing import Dict, List, NewType, Tuple, TypedDict, cast
 
+import pandas as pd
 import sqlalchemy
 from sqlalchemy.orm import selectinload
-
-import pandas as pd
 
 import conbench.metrics
 import conbench.util

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -5,10 +5,12 @@ import threading
 import time
 from collections import defaultdict
 from datetime import datetime
-from typing import Dict, List, Tuple, TypedDict
+from typing import Dict, List, NewType, Tuple, TypedDict, cast
 
 import sqlalchemy
 from sqlalchemy.orm import selectinload
+
+import pandas as pd
 
 import conbench.metrics
 import conbench.util
@@ -40,6 +42,14 @@ original_sigint_handler = signal.getsignal(signal.SIGINT)
 original_sigquit_handler = signal.getsignal(signal.SIGQUIT)
 
 log = logging.getLogger(__name__)
+
+
+TBenchmarkName = NewType("TBenchmarkName", str)
+
+# A type for a dictionary: key is 4-tuple defining a time series, and value is
+# a pandas dataframe containing the time series (index: pd.DateTimeIndex
+# tz-aware, one column: single value summary).
+TDict4tdf = Dict[Tuple[TBenchmarkName, str, str, str], pd.DataFrame]
 
 
 @dataclasses.dataclass
@@ -103,8 +113,9 @@ class BMRTBenchmarkResult:
 
 class CacheDict(TypedDict):
     by_id: Dict[str, BMRTBenchmarkResult]
-    by_benchmark_name: Dict[str, List[BMRTBenchmarkResult]]
+    by_benchmark_name: Dict[TBenchmarkName, List[BMRTBenchmarkResult]]
     by_case_id: Dict[str, List[BMRTBenchmarkResult]]
+    dict4tdf: TDict4tdf
     meta: CacheUpdateMetaInfo
 
 
@@ -130,7 +141,7 @@ _STARTED = False
 BMRT_CACHE_SIZE = 0.3 * 10**6
 if Config.TESTING:
     # quicker update in testing
-    BMRT_CACHE_SIZE = 0.2 * 10**6
+    BMRT_CACHE_SIZE = 0.05 * 10**6
 
 
 # Fetching one million items from a sample DB takes ~1 minute on my machine
@@ -168,7 +179,7 @@ def _fetch_and_cache_most_recent_results() -> None:
     result_rows_iterator = Session.scalars(query_statement)
 
     by_id_dict: Dict[str, BMRTBenchmarkResult] = {}
-    by_name_dict: Dict[str, List[BMRTBenchmarkResult]] = defaultdict(list)
+    by_name_dict: Dict[TBenchmarkName, List[BMRTBenchmarkResult]] = defaultdict(list)
     by_case_id_dict: Dict[str, List[BMRTBenchmarkResult]] = defaultdict(list)
 
     first_result = None
@@ -191,7 +202,10 @@ def _fetch_and_cache_most_recent_results() -> None:
         # For now: put both, failed and non-failed results into the cache.
         # It would be a nice code simplification to only consider succeeded
         # ones, but then we miss out on reporting about the failed ones.
-        benchmark_name = str(result.case.name)
+        # Note: with named types it's here not enough to to # type: ...
+        # but an explicit cast is required? perf impact? dunno.
+        # Related: https://github.com/python/typing/discussions/1146
+        benchmark_name = cast(TBenchmarkName, str(result.case.name))
 
         # A textual representation of the case permutation. As it is 'complete'
         # it should also work as a proper identifier (like primary key).
@@ -251,6 +265,9 @@ def _fetch_and_cache_most_recent_results() -> None:
     assert first_result
     assert last_result
 
+    # Group all benchmark results into timeseries
+    dict4tdf = _generate_tsdf_per_4tuple(by_name_dict)
+
     # Mutate the dictionary which is accessed by other threads, do this in a
     # quick fashion -- each of this assignments is atomic (thread-safe), but
     # between those two assignments a thread might perform read access. (minor
@@ -260,6 +277,7 @@ def _fetch_and_cache_most_recent_results() -> None:
     bmrt_cache["by_id"] = by_id_dict
     bmrt_cache["by_benchmark_name"] = by_name_dict
     bmrt_cache["by_case_id"] = by_case_id_dict
+    bmrt_cache["dict4tdf"] = dict4tdf
     bmrt_cache["meta"] = CacheUpdateMetaInfo(
         newest_result_time_str=first_result.ui_time_started_at,
         covered_timeframe_days_approx=str(
@@ -343,6 +361,91 @@ def _periodically_fetch_last_n_benchmark_results() -> None:
     # part of gunicorn's worker process shutdown -- therefore the signal
     # handler-based logic below which injects a shutdown signal into the
     # thread.
+
+
+def _generate_tsdf_per_4tuple(
+    by_name_dict: Dict[TBenchmarkName, List[BMRTBenchmarkResult]]
+) -> TDict4tdf:
+    t2 = time.monotonic()
+    by_name_dict_with_timeseries_tuplekeys: Dict[
+        TBenchmarkName, Dict[Tuple, List[BMRTBenchmarkResult]]
+    ] = {}
+    for bname, results in by_name_dict.items():
+        # The magic time series 4-tuple is
+        # bname, caseid, hwid, ctxid
+        by_ts_tuple: Dict[Tuple, List[BMRTBenchmarkResult]] = defaultdict(list)
+        for r in results:
+            by_ts_tuple[(r.case_id, r.context_id, r.hardware_id)].append(r)
+        by_name_dict_with_timeseries_tuplekeys[bname] = by_ts_tuple
+
+    t3 = time.monotonic()
+
+    tsdf_per_4tuple: TDict4tdf = {}
+
+    # Brutal, slow, approach: (ideally we find a way to represent all data in a
+    # single dataframe with decent multi-index -- that could be a major speedup
+    # for timeseries analysis on all of these series in a bulk.) one dataframe
+    # per 4-tuple: (bname, case_id, context_id, hardware_id).
+    # I have seen this below DF construction loop to take 3 seconds for 2*10^5
+    # results.
+    for bname, unsorted_timeseries in by_name_dict_with_timeseries_tuplekeys.items():
+        for (
+            case_id,
+            context_id,
+            hardware_id,
+        ), usresults in unsorted_timeseries.items():
+            # Think: `usresults` is a list not yet sorted by time.
+
+            df = pd.DataFrame(
+                # Note(jp:): cannot use a generator expression here, len needs
+                # to be known.
+                {"svs": [r.svs for r in usresults]},
+                # Note(jp): also no generator expression possible. The
+                # `unit="s"` is the critical ingredient to convert this list of
+                # floaty unix timestamps to datetime representation. `utc=True`
+                # is required to localize the pandas DateTimeIndex to UTC
+                # (input is tz-naive).
+                index=pd.to_datetime(
+                    [r.started_at for r in usresults], unit="s", utc=True
+                ),
+            )
+            # Sort by time.
+            df = df.sort_index()
+            tsdf_per_4tuple[(bname, case_id, context_id, hardware_id)] = df
+
+    t4 = time.monotonic()
+    log.info("BMRT cache pop: quadratic sort loop took %.3f s", t3 - t2)
+    log.info(
+        "BMRT cache pop: df constr took %.3f s (%s time series)",
+        t4 - t3,
+        len(tsdf_per_4tuple),
+    )
+
+    # The following comment is provides insight into the structure of the
+    # return value. It shows one example for the key (4-tuple) and
+    # corresponding value (and its properties; Index, h)
+
+    # for i, (t4, dffff) in enumerate(tsdf_per_4tuple.items()):
+    #     if i % 1000 == 0:
+    #         print(t4)
+    #         print(dffff)
+    # ('tpch-foobar', '750317efddda4b76a80f72d9ac44f882', 'c99e3d44ccf9415996209006244d6b10', '31ce04b765d44f32a4f2c6a7762e2ddb')
+    #                                             svs
+    # 2022-09-28 02:25:54.315165043+00:00   93.072853
+    # 2022-09-28 10:32:56.099033117+00:00  100.253622
+    # 2022-09-28 13:51:49.347893+00:00     102.833077
+    # 2022-09-28 15:57:35.356076002+00:00   99.807175
+    # 2022-09-28 17:06:46.327281952+00:00  102.777138
+    # 2022-09-28 17:14:14.036443949+00:00  100.854897
+    # 2022-09-28 20:08:16.950268984+00:00   99.565141
+    # 2022-09-28 20:10:27.393528938+00:00   93.057321
+    # 2022-09-29 00:02:27.419251919+00:00   99.077197
+    # 2022-09-29 00:17:44.202492952+00:00   96.842827
+    # 2022-09-29 02:26:19.996010065+00:00   91.103735
+    # 2022-09-29 03:18:40.925746918+00:00         NaN
+    # 2022-09-29 03:52:28.406414986+00:00         NaN
+
+    return tsdf_per_4tuple
 
 
 def start_jobs():

--- a/conbench/templates/c-benchmark-trends.html
+++ b/conbench/templates/c-benchmark-trends.html
@@ -1,0 +1,280 @@
+{% extends "app.html" %}
+{% block app_content %}
+  <h3>
+    benchmark <strong>'{{ benchmark_name }}'</strong> / trends
+  </h3>
+  <span class="fs-4"><code>{{ this_case_text_id }}</code></span>
+  <div class="mt-5">
+    <h5 class="mb-3">
+      History for unique case/hardware/context combinations
+      <sup><i style="font-size: 12px"
+   class="bi bi-info-circle"
+   data-bs-toggle="tooltip"
+   data-bs-title="Benchmark results, grouped by unique (case, hardware, context) combinations. ">
+      </i></sup>
+    </h5>
+    <!--  Strategy: BS gutters, see https://getbootstrap.com/docs/5.2/layout/gutters/  -->
+    <div class="row gy-5">
+      {% for cch, plotinfo in infos_for_uplots.items() %}
+        <div class="col-6" style="width: 600px">
+          <div class="cb-tinyplot pt-1 shadow">
+            <!--https://getbootstrap.com/docs/5.3/utilities/flex/#auto-margins-->
+            <div class="d-flex">
+              <div class="hardware"
+                   data-bs-toggle="tooltip"
+                   data-bs-title="Hardware"
+                   data-bs-delay='{"show":700,"hide":150}'>
+                <i class="bi bi-cpu"></i> {{ plotinfo.hwname[:25] }}
+              </div>
+              <div class="context"
+                   data-bs-toggle="tooltip"
+                   data-bs-title="Context"
+                   data-bs-delay='{"show":700,"hide":150}'>
+                <i class="bi bi-sliders2"></i> <a href="#"
+    data-bs-toggle="offcanvas"
+    data-bs-target="#offcanvasContextDict-{{ plotinfo.ctxid }}"
+    aria-controls="offcanvasContextDict-{{ plotinfo.ctxid }}">{{ plotinfo.ctxid[:7] }}</a>
+              </div>
+              <div class="ms-auto ps-2 results">
+                {{ plotinfo.n_results }} results <a href="{{ plotinfo.url_to_newest_result }}">(full hist)</a>
+              </div>
+            </div>
+            <div class="cb-plot-{{ cch }}" style="width: 550px"></div>
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+    <div style="font-family: 'Roboto Mono';">.</div>
+  </div>
+  {% for ctxid, context_json in context_json_by_context_id.items() %}
+    <div class="offcanvas offcanvas-start"
+         data-bs-scroll="true"
+         tabindex="-1"
+         id="offcanvasContextDict-{{ ctxid }}"
+         aria-labelledby="offcanvasContextDictLabel-{{ ctxid }}">
+      <div class="offcanvas-header">
+        <span class="offcanvas-title" id="offcanvasContextDictLabel-{{ ctxid }}">Context {{ ctxid }}</span>
+        <button type="button"
+                class="btn-close"
+                data-bs-dismiss="offcanvas"
+                aria-label="Close"></button>
+      </div>
+      <div class="offcanvas-body offcanvas-cb-context">
+        <code>
+          <pre style="">{{context_json}}</pre>
+        </code>
+      </div>
+    </div>
+  {% endfor %}
+{% endblock %}
+{% block scripts %}
+  {{ super() }}
+  <script>
+    let plot_info_by_cch = {{ infos_for_uplots_json|safe }};
+
+    function orderOfMagnMax(values) {
+      // assume only positive values (benchmark data: time, bandwidth, etc)
+      let max = Math.max(...values);
+      // Get order of magnitude of maximum, also see
+      // https://stackoverflow.com/a/23917134/145400
+      let oommax = Math.floor(Math.log(max) / Math.LN10 + 0.000000001);
+      return oommax;
+    }
+
+    function switchToScientifcNotation(values) {
+      // Switch to scientific notation for large values, and for small
+      // values. Assume only positive values.
+      if (orderOfMagnMax(values) > 4 || orderOfMagnMax(values) < -1 ) {
+        return true;
+      }
+      return false;
+    }
+
+    function formatValuesForAxis(values) {
+      /*
+      Do not exclusively show exponential/scientific notation, but only
+      when the maximum value is larger than 10^5.
+      Alternatively, prepare tick labels in backend and use
+      matplotlib.ticker.ScalarFormatter, also see
+      https://stackoverflow.com/a/42658124/145400
+      */
+
+      if (switchToScientifcNotation(values)) {
+        return values.map((v) => v.toExponential(1));
+      }
+
+      //return values.map((v) => v.toPrecision(2));
+      // kudos to https://stackoverflow.com/a/58494899/145400
+      return values.map((v) => parseFloat(v.toPrecision(2)));
+    }
+
+    function yAxisLabelSpace(values) {
+      // For scientific notation there needs to be more space.
+      if (switchToScientifcNotation(values)) {
+        return 60;
+      }
+      return 45;
+    }
+
+    function renderPlots() {
+
+      function generateUPlotOpts(yValues, unitStr) {
+      return {
+        title: "",
+        class: "cb-uplot",
+        width: 550,
+        height: 270,
+        cursor: {
+          show: false,
+        },
+        legend: {
+          show: false,
+        },
+        series: [
+          {},
+          {
+            sorted: 0,
+            show: true,
+            spanGaps: false,
+            stroke: "#812570", // dark magenta, main line color
+            width: 0.6,
+            // I have been taking greenish colors from this palette:
+            // https://colorhunt.co/palette/b9eddd87cbb9569daa577d86 We can
+            // think about greenifying some graphs, and reddifying others,
+            // based on their properties.
+            fill: "#38BDD122", // skyblue, transp
+            //fill: "rgba(255, 0, 0, 0.3)",
+            //dash: [10, 5],
+            scale: "y",
+            points: {
+              // Without `show: true`, points do not always show.
+              show: true,
+              size: 5,
+              fill: 'rgba(87, 125, 134, 0.7)'
+            }
+          }
+        ],
+        axes: [
+          {
+            //label: "date",
+            labelFont: "bold 12px 'Roboto Mono'",
+            font: "11px 'Roboto Mono'",
+            stroke: "#812570", // dark magenta
+            // 24 hour format on time axis ticks, remove am/pm, etc.
+            // Copied the default value from docs, then edited.
+            values: [
+              [3600 * 24 * 365,   "{YYYY}",         null,                            null,    null,                      null,    null,              null,        1],
+              [3600 * 24 * 28,    "{MMM}",          "\n{YYYY}",                      null,    null,                      null,    null,              null,        1],
+              [3600 * 24,         "{MM}/{DD}",        "\n{YYYY}",                      null,    null,                      null,    null,              null,        1],
+              [3600,              "{HH}",        "\n{YYYY}-{MM}-{DD}",                null,    "\n{MM}-{DD}",               null,    null,              null,        1],
+              [60,                "{HH}:{mm}",   "\n{YYYY}-{MM}-{DD}",                null,    "\n{MM}-{DD}",               null,    null,              null,        1],
+              [1,                 ":{ss}",          "\n{YYYY}-{MM}-{DD} {HH}:{mm}",   null,    "\n{MM}-{DD} {HH}:{mm}",  null,    "\n{HH}:{mm}",  null,        1],
+              [0.001,             ":{ss}.{fff}",    "\n{YYYY}-{MM}-{DD} {HH}:{mm}",   null,    "\n{MM}-{DD} {HH}:{mm}",  null,    "\n{HH}:{mm}",  null,        1],
+            ],
+          },
+          {
+            label: unitStr,
+            labelFont: "bold 12px 'Roboto Mono'",
+            font: "11px  'Roboto Mono'",
+            stroke: "#812570", // dark magenta
+            scale: "y",
+            // give y axis labels some space
+            //size: 57,
+            size: yAxisLabelSpace(yValues),
+            // This is used for y axis formatting. Trade-off:
+            // predictable width, medium precision is sufficient.
+            values: (u, splits) => formatValuesForAxis(splits),
+          }
+        ],
+        scales: {
+
+          "y": {
+            range: (u, datamin, datamax) => {
+              // Preparing for all kinds of ranges and orders of
+              // magnitude, always show the zero for keeping plots most
+              // meaningful -- if the relative change is very small then
+              // it will be rather invisible in a plot like this, which
+              // is the goal.
+              return [0, datamax * 1.2];
+            },
+
+          }
+        },
+      }};
+
+      {% for cch, plotinfo in infos_for_uplots.items() %}
+        // About plot_info_by_cch[xxx]["data_for_uplot"]:
+        // 2-tuple. First item: array of time values, second item:
+        // array of ordinate values.
+        let uplot_{{cch}} = new uPlot(
+          generateUPlotOpts(
+            plot_info_by_cch["{{cch}}"]["data_for_uplot"][1],
+            plot_info_by_cch["{{cch}}"]["unit"],
+            ),
+          plot_info_by_cch["{{cch}}"]["data_for_uplot"],
+          $('.cb-plot-{{cch}}')[0]
+          );
+      {% endfor %}
+
+    };
+
+    $(document).ready(function () {
+      // Enable bootstrap tooltips on this page.
+      const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+      const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));
+
+      $('table.conbench-datatable').each(function() {
+        $(this).DataTable({
+            // Note(JP): this enables a special, simple plugin called
+            // `conditionalPaging` which must be included, e.g. via the dist URLs
+            // published in https://cdn.datatables.net/plug-ins/1.13.3/features/.
+            // kudos to https://stackoverflow.com/a/29639664/145400
+          "conditionalPaging": true,
+          "responsive": true,
+            // the default default seems to be the first item in lengthMenu.
+          "lengthMenu": [ 5, 10, 50, 75, 100, 250, 750 ],
+            // but when pageLength is also set, then _this_ is the default.
+          "pageLength": 10,
+            // Take rather precise control of layouting elements, put bottom elements
+            // into a mult-col single row, using BS's grid system.
+          "dom": '<"row"<"d-flex flex-row-reverse p-0"fl>>rt<"row p-2"<"col-6"i><".col-6"p>>',
+          "order": [[0, 'desc']],
+          "columnDefs": [{ "orderable": true }],
+          initComplete: function () {
+            var api = this.api();
+                // reveal only after DOM modification is complete (reduce loading
+                // layout shift artifacts)
+            $('table.conbench-datatable').show();
+            api.columns.adjust();
+            $('.pagination').addClass('pagination-sm'); // add BS class for smaller pagination bar
+          },
+        });
+      });
+    });
+
+  // uPlot uses canvas for plotting. To make sure the fonts asked for in here
+  // are really available before starting to draw in the canvace element use
+  // the technique described in  https://stackoverflow.com/a/7289880/145400,
+  // otherwise there are plenty of race conditions that might or might not hit
+  // in across browser refreshs. Also see
+  // https://github.com/typekit/webfontloader
+  WebFontConfig = {
+      google: {
+        families: ['Roboto']
+      },
+      active: function() {
+      /* code to execute once all font families are loaded */
+      console.log(" I sure hope my font is loaded now. ");
+      renderPlots();
+    }
+   };
+
+   (function(d) {
+      var wf = d.createElement('script'), s = d.scripts[0];
+      wf.src = 'https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js';
+      wf.async = true;
+      s.parentNode.insertBefore(wf, s);
+   })(document);
+
+  </script>
+{% endblock %}


### PR DESCRIPTION
Showing timeseries plots / sparklines / small multiples only after selecting benchmark -> case is a little deep, late. Pull this one level up (this is a major takeaway of a conversation I had with Jon). But when going one level up, it becomes important to decide _which_ series to show, plot. Otherwise, it might be hundreds or thousands of them. Recency is one good criterion. But even when showing only recently populated timeseries there's too much. So. It makes sense to do simple/obvious type of analyses on individual timeseries and to then display those that have interesting statistical properties, such as:
- large scattering of data
- a trend (increasing, or decreasing)
- ...

All of these require setting thresholds, but I think it's a powerful approach to show, for example, top N recently populated timeseries by relative change (increasing -> perf regression).

This patch works into that direction.