### PR TITLE
kube-prometheus: isDefault: true on single datasource, change dashboard def to use that

### DIFF
--- a/k8s/kube-prometheus/conbench-flavor.jsonnet
+++ b/k8s/kube-prometheus/conbench-flavor.jsonnet
@@ -42,6 +42,20 @@ local kp =
           // `bash build.sh conbench-flavor.jsonnet`
           'conbench-grafana-dashboard.json': (importstr 'conbench-grafana-dashboard.json'),
         },
+        // The following data source config object is here "only" to set
+        // isDefault: true. The other values are copy/pasted from the build
+        // output. This is not ideal. Also see
+        // https://github.com/prometheus-operator/kube-prometheus/issues/2131
+        datasources+:: [{
+          access: 'proxy',
+          orgId: 1,
+          editable: false,
+          name: 'prometheus',
+          type: 'prometheus',
+          url: 'http://prometheus-k8s.monitoring.svc:9090',
+          version: 1,
+          isDefault: true,
+        }],
         config: {
           // http://docs.grafana.org/installation/configuration/
           sections: {

--- a/k8s/kube-prometheus/conbench-grafana-dashboard.json
+++ b/k8s/kube-prometheus/conbench-grafana-dashboard.json
@@ -1191,8 +1191,8 @@
       {
         "current": {
           "selected": true,
-          "text": "prometheus",
-          "value": "prometheus"
+          "text": "default",
+          "value": "default"
         },
         "description": "",
         "hide": 0,


### PR DESCRIPTION
See commit msg + code comments.
Towards using exactly the same dashboard config across various Grafana deployments.