### PR TITLE
landing page: per-run result count: fix key lookup

### DIFF
--- a/conbench/app/index.py
+++ b/conbench/app/index.py
@@ -72,7 +72,7 @@ class Index(AppEndpoint, RunMixin):
             # ~10 runs, and that is provided by this approach.
             result_count = "n/a"
             if r.id in bmrt_cache["by_run_id"]:
-                result_count = str(len(bmrt_cache["by_run_id"]))
+                result_count = str(len(bmrt_cache["by_run_id"][r.id]))
 
             rd = RunForDisplay(
                 ctime_for_table=r.timestamp.strftime("%Y-%m-%d %H:%M:%S UTC"),


### PR DESCRIPTION
Currently this reports the wrong count, because I forgot to go one dimension deeper. :hole: 