### PR TITLE
benchalerts: include hardware names in messages

### DIFF
--- a/benchalerts/benchalerts/conbench_dataclasses.py
+++ b/benchalerts/benchalerts/conbench_dataclasses.py
@@ -17,6 +17,7 @@ class BenchmarkResultInfo:
     run_id: str
     run_reason: str
     run_time: str
+    run_hardware: str
     run_link: str
 
 
@@ -80,6 +81,7 @@ class RunComparisonInfo:
                     run_id=self.contender_id,
                     run_reason=self.contender_reason,
                     run_time=self.contender_datetime,
+                    run_hardware=self.contender_hardware_name,
                     run_link=self.run_compare_link,
                 )
                 for comparison in self.compare_results
@@ -100,6 +102,7 @@ class RunComparisonInfo:
                     run_id=self.contender_id,
                     run_reason=self.contender_reason,
                     run_time=self.contender_datetime,
+                    run_hardware=self.contender_hardware_name,
                     run_link=self.contender_link,
                 )
                 for benchmark_result in self.benchmark_results
@@ -117,6 +120,11 @@ class RunComparisonInfo:
         """The contender run datetime."""
         dt: str = self.contender_info["timestamp"]
         return dt.replace("T", " ")
+
+    @property
+    def contender_hardware_name(self) -> str:
+        """The contender run machine."""
+        return self.contender_info["hardware"]["name"]
 
     @property
     def contender_link(self) -> str:

--- a/benchalerts/benchalerts/message_formatting.py
+++ b/benchalerts/benchalerts/message_formatting.py
@@ -28,8 +28,8 @@ class _Pluralizer:
         return "s" if self.plural else ""
 
 
-def _run_bullet(reason: str, time: str, link: str) -> str:
-    return f"- {reason.title()} Run at [{time}]({link})"
+def _run_bullet(reason: str, time: str, link: str, hardware: str) -> str:
+    return f"- {reason.title()} Run on `{hardware}` at [{time}]({link})"
 
 
 def _list_results(
@@ -52,6 +52,7 @@ def _list_results(
                 benchmark_result.run_reason,
                 benchmark_result.run_time,
                 benchmark_result.run_link,
+                benchmark_result.run_hardware,
             )
             previous_run_id = benchmark_result.run_id
         out += f"\n  - [{benchmark_result.name}]({benchmark_result.link})"
@@ -161,6 +162,7 @@ def github_check_summary(
             comparison.contender_reason,
             comparison.contender_datetime,
             comparison.contender_link,
+            comparison.contender_hardware_name,
         )
 
     return summary

--- a/benchalerts/tests/unit_tests/expected_md/comment_errors_baselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_errors_baselines.md
@@ -2,14 +2,14 @@ Conbench analyzed the 3 benchmark runs on commit `abc`.
 
 There were 3 benchmark results with an error:
 
-- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
+- Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
   - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmark-results/some-benchmark-uuid-4)
   - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmark-results/some-benchmark-uuid-4)
 - and 1 more (see the report linked below)
 
 There were 3 benchmark results indicating a performance regression:
 
-- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
+- Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
   - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
   - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
 - and 1 more (see the report linked below)

--- a/benchalerts/tests/unit_tests/expected_md/comment_errors_nobaselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_errors_nobaselines.md
@@ -2,7 +2,7 @@ Conbench analyzed the 2 benchmark runs on commit `abc`.
 
 There were 2 benchmark results with an error:
 
-- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+- Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
   - [file-write](http://localhost/benchmark-results/some-benchmark-uuid-2)
   - [file-write](http://localhost/benchmark-results/some-benchmark-uuid-2)
 

--- a/benchalerts/tests/unit_tests/expected_md/comment_regressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_regressions.md
@@ -2,7 +2,7 @@ Conbench analyzed the 3 benchmark runs on commit `abc`.
 
 There were 2 benchmark results indicating a performance regression:
 
-- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
+- Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
   - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
   - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
 

--- a/benchalerts/tests/unit_tests/expected_md/summary_errors_baselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_errors_baselines.md
@@ -4,7 +4,7 @@ Conbench analyzed the 3 benchmark runs on commit `abc`.
 
 These are errors that were caught while running the benchmarks. You can click each link to go to the Conbench entry for that benchmark, which might have more information about what the error was.
 
-- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
+- Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
   - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmark-results/some-benchmark-uuid-4)
   - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmark-results/some-benchmark-uuid-4)
   - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmark-results/some-benchmark-uuid-4)
@@ -15,13 +15,13 @@ There were 3 possible performance regressions, according to the lookback z-score
 
 ### Benchmarks with regressions:
 
-- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
+- Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
   - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
   - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
   - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
 
 ## All benchmark runs analyzed:
 
-- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
-- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
-- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+- Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+- Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+- Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)

--- a/benchalerts/tests/unit_tests/expected_md/summary_errors_nobaselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_errors_nobaselines.md
@@ -4,7 +4,7 @@ Conbench analyzed the 2 benchmark runs on commit `abc`.
 
 These are errors that were caught while running the benchmarks. You can click each link to go to the Conbench entry for that benchmark, which might have more information about what the error was.
 
-- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+- Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
   - [file-write](http://localhost/benchmark-results/some-benchmark-uuid-2)
   - [file-write](http://localhost/benchmark-results/some-benchmark-uuid-2)
 

--- a/benchalerts/tests/unit_tests/expected_md/summary_nocommit.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_nocommit.md
@@ -6,5 +6,5 @@ There were 0 possible performance regressions, according to the lookback z-score
 
 ## All benchmark runs analyzed:
 
-- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/no_commit)
-- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/no_commit)
+- Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/no_commit)
+- Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/no_commit)

--- a/benchalerts/tests/unit_tests/expected_md/summary_noregressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_noregressions.md
@@ -6,5 +6,5 @@ There were 0 possible performance regressions, according to the lookback z-score
 
 ## All benchmark runs analyzed:
 
-- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
-- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+- Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+- Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)

--- a/benchalerts/tests/unit_tests/expected_md/summary_regressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_regressions.md
@@ -6,12 +6,12 @@ There were 2 possible performance regressions, according to the lookback z-score
 
 ### Benchmarks with regressions:
 
-- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
+- Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
   - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
   - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
 
 ## All benchmark runs analyzed:
 
-- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
-- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
-- Some Run Reason Run at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+- Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+- Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+- Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)


### PR DESCRIPTION
Fixes #1322.

Also helps with https://github.com/conbench/conbench/issues/748 since we've deployed the latest changes to the Arrow and Velox instances that we test against.