### PR TITLE
buildkite ci: process PROM_REMOTE_WRITE_* class of environment variables

### DIFF
--- a/conbench/api/compare.py
+++ b/conbench/api/compare.py
@@ -239,7 +239,7 @@ class CompareBenchmarkResultsAPI(ApiEndpoint):
         return benchmark_result
 
     @maybe_login_required
-    def get(self, compare_ids) -> f.Response:
+    def get(self, compare_ids: str) -> f.Response:
         """
         ---
         description: |
@@ -307,7 +307,6 @@ class CompareBenchmarkResultsAPI(ApiEndpoint):
         with _semaphore_compare_get:
             return self._get(compare_ids)
 
-    @maybe_login_required
     def _get(self, compare_ids: str) -> f.Response:
         baseline_result_id, contender_result_id = _parse_two_ids_or_abort(compare_ids)
         threshold, threshold_z = _get_threshold_args_from_request()
@@ -412,7 +411,7 @@ class CompareRunsAPI(ApiEndpoint):
         return joined_results
 
     @maybe_login_required
-    def get(self, compare_ids) -> f.Response:
+    def get(self, compare_ids: str) -> f.Response:
         """
         ---
         description: |
@@ -458,7 +457,7 @@ class CompareRunsAPI(ApiEndpoint):
         with _semaphore_compare_get:
             return self._get(compare_ids)
 
-    def _get(self, compare_ids) -> f.Response:
+    def _get(self, compare_ids: str) -> f.Response:
         baseline_run_id, contender_run_id = _parse_two_ids_or_abort(compare_ids)
         threshold, threshold_z = _get_threshold_args_from_request()
         baseline_results = self._get_all_results_for_a_run(baseline_run_id)

--- a/k8s/kube-prometheus/deploy-or-update.sh
+++ b/k8s/kube-prometheus/deploy-or-update.sh
@@ -29,7 +29,7 @@ set -o xtrace
 # Design goal: can be run multiple times against the same k8s cluster
 #     with the following behavior:
 #     - if kube-prometheus stack changed, an update is performed
-#       (here we largely rely on the promised of the kube-prometheus project)
+#       (here we largely rely on the promises of the kube-prometheus project)
 #     -
 #
 


### PR DESCRIPTION
In many of the previous patches I had prepared for the moment where we have configuration details to inject about a system to push data to:

![image](https://github.com/conbench/conbench/assets/265630/64c7d816-6d76-4cc1-8a9f-167d302466a0)

`Makefile` and `k8s/kube-prometheus/deploy-or-update.sh` use the following environment variables when set:

```
PROM_REMOTE_WRITE_ENDPOINT_URL
PROM_REMOTE_WRITE_PASSWORD_FILE_PATH
PROM_REMOTE_WRITE_USERNAME
PROM_REMOTE_WRITE_CLUSTER_LABEL_VALUE
```

The sensitive bits of information end up being injected as k8s secret: https://github.com/conbench/conbench/blob/86b8b12857ce574403dacd1b82da4b43cf86bb1f/k8s/kube-prometheus/deploy-or-update.sh#L69

This is coordinated with https://github.com/conbench/conbench/blob/86b8b12857ce574403dacd1b82da4b43cf86bb1f/k8s/kube-prometheus/conbench-flavor.jsonnet#L107


Other bits just end up being injected into the conbench-flavored kube-prometheus stack config, like here:
https://github.com/conbench/conbench/blob/86b8b12857ce574403dacd1b82da4b43cf86bb1f/k8s/kube-prometheus/conbench-flavor.jsonnet#L25

That magic is done with sed/Makefile: https://github.com/conbench/conbench/blob/86b8b12857ce574403dacd1b82da4b43cf86bb1f/Makefile#L342

What this patch is doing is that it's essentially preparing for utils.sh (run as part of a buildkite pipeline) to have the relevant information available.




