### PR TITLE
SQLAlchemy database session isolation: per-request and per-BMRT cache update 

### DIFF
--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -285,21 +285,11 @@ def dict_or_objattrs_to_nonsensitive_string(obj):
 
 
 # Leaving the `os.environ.get("FLASK_APP", None)` in here although I really
-# don't quite understand intent and purpose.
+# don't quite understand intent and purpose. Update: so this is to distinguish
+# legacy CLI entrypoint from Flask web application entry point. Wow. OK.
+# gunicorn is configured with wsgi_app = "conbench:application" and this will
+# fail if the code below doesn't execute.
 if os.environ.get("FLASK_APP", None):
     from .config import Config
 
     application = create_application(Config)
-
-# Note(JP): when FLASK_APP is set then this here is not executed, but instead
-# gunicorn loads into the app using a stringified import instruction such as
-# `conbench:application` (codified in the gunicorn cmd line args). see
-# .flaskenv used by `$ flask run` Note(JP): oh wow, this is probably how with
-# the gunicorn deployment we never ran this Session.remove() between requests.
-# if os.environ.get("FLASK_APP", None):
-#     from .config import Config
-#     from .db import Session
-#     application = create_application(Config)
-#     @application.teardown_appcontext
-#     def cleanup(_):
-#         Session.remove()

--- a/conbench/__init__.py
+++ b/conbench/__init__.py
@@ -104,6 +104,7 @@ def _init_flask_application(app):
     import flask
     import flask_swagger_ui
     import werkzeug.exceptions
+
     from conbench.dbsession import flask_scoped_session
 
     from .api import api
@@ -283,9 +284,12 @@ def dict_or_objattrs_to_nonsensitive_string(obj):
     return json.dumps(sanitized, sort_keys=True, default=str, indent=2)
 
 
-from .config import Config
+# Leaving the `os.environ.get("FLASK_APP", None)` in here although I really
+# don't quite understand intent and purpose.
+if os.environ.get("FLASK_APP", None):
+    from .config import Config
 
-application = create_application(Config)
+    application = create_application(Config)
 
 # Note(JP): when FLASK_APP is set then this here is not executed, but instead
 # gunicorn loads into the app using a stringified import instruction such as

--- a/conbench/api/compare.py
+++ b/conbench/api/compare.py
@@ -8,9 +8,10 @@ import flask as f
 import sigfig
 import sqlalchemy as s
 
+from conbench.dbsession import current_session
+
 from ..api import rule
 from ..api._endpoint import ApiEndpoint, maybe_login_required
-from ..db import Session
 from ..entities.benchmark_result import BenchmarkResult
 from ..entities.history import _less_is_better, set_z_scores
 from ..hacks import set_display_benchmark_name, set_display_case_permutation
@@ -351,7 +352,7 @@ class CompareRunsAPI(ApiEndpoint):
         """Get all benchmark results for a run. Abort if the run doesn't exist or if
         there are no results for the run.
         """
