### PR TITLE
benchalerts: allow check/comment customization

### DIFF
--- a/benchalerts/benchalerts/__init__.py
+++ b/benchalerts/benchalerts/__init__.py
@@ -15,5 +15,6 @@
 from . import pipeline_steps
 from ._version import __version__
 from .alert_pipeline import AlertPipeline
+from .message_formatting import Alerter
 
-__all__ = ["__version__", "AlertPipeline", "pipeline_steps"]
+__all__ = ["__version__", "Alerter", "AlertPipeline", "pipeline_steps"]

--- a/benchalerts/benchalerts/message_formatting.py
+++ b/benchalerts/benchalerts/message_formatting.py
@@ -4,11 +4,7 @@ import textwrap
 from typing import List, Optional
 
 from .conbench_dataclasses import BenchmarkResultInfo, FullComparisonInfo
-
-
-def _clean(text: str) -> str:
-    """Clean text so it displays nicely as GitHub Markdown."""
-    return textwrap.fill(textwrap.dedent(text), 10000).replace("  ", "\n\n").strip()
+from .integrations.github import CheckStatus
 
 
 class _Pluralizer:
@@ -63,201 +59,245 @@ def _list_results(
     return out
 
 
-def _intro_sentence(full_comparison: FullComparisonInfo) -> str:
-    """Generate a Markdown sentence to introduce a message."""
-    s = _Pluralizer(full_comparison.run_comparisons).s
-    if full_comparison.commit_hash:
-        intro = _clean(
-            f"""
-            Conbench analyzed the {len(full_comparison.run_comparisons)} benchmark
-            run{s} on commit `{full_comparison.commit_hash[:8]}`.
-            """
-        )
-    else:
-        intro = _clean(
-            f"""
-            Conbench analyzed the {len(full_comparison.run_comparisons)} benchmark
-            run{s} that triggered this notification.
-            """
-        )
-    return intro + "\n\n"
+class Alerter:
+    """A class to generate default messages and statuses for alerting. You can override
+    any methods for your project's custom settings.
+    """
 
+    @staticmethod
+    def clean(text: str) -> str:
+        """A small helper: clean block text so it displays nicely as GitHub Markdown."""
+        return textwrap.fill(textwrap.dedent(text), 10000).replace("  ", "\n\n").strip()
 
-def github_check_summary(
-    full_comparison: FullComparisonInfo, build_url: Optional[str]
-) -> str:
-    """Generate a Markdown summary of what happened regarding errors and regressions."""
-    summary = _intro_sentence(full_comparison)
-
-    if not full_comparison.has_any_contender_runs:
-        summary += _clean(
-            """
-            None of the specified runs were found on the Conbench server.
-            """
-        )
-        if build_url:
-            summary += f" See the [build logs]({build_url}) for more information."
-        # exit early
-        return summary
-
-    if not full_comparison.has_any_contender_results:
-        summary += _clean(
-            """
-            None of the specified runs had any associated benchmark results.
-            """
-        )
-        if build_url:
-            summary += f" See the [build logs]({build_url}) for more information."
-        # exit early
-        return summary
-
-    if full_comparison.results_with_errors:
-        summary += _clean(
-            """
-            ## Benchmarks with errors
-
-            These are errors that were caught while running the benchmarks. You can
-            click each link to go to the Conbench entry for that benchmark, which might
-            have more information about what the error was.
-            """
-        )
-        summary += _list_results(full_comparison.results_with_errors)
-
-    summary += "## Benchmarks with performance regressions\n\n"
-
-    if not full_comparison.has_any_z_analyses:
-        summary += _clean(
-            """
-            There weren't enough matching historic runs in Conbench to make a call on
-            whether there were regressions or not.
-
-            To use the lookback z-score method of determining regressions, there need to
-            be at least two historic runs on the default branch which, when compared to
-            one of the runs on the contender commit, are on the same hardware, and have
-            at least one of the same benchmark case and context pairs.
-            """
-        )
-        # exit early
-        return summary
-
-    pluralizer = _Pluralizer(full_comparison.results_with_z_regressions)
-    were = pluralizer.were
-    s = pluralizer.s
-    summary += _clean(
-        f"""
-        There {were} {len(full_comparison.results_with_z_regressions)} possible
-        performance regression{s}, according to the lookback z-score method.
-        """
-    )
-    summary += "\n\n"
-
-    if full_comparison.results_with_z_regressions:
-        summary += "### Benchmarks with regressions:"
-        summary += _list_results(full_comparison.results_with_z_regressions)
-
-    summary += "## All benchmark runs analyzed:\n"
-    for comparison in full_comparison.run_comparisons:
-        summary += "\n"
-        summary += _run_bullet(
-            comparison.contender_reason,
-            comparison.contender_datetime,
-            comparison.contender_link,
-            comparison.contender_hardware_name,
-        )
-
-    return summary
-
-
-def github_check_details(full_comparison: FullComparisonInfo) -> Optional[str]:
-    """Generate Markdown details of what happened regarding regressions."""
-    details = ""
-
-    if not full_comparison.commit_hash:
-        details += _clean(
-            """
-            This report was not associated with any commit connected to the git graph.
-            This probably means that benchmarks were run on a transient merge-commit.
-            """
-        )
-        details += "\n\n"
-
-    if full_comparison.has_any_z_analyses:
-        details += _clean(
-            f"""
-            This report was generated using the lookback z-score method with a z-score
-            threshold of {full_comparison.z_score_threshold}.
-            """
-        )
-
-    return details or None
-
-
-def pr_comment_link_to_check(
-    full_comparison: FullComparisonInfo, check_link: str
-) -> str:
-    """Generate a GitHub PR comment that summarizes and links to a GitHub Check."""
-    comment = _intro_sentence(full_comparison)
-
-    if not full_comparison.has_any_contender_runs:
-        comment += _clean(
-            """
-            None of the specified runs were found on the Conbench server.
-            """
-        )
-        comment += "\n\n"
-    elif not full_comparison.has_any_contender_results:
-        comment += _clean(
-            """
-            None of the specified runs had any associated benchmark results.
-            """
-        )
-        comment += "\n\n"
-    else:
-        if full_comparison.results_with_errors:
-            pluralizer = _Pluralizer(full_comparison.results_with_errors)
-            were = pluralizer.were
-            s = pluralizer.s
-            comment += _clean(
+    def intro_sentence(self, full_comparison: FullComparisonInfo) -> str:
+        """Generate a Markdown sentence to introduce a message."""
+        s = _Pluralizer(full_comparison.run_comparisons).s
+        if full_comparison.commit_hash:
+            intro = self.clean(
                 f"""
-                There {were} {len(full_comparison.results_with_errors)} benchmark
-                result{s} with an error:
+                Conbench analyzed the {len(full_comparison.run_comparisons)} benchmark
+                run{s} on commit `{full_comparison.commit_hash[:8]}`.
                 """
-            )
-            comment += _list_results(full_comparison.results_with_errors, limit=2)
-
-        if not full_comparison.has_any_z_analyses:
-            comment += _clean(
-                """
-                There weren't enough matching historic benchmark results to make a call
-                on whether there were regressions.
-                """
-            )
-            comment += "\n\n"
-        elif full_comparison.results_with_z_regressions:
-            pluralizer = _Pluralizer(full_comparison.results_with_z_regressions)
-            were = pluralizer.were
-            s = pluralizer.s
-            comment += _clean(
-                f"""
-                There {were} {len(full_comparison.results_with_z_regressions)} benchmark
-                result{s} indicating a performance regression:
-                """
-            )
-            comment += _list_results(
-                full_comparison.results_with_z_regressions, limit=2
             )
         else:
-            comment += _clean(
+            intro = self.clean(
+                f"""
+                Conbench analyzed the {len(full_comparison.run_comparisons)} benchmark
+                run{s} that triggered this notification.
                 """
-                There were no benchmark performance regressions. 🎉
+            )
+        return intro + "\n\n"
+
+    def github_check_status(self, full_comparison: FullComparisonInfo) -> CheckStatus:
+        """Return a different status based on errors and regressions."""
+        if full_comparison.results_with_errors:
+            # results with errors require action
+            return CheckStatus.ACTION_REQUIRED
+        elif full_comparison.results_with_z_regressions:
+            # no errors, but results with regressions are still a failure
+            return CheckStatus.FAILURE
+        elif full_comparison.has_any_z_analyses:
+            # we analyzed z-scores and didn't find errors or regressions
+            return CheckStatus.SUCCESS
+        elif full_comparison.has_any_contender_results:
+            # we have results but couldn't analyze z-scores
+            # (normal at beginning of history)
+            return CheckStatus.SKIPPED
+        else:
+            # we don't have results; this requires action
+            return CheckStatus.ACTION_REQUIRED
+
+    def github_check_title(self, full_comparison: FullComparisonInfo) -> str:
+        if full_comparison.results_with_errors:
+            return "Some benchmarks had errors"
+        elif not full_comparison.has_any_z_analyses:
+            return "Could not do the lookback z-score analysis"
+        else:
+            pluralizer = _Pluralizer(full_comparison.results_with_z_regressions)
+            s = pluralizer.s
+            return (
+                f"Found {len(full_comparison.results_with_z_regressions)} regression{s}"
+            )
+
+    def github_check_summary(
+        self, full_comparison: FullComparisonInfo, build_url: Optional[str]
+    ) -> str:
+        """Generate a Markdown summary of what happened regarding errors and
+        regressions.
+        """
+        summary = self.intro_sentence(full_comparison)
+
+        if not full_comparison.has_any_contender_runs:
+            summary += self.clean(
+                """
+                None of the specified runs were found on the Conbench server.
+                """
+            )
+            if build_url:
+                summary += f" See the [build logs]({build_url}) for more information."
+            # exit early
+            return summary
+
+        if not full_comparison.has_any_contender_results:
+            summary += self.clean(
+                """
+                None of the specified runs had any associated benchmark results.
+                """
+            )
+            if build_url:
+                summary += f" See the [build logs]({build_url}) for more information."
+            # exit early
+            return summary
+
+        if full_comparison.results_with_errors:
+            summary += self.clean(
+                """
+                ## Benchmarks with errors
+
+                These are errors that were caught while running the benchmarks. You can
+                click each link to go to the Conbench entry for that benchmark, which
+                might have more information about what the error was.
+                """
+            )
+            summary += _list_results(full_comparison.results_with_errors)
+
+        summary += "## Benchmarks with performance regressions\n\n"
+
+        if not full_comparison.has_any_z_analyses:
+            summary += self.clean(
+                """
+                There weren't enough matching historic runs in Conbench to make a call
+                on whether there were regressions or not.
+
+                To use the lookback z-score method of determining regressions, there
+                need to be at least two historic runs on the default branch which, when
+                compared to one of the runs on the contender commit, are on the same
+                hardware, and have at least one of the same benchmark case and context
+                pairs.
+                """
+            )
+            # exit early
+            return summary
+
+        pluralizer = _Pluralizer(full_comparison.results_with_z_regressions)
+        were = pluralizer.were
+        s = pluralizer.s
+        summary += self.clean(
+            f"""
+            There {were} {len(full_comparison.results_with_z_regressions)} possible
+            performance regression{s}, according to the lookback z-score method.
+            """
+        )
+        summary += "\n\n"
+
+        if full_comparison.results_with_z_regressions:
+            summary += "### Benchmarks with regressions:"
+            summary += _list_results(full_comparison.results_with_z_regressions)
+
+        summary += "## All benchmark runs analyzed:\n"
+        for comparison in full_comparison.run_comparisons:
+            summary += "\n"
+            summary += _run_bullet(
+                comparison.contender_reason,
+                comparison.contender_datetime,
+                comparison.contender_link,
+                comparison.contender_hardware_name,
+            )
+
+        return summary
+
+    def github_check_details(
+        self, full_comparison: FullComparisonInfo
+    ) -> Optional[str]:
+        """Generate Markdown details of what happened regarding regressions."""
+        details = ""
+
+        if not full_comparison.commit_hash:
+            details += self.clean(
+                """
+                This report was not associated with any commit connected to the git
+                graph. This probably means that benchmarks were run on a transient
+                merge-commit.
+                """
+            )
+            details += "\n\n"
+
+        if full_comparison.has_any_z_analyses:
+            details += self.clean(
+                f"""
+                This report was generated using the lookback z-score method with a
+                z-score threshold of {full_comparison.z_score_threshold}.
+                """
+            )
+
+        return details or None
+
+    def github_pr_comment(
+        self, full_comparison: FullComparisonInfo, check_link: str
+    ) -> str:
+        """Generate a GitHub PR comment that summarizes and links to a GitHub Check."""
+        comment = self.intro_sentence(full_comparison)
+
+        if not full_comparison.has_any_contender_runs:
+            comment += self.clean(
+                """
+                None of the specified runs were found on the Conbench server.
                 """
             )
             comment += "\n\n"
+        elif not full_comparison.has_any_contender_results:
+            comment += self.clean(
+                """
+                None of the specified runs had any associated benchmark results.
+                """
+            )
+            comment += "\n\n"
+        else:
+            if full_comparison.results_with_errors:
+                pluralizer = _Pluralizer(full_comparison.results_with_errors)
+                were = pluralizer.were
+                s = pluralizer.s
+                comment += self.clean(
+                    f"""
+                    There {were} {len(full_comparison.results_with_errors)} benchmark
+                    result{s} with an error:
+                    """
+                )
+                comment += _list_results(full_comparison.results_with_errors, limit=2)
 
-    comment += _clean(
-        f"""
-        The [full Conbench report]({check_link}) has more details.
-        """
-    )
+            if not full_comparison.has_any_z_analyses:
+                comment += self.clean(
+                    """
+                    There weren't enough matching historic benchmark results to make a
+                    call on whether there were regressions.
+                    """
+                )
+                comment += "\n\n"
+            elif full_comparison.results_with_z_regressions:
+                pluralizer = _Pluralizer(full_comparison.results_with_z_regressions)
+                were = pluralizer.were
+                s = pluralizer.s
+                comment += self.clean(
+                    f"""
+                    There {were} {len(full_comparison.results_with_z_regressions)}
+                    benchmark result{s} indicating a performance regression:
+                    """
+                )
+                comment += _list_results(
+                    full_comparison.results_with_z_regressions, limit=2
+                )
+            else:
+                comment += self.clean(
+                    """
+                    There were no benchmark performance regressions. 🎉
+                    """
+                )
+                comment += "\n\n"
 
-    return comment
+        comment += self.clean(
+            f"""
+            The [full Conbench report]({check_link}) has more details.
+            """
+        )
+
+        return comment

--- a/benchalerts/benchalerts/pipeline_steps/github.py
+++ b/benchalerts/benchalerts/pipeline_steps/github.py
@@ -133,8 +133,8 @@ class GitHubPRCommentAboutCheckStep(AlertPipelineStep):
         The name for this step. If not given, will default to this class's name.
     alerter
         Advanced usage; should not be necessary in most cases. An optional Alerter
-        instance to use to format the GitHub Check's status, title, summary, and
-        details. If not provided, will default to ``Alerter()``.
+        instance to use to format the comment. If not provided, will default to
+        ``Alerter()``.
 
     Returns
     -------

--- a/benchalerts/tests/unit_tests/expected_md/comment_errors_baselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_errors_baselines.md
@@ -15,3 +15,5 @@ There were 3 benchmark results indicating a performance regression:
 - and 1 more (see the report linked below)
 
 The [full Conbench report](https://github.com/github/hello-world/runs/4) has more details.
+
+This message was generated from pytest.

--- a/benchalerts/tests/unit_tests/expected_md/comment_errors_nobaselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_errors_nobaselines.md
@@ -9,3 +9,5 @@ There were 2 benchmark results with an error:
 There weren't enough matching historic benchmark results to make a call on whether there were regressions.
 
 The [full Conbench report](https://github.com/github/hello-world/runs/4) has more details.
+
+This message was generated from pytest.

--- a/benchalerts/tests/unit_tests/expected_md/comment_nocommit.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_nocommit.md
@@ -3,3 +3,5 @@ Conbench analyzed the 2 benchmark runs that triggered this notification.
 There were no benchmark performance regressions. 🎉
 
 The [full Conbench report](https://github.com/github/hello-world/runs/4) has more details.
+
+This message was generated from pytest.

--- a/benchalerts/tests/unit_tests/expected_md/comment_noerrors_nobaselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_noerrors_nobaselines.md
@@ -3,3 +3,5 @@ Conbench analyzed the 2 benchmark runs on commit `abc`.
 There weren't enough matching historic benchmark results to make a call on whether there were regressions.
 
 The [full Conbench report](https://github.com/github/hello-world/runs/4) has more details.
+
+This message was generated from pytest.

--- a/benchalerts/tests/unit_tests/expected_md/comment_noregressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_noregressions.md
@@ -3,3 +3,5 @@ Conbench analyzed the 2 benchmark runs on commit `abc`.
 There were no benchmark performance regressions. 🎉
 
 The [full Conbench report](https://github.com/github/hello-world/runs/4) has more details.
+
+This message was generated from pytest.

--- a/benchalerts/tests/unit_tests/expected_md/comment_noresults.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_noresults.md
@@ -3,3 +3,5 @@ Conbench analyzed the 1 benchmark run on commit `abc`.
 None of the specified runs had any associated benchmark results.
 
 The [full Conbench report](https://github.com/github/hello-world/runs/4) has more details.
+
+This message was generated from pytest.

--- a/benchalerts/tests/unit_tests/expected_md/comment_noruns.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_noruns.md
@@ -3,3 +3,5 @@ Conbench analyzed the 0 benchmark runs that triggered this notification.
 None of the specified runs were found on the Conbench server.
 
 The [full Conbench report](https://github.com/github/hello-world/runs/4) has more details.
+
+This message was generated from pytest.

--- a/benchalerts/tests/unit_tests/expected_md/comment_regressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_regressions.md
@@ -7,3 +7,5 @@ There were 2 benchmark results indicating a performance regression:
   - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
 
 The [full Conbench report](https://github.com/github/hello-world/runs/4) has more details.
+
+This message was generated from pytest.

--- a/benchalerts/tests/unit_tests/expected_md/summary_errors_baselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_errors_baselines.md
@@ -25,3 +25,5 @@ There were 3 possible performance regressions, according to the lookback z-score
 - Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
 - Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
 - Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+
+This message was generated from pytest.

--- a/benchalerts/tests/unit_tests/expected_md/summary_errors_nobaselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_errors_nobaselines.md
@@ -13,3 +13,5 @@ These are errors that were caught while running the benchmarks. You can click ea
 There weren't enough matching historic runs in Conbench to make a call on whether there were regressions or not.
 
 To use the lookback z-score method of determining regressions, there need to be at least two historic runs on the default branch which, when compared to one of the runs on the contender commit, are on the same hardware, and have at least one of the same benchmark case and context pairs.
+
+This message was generated from pytest.

--- a/benchalerts/tests/unit_tests/expected_md/summary_nocommit.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_nocommit.md
@@ -8,3 +8,5 @@ There were 0 possible performance regressions, according to the lookback z-score
 
 - Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/no_commit)
 - Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/no_commit)
+
+This message was generated from pytest.

--- a/benchalerts/tests/unit_tests/expected_md/summary_noerrors_nobaselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_noerrors_nobaselines.md
@@ -5,3 +5,5 @@ Conbench analyzed the 2 benchmark runs on commit `abc`.
 There weren't enough matching historic runs in Conbench to make a call on whether there were regressions or not.
 
 To use the lookback z-score method of determining regressions, there need to be at least two historic runs on the default branch which, when compared to one of the runs on the contender commit, are on the same hardware, and have at least one of the same benchmark case and context pairs.
+
+This message was generated from pytest.

--- a/benchalerts/tests/unit_tests/expected_md/summary_noregressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_noregressions.md
@@ -8,3 +8,5 @@ There were 0 possible performance regressions, according to the lookback z-score
 
 - Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
 - Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+
+This message was generated from pytest.

--- a/benchalerts/tests/unit_tests/expected_md/summary_noresults.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_noresults.md
@@ -1,3 +1,5 @@
 Conbench analyzed the 1 benchmark run on commit `abc`.
 
 None of the specified runs had any associated benchmark results. See the [build logs](https://austin.something) for more information.
+
+This message was generated from pytest.

--- a/benchalerts/tests/unit_tests/expected_md/summary_noruns.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_noruns.md
@@ -1,3 +1,5 @@
 Conbench analyzed the 0 benchmark runs that triggered this notification.
 
 None of the specified runs were found on the Conbench server. See the [build logs](https://austin.something) for more information.
+
+This message was generated from pytest.

--- a/benchalerts/tests/unit_tests/expected_md/summary_regressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_regressions.md
@@ -15,3 +15,5 @@ There were 2 possible performance regressions, according to the lookback z-score
 - Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
 - Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
 - Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+
+This message was generated from pytest.

--- a/benchalerts/tests/unit_tests/test_pipeline_steps/test_github.py
+++ b/benchalerts/tests/unit_tests/test_pipeline_steps/test_github.py
@@ -25,14 +25,14 @@ class MockAlerter(Alerter):
     def github_check_summary(
         self, full_comparison: FullComparisonInfo, build_url: Optional[str]
     ) -> str:
-        old_message = super().github_check_summary(full_comparison, build_url)
-        return old_message + "\n\nThis message was generated from pytest."
+        previous_message = super().github_check_summary(full_comparison, build_url)
+        return previous_message + "\n\nThis message was generated from pytest."
 
     def github_pr_comment(
         self, full_comparison: FullComparisonInfo, check_link: str
     ) -> str:
-        old_message = super().github_pr_comment(full_comparison, check_link)
-        return old_message + "\n\nThis message was generated from pytest."
+        previous_message = super().github_pr_comment(full_comparison, check_link)
+        return previous_message + "\n\nThis message was generated from pytest."
 
 
 @pytest.mark.parametrize(

--- a/benchalerts/tests/unit_tests/test_pipeline_steps/test_github.py
+++ b/benchalerts/tests/unit_tests/test_pipeline_steps/test_github.py
@@ -25,14 +25,14 @@ class MockAlerter(Alerter):
     def github_check_summary(
         self, full_comparison: FullComparisonInfo, build_url: Optional[str]
     ) -> str:
-        previous_message = super().github_check_summary(full_comparison, build_url)
-        return previous_message + "\n\nThis message was generated from pytest."
+        base_message = super().github_check_summary(full_comparison, build_url)
+        return base_message + "\n\nThis message was generated from pytest."
 
     def github_pr_comment(
         self, full_comparison: FullComparisonInfo, check_link: str
     ) -> str:
-        previous_message = super().github_pr_comment(full_comparison, check_link)
-        return previous_message + "\n\nThis message was generated from pytest."
+        base_message = super().github_pr_comment(full_comparison, check_link)
+        return base_message + "\n\nThis message was generated from pytest."
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #475. Fixes #756. Fixes #1032.

This PR allows an "advanced" user to customize `benchalerts` PR comment text, and GitHub Check text and statuses. They do this by subclassing the default formatter class and overriding its methods. Some use cases for this (definitely not exhaustive)
- add internal project links in the text, or specific instructions on what to do next
- certain conceptual benchmarks may be deemed "too noisy" to create a "failure" status, so add custom status logic to handle those
- etc (see the linked issues)

This UX isn't great but it is very flexible. I think that's sufficient for the level of user that wants to implement this.