-        result = Session.scalars(
+        result = current_session.scalars(
             s.select(BenchmarkResult).where(BenchmarkResult.run_id == run_id)
         ).all()
 

--- a/conbench/api/compare.py
+++ b/conbench/api/compare.py
@@ -346,6 +346,9 @@ class CompareBenchmarkResultsAPI(ApiEndpoint):
         return f.jsonify(comparator._dict_for_api_json)
 
 
+# from filprofiler.api import profile as filprofile
+
+
 class CompareRunsAPI(ApiEndpoint):
     @staticmethod
     def _get_all_results_for_a_run(run_id: str) -> List[BenchmarkResult]:

--- a/conbench/api/index.py
+++ b/conbench/api/index.py
@@ -6,12 +6,14 @@ import flask_login
 import marshmallow
 from sqlalchemy.sql import text
 
+from conbench.dbsession import current_session
+
 from ..api import api, rule
 from ..api._docs import api_server_url, spec
 from ..api._endpoint import ApiEndpoint
 from ..buildinfo import BUILD_INFO
 from ..config import Config
-from ..db import Session, empty_db_tables
+from ..db import empty_db_tables
 
 log = logging.getLogger(__name__)
 
@@ -167,7 +169,9 @@ class PingAPI(ApiEndpoint):
                 # dev/from-scratch deployments? Update(JP): pragmatic solution:
                 # do not query in TESTING mode.
                 alembic_version = list(
-                    Session.execute(text("SELECT version_num FROM alembic_version"))
+                    current_session.execute(
+                        text("SELECT version_num FROM alembic_version")
+                    )
                 )[0][0]
             except Exception as exc:
                 # Reduce noise: do not log full error, and also only on debug

--- a/conbench/api/results.py
+++ b/conbench/api/results.py
@@ -5,12 +5,13 @@ import flask_login
 import orjson
 from sqlalchemy import select
 
+from conbench.dbsession import current_session
+
 import conbench.metrics
 
 from ..api import rule
 from ..api._docs import spec
 from ..api._endpoint import ApiEndpoint, maybe_login_required
-from ..db import Session
 from ..entities._entity import NotFound
 from ..entities.benchmark_result import (
     BenchmarkResult,
@@ -183,7 +184,7 @@ class BenchmarkListAPI(ApiEndpoint, BenchmarkValidationMixin):
                     "issue 978)"
                 )
 
-            benchmark_results = Session.scalars(
+            benchmark_results = current_session.scalars(
                 select(BenchmarkResult).where(BenchmarkResult.run_id.in_(run_ids))
             ).all()
 

--- a/conbench/api/results.py
+++ b/conbench/api/results.py
@@ -5,9 +5,8 @@ import flask_login
 import orjson
 from sqlalchemy import select
 
-from conbench.dbsession import current_session
-
 import conbench.metrics
+from conbench.dbsession import current_session
 
 from ..api import rule
 from ..api._docs import spec

--- a/conbench/app/index.py
+++ b/conbench/app/index.py
@@ -7,9 +7,8 @@ from urllib.parse import urlparse
 import flask
 from sqlalchemy import select
 
-from conbench.dbsession import current_session
-
 import conbench.util
+from conbench.dbsession import current_session
 
 from ..app import rule
 from ..app._endpoint import AppEndpoint, authorize_or_terminate

--- a/conbench/app/index.py
+++ b/conbench/app/index.py
@@ -7,13 +7,14 @@ from urllib.parse import urlparse
 import flask
 from sqlalchemy import select
 
+from conbench.dbsession import current_session
+
 import conbench.util
 
 from ..app import rule
 from ..app._endpoint import AppEndpoint, authorize_or_terminate
 from ..app.results import RunMixin
 from ..config import Config
-from ..db import Session
 from ..entities.run import Run
 
 log = logging.getLogger(__name__)
@@ -50,7 +51,7 @@ class Index(AppEndpoint, RunMixin):
 
         # Following
         # https://docs.sqlalchemy.org/en/20/orm/queryguide/select.html#selecting-orm-entities
-        runs = Session.scalars(
+        runs = current_session.scalars(
             select(Run).order_by(Run.timestamp.desc()).limit(1000)
         ).all()
 

--- a/conbench/db.py
+++ b/conbench/db.py
@@ -5,10 +5,9 @@ import sys
 import orjson
 import psycopg2
 import sqlalchemy.exc
+import sqlalchemy.orm
 import tenacity
 from sqlalchemy import create_engine
-import sqlalchemy.orm
-
 
 from .config import Config
 

--- a/conbench/dbsession.py
+++ b/conbench/dbsession.py
@@ -1,0 +1,86 @@
+"""
+This is largely based on the nice
+https://github.com/dtheodor/flask-sqlalchemy-session
+
+patched for modern Werkzeug, patch modeled after
+https://github.com/pallets-eco/flask-sqlalchemy/commit/3565f0587519168c5ea4301f6e4bfba8c2ac4dee?diff=split
+Also see https://github.com/dtheodor/flask-sqlalchemy-session/issues/14
+
+Provides an SQLAlchemy scoped session that creates unique sessions per Flask
+request.
+"""
+from werkzeug.local import LocalProxy
+from flask import _app_ctx_stack, current_app
+from sqlalchemy.orm import scoped_session
+
+
+import os
+
+
+__all__ = ["current_session", "flask_scoped_session"]
+
+# Plan for only using threading.
+from threading import get_ident as get_cur_thread
+
+
+def _get_session():
+    # pylint: disable=missing-docstring, protected-access
+    context = _app_ctx_stack.top
+    if context is None:
+        raise RuntimeError(
+            "Cannot access current_session when outside of an application " "context."
+        )
+    app = current_app._get_current_object()
+    if not hasattr(app, "scoped_session"):
+        raise AttributeError(
+            "{0} has no 'scoped_session' attribute. You need to initialize it "
+            "with a flask_scoped_session.".format(app)
+        )
+    return app.scoped_session
+
+
+current_session = LocalProxy(_get_session)
+"""Provides the current SQL Alchemy session within a request.
+
+Will raise an exception if no :data:`~flask.current_app` is available or it has
+not been initialized with a :class:`flask_scoped_session`
+"""
+
+
+class flask_scoped_session(scoped_session):
+    """A :class:`~sqlalchemy.orm.scoping.scoped_session` whose scope is set to
+    the Flask application context.
+    """
+
+    def __init__(self, session_factory, app=None):
+        """
+        :param session_factory: A callable that returns a
+            :class:`~sqlalchemy.orm.session.Session`
+        :param app: a :class:`~flask.Flask` application
+        """
+        super(flask_scoped_session, self).__init__(
+            session_factory, scopefunc=get_cur_thread
+        )
+        # the _app_ctx_stack.__ident_func__ is the greenlet.get_current, or
+        # thread.get_ident if no greenlets are used.
+        # each Flask request is launched in a seperate greenlet/thread, so our
+        # session is unique per request
+        # _app_ctx_stack looks like internal API but is the only way to get to
+        # the active application context without adding logic to figure out
+        # whether threads, greenlets, or something else is used to create new
+        # application contexts. Keep in mind to refactor if Flask changes its
+        # public/private API towards this.
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app):
+        """Setup scoped session creation and teardown for the passed ``app``.
+
+        :param app: a :class:`~flask.Flask` application
+        """
+        app.scoped_session = self
+
+        @app.teardown_appcontext
+        def remove_scoped_session(*args, **kwargs):
+            # pylint: disable=missing-docstring,unused-argument,unused-variable
+            app.scoped_session.remove()

--- a/conbench/dbsession.py
+++ b/conbench/dbsession.py
@@ -11,14 +11,13 @@ request.
 """
 import os
 
-from werkzeug.local import LocalProxy
 from flask import _app_ctx_stack, current_app
 from sqlalchemy.orm import scoped_session
+from werkzeug.local import LocalProxy
 
 # This is the SQLAlchemy session object which is meant to be used outside
 # HTTP request context.
 from conbench.db import _session
-
 
 __all__ = ["current_session", "flask_scoped_session"]
 

--- a/conbench/entities/_entity.py
+++ b/conbench/entities/_entity.py
@@ -8,11 +8,13 @@ from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 from sqlalchemy.orm import declarative_base, mapped_column
 from sqlalchemy.orm.exc import NoResultFound
 
+
+from conbench.dbsession import current_session
+
 # Use stdlib once that's there:
 # https://github.com/python/cpython/issues/102461
 from uuid_extensions import uuid7
 
-from conbench.db import Session
 
 Base = declarative_base()
 NotNull = functools.partial(mapped_column, nullable=False)
@@ -75,16 +77,16 @@ class EntityMixin(Generic[T]):
 
     @classmethod
     def count(cls):
-        return Session.query(cls).count()
+        return current_session.query(cls).count()
 
     @classmethod
     def distinct(cls, column, filters):
-        q = Session.query(distinct(column))
+        q = current_session.query(distinct(column))
         return q.filter(*filters).all()
 
     @classmethod
     def search(cls, filters, joins=None, order_by=None, limit=None):
-        q = Session.query(cls)
+        q = current_session.query(cls)
         if joins:
             for join in joins:
                 q = q.join(join)
@@ -112,10 +114,10 @@ class EntityMixin(Generic[T]):
         # interface, the object will stay around in 2.0 but will no longer be
         # part of documentation nor will it be supported for the most part. The
         # select() construct now suits both the Core and ORM use cases, which
-        # when invoked via the Session.execute() method will return
+        # when invoked via the current_session.execute() method will return
         # ORM-oriented results, that is, ORM objects if that’s what was
         # requested.""
-        query = Session.query(cls)
+        query = current_session.query(cls)
         if filter_args:
             query = query.filter(*filter_args)
         if kwargs:
@@ -128,23 +130,23 @@ class EntityMixin(Generic[T]):
 
     @classmethod
     def get(cls, _id):
-        return Session().get(cls, _id)
+        return current_session.get(cls, _id)
 
     @classmethod
     def one(cls, **kwargs):
         try:
-            return Session.query(cls).filter_by(**kwargs).one()
+            return current_session.query(cls).filter_by(**kwargs).one()
         except NoResultFound:
             raise NotFound()
 
     @classmethod
     def first(cls, **kwargs):
-        return Session.scalars(select(cls).filter_by(**kwargs)).first()
+        return current_session.scalars(select(cls).filter_by(**kwargs)).first()
 
     @classmethod
     def delete_all(cls):
-        Session.query(cls).delete()
-        Session.commit()
+        current_session.query(cls).delete()
+        current_session.commit()
 
     @classmethod
     def create(cls, data):
@@ -156,13 +158,13 @@ class EntityMixin(Generic[T]):
     def upsert_do_nothing(cls, row_list: List[dict]):
         """Try to insert rows. If there is a conflict on any row, ignore that row."""
         statement = postgresql_insert(cls).values(row_list).on_conflict_do_nothing()
-        Session.execute(statement)
-        Session.commit()
+        current_session.execute(statement)
+        current_session.commit()
 
     @classmethod
     def bulk_save_objects(self, bulk):
-        Session.bulk_save_objects(bulk)
-        Session.commit()
+        current_session.bulk_save_objects(bulk)
+        current_session.commit()
 
     def update(self, data):
         for field, value in data.items():
@@ -170,12 +172,12 @@ class EntityMixin(Generic[T]):
         self.save()
 
     def save(self):
-        Session.add(self)
-        Session.commit()
+        current_session.add(self)
+        current_session.commit()
 
     def delete(self):
-        Session.delete(self)
-        Session.commit()
+        current_session.delete(self)
+        current_session.commit()
 
     @classmethod
     def get_or_create(cls: Type[T], props: Dict) -> T:
@@ -188,16 +190,16 @@ class EntityMixin(Generic[T]):
         """
 
         def _fetch_first():
-            return Session.scalars(select(cls).filter_by(**props)).first()
+            return current_session.scalars(select(cls).filter_by(**props)).first()
 
         result = _fetch_first()
         if result is not None:
             return result
 
         obj = cls(**props)
-        Session.add(obj)
+        current_session.add(obj)
         try:
-            Session.commit()
+            current_session.commit()
             return obj
         except sqlalchemy.exc.IntegrityError as exc:
             if "violates unique constraint" not in str(exc):
@@ -206,7 +208,7 @@ class EntityMixin(Generic[T]):
         # When we end up here it means that a unique key constraint was
         # violated. We did hit a narrow race condition: query failed, creation
         # failed. Query again.
-        Session.rollback()
+        current_session.rollback()
         result = _fetch_first()
         assert result is not None
         return result

--- a/conbench/entities/_entity.py
+++ b/conbench/entities/_entity.py
@@ -8,13 +8,11 @@ from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 from sqlalchemy.orm import declarative_base, mapped_column
 from sqlalchemy.orm.exc import NoResultFound
 
-
-from conbench.dbsession import current_session
-
 # Use stdlib once that's there:
 # https://github.com/python/cpython/issues/102461
 from uuid_extensions import uuid7
 
+from conbench.dbsession import current_session
 
 Base = declarative_base()
 NotNull = functools.partial(mapped_column, nullable=False)

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -16,9 +16,8 @@ from sqlalchemy import select
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import Mapped, relationship
 
-from conbench.dbsession import current_session
-
 import conbench.util
+from conbench.dbsession import current_session
 from conbench.numstr import numstr
 
 from ..entities._entity import (

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -16,8 +16,9 @@ from sqlalchemy import select
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import Mapped, relationship
 
+from conbench.dbsession import current_session
+
 import conbench.util
-from conbench.db import Session
 from conbench.numstr import numstr
 
 from ..entities._entity import (
@@ -831,7 +832,9 @@ def validate_run_result_consistency(userres: Any) -> None:
     Be sure to call this (latest) right before writing a BenchmarkResult object
     into the database, and after having created the Run object in the database.
     """
-    run = Session.scalars(select(Run).where(Run.id == userres["run_id"])).first()
+    run = current_session.scalars(
+        select(Run).where(Run.id == userres["run_id"])
+    ).first()
 
     if run is None:
         return

--- a/conbench/entities/commit.py
+++ b/conbench/entities/commit.py
@@ -12,9 +12,8 @@ import requests
 import sqlalchemy as s
 from sqlalchemy.orm import Mapped, Query, relationship
 
-from conbench.dbsession import current_session
-
 from conbench import metrics, util
+from conbench.dbsession import current_session
 
 from ..config import Config
 from ..entities._entity import (

--- a/conbench/entities/commit.py
+++ b/conbench/entities/commit.py
@@ -12,10 +12,11 @@ import requests
 import sqlalchemy as s
 from sqlalchemy.orm import Mapped, Query, relationship
 
+from conbench.dbsession import current_session
+
 from conbench import metrics, util
 
 from ..config import Config
-from ..db import Session
 from ..entities._entity import (
     Base,
     EntityMixin,
@@ -214,7 +215,7 @@ class Commit(Base, EntityMixin):
             raise CantFindAncestorCommitsError("fork_point_commit timestamp is null")
 
         # Get default branch commits before/including the fork point
-        query = Session.query(
+        query = current_session.query(
             Commit.id.label("ancestor_id"),
             Commit.timestamp.label("ancestor_timestamp"),
             s.sql.expression.literal(True, s.Boolean).label("on_default_branch"),
@@ -227,7 +228,7 @@ class Commit(Base, EntityMixin):
 
         # If this commit is on a non-default branch, add all commits since the fork point
         if self != fork_point_commit:
-            branch_query = Session.query(
+            branch_query = current_session.query(
                 Commit.id.label("ancestor_id"),
                 Commit.timestamp.label("ancestor_timestamp"),
                 s.sql.expression.literal(False, s.Boolean).label("on_default_branch"),

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -11,9 +11,8 @@ import sqlalchemy as s
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from conbench.dbsession import current_session
-
 import conbench.util
+from conbench.dbsession import current_session
 
 from ..entities._entity import (
     Base,

--- a/conbench/tests/api/_fixtures.py
+++ b/conbench/tests/api/_fixtures.py
@@ -2,6 +2,7 @@ import copy
 from datetime import datetime
 from typing import Dict, List, Tuple
 
+from ...db import _session as dbsession
 from ...entities.benchmark_result import BenchmarkResult
 from ...entities.commit import Commit
 from ...entities.run import SchemaGitHubCreate
@@ -293,7 +294,9 @@ def benchmark_result(
     if error is not None:
         data["error"] = error
 
-    return BenchmarkResult.create(data)
+    result = BenchmarkResult.create(data)
+    dbsession.commit()
+    return result
 
 
 def gen_fake_data(

--- a/conbench/tests/api/test_users.py
+++ b/conbench/tests/api/test_users.py
@@ -4,6 +4,7 @@ import pytest
 
 from ...api._examples import _api_user_entity
 from ...config import TestConfig
+from ...db import _session as dbsession
 from ...entities._entity import NotFound
 from ...entities.user import User
 from ...tests.api import _asserts
@@ -116,6 +117,8 @@ class TestUserPut(_asserts.PutEnforcer):
         # update name
         data = {"name": "Updated name"}
         response = client.put(f"/api/users/{self.fixture_user.id}/", json=data)
+
+        dbsession.commit()
 
         # after
         after = User.one(id=self.fixture_user.id)

--- a/conbench/tests/api/test_users.py
+++ b/conbench/tests/api/test_users.py
@@ -140,6 +140,8 @@ class TestUserPut(_asserts.PutEnforcer):
         data = self.valid_payload
         response = client.put(f"/api/users/{self.fixture_user.id}/", json=data)
 
+        dbsession.commit()
+
         # after
         after = User.one(id=self.fixture_user.id)
         self.assert_200_ok(response, _expected_entity(after))

--- a/conbench/tests/conftest.py
+++ b/conbench/tests/conftest.py
@@ -2,7 +2,8 @@ import pytest
 
 from .. import create_application
 from ..config import TestConfig
-from ..db import Session, configure_engine, create_all, drop_all, empty_db_tables
+from ..db import _session as Session
+from ..db import configure_engine, create_all, drop_all, empty_db_tables
 
 pytest.register_assert_rewrite("conbench.tests.api._asserts")
 pytest.register_assert_rewrite("conbench.tests.app._asserts")

--- a/conbench/tests/entities/test_history.py
+++ b/conbench/tests/entities/test_history.py
@@ -7,7 +7,7 @@ import pytest
 import sigfig
 import sqlalchemy as s
 
-from ...db import Session
+from ...db import _session as Session
 from ...entities.commit import Commit
 from ...entities.history import (
     _detect_shifts_with_trimmed_estimators,


### PR DESCRIPTION
For https://github.com/conbench/conbench/issues/1300.

The out-of-band database interaction from within the test suite was particularly painful here, but I think it also revealed that we had a problem there: re-using the same session/sessionmaker object without clear teardown/isolation points.