### PR TITLE
UI: work on per-run view: details panel, toggle info/error JSON docs, re-structure table

### DIFF
--- a/conbench/app/results.py
+++ b/conbench/app/results.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Dict, Optional
 
@@ -154,6 +155,14 @@ class RunMixin:
         # If this run isn't associated with a commit, do no more augmentation
         if not c:
             return
+
+        run["info_json_doc_for_ui"] = ""
+        if run["info"]:
+            run["info_json_doc_for_ui"] = json.dumps(run["info"], indent=2)
+
+        run["error_info_doc_for_ui"] = ""
+        if run["error_info"]:
+            run["error_info_doc_for_ui"] = json.dumps(run["error_info"], indent=2)
 
         # Note(JP): `run["commit"]["timestamp"]` can be `None`, see
         # https://github.com/conbench/conbench/pull/651

--- a/conbench/static/app.css
+++ b/conbench/static/app.css
@@ -129,6 +129,13 @@ table.c-bench-caseperm-table th {
   font-size: 12px;
 }
 
+
+div.cb-run-details-panel {
+  background-color: #00505033;
+  padding: 15px;
+
+}
+
 span.case-parm-value {
   font-family: monospace;
   font-size: 0.7rem;

--- a/conbench/static/app.css
+++ b/conbench/static/app.css
@@ -145,7 +145,7 @@ span.case-parm-value.selected {
   background-color: #7bffff;
 }
 
-div.dead-case-parameter-box {
+div.cb-infobox {
   border: 1px solid #81257077;
   margin-top: 10px;
   padding: 15px;

--- a/conbench/templates/c-benchmark-cases.html
+++ b/conbench/templates/c-benchmark-cases.html
@@ -49,7 +49,7 @@
    aria-expanded="false"
    aria-controls="collapseDeadCaseParameters">view</a>).
     <div class="collapse" id="collapseDeadCaseParameters">
-      <div class="dead-case-parameter-box">
+      <div class="cb-infobox">
         {% for case_param_key, age_string in dead_stock_casekeys.items() %}
           <code>{{ case_param_key }}</code> ({{ age_string }})
           <br>

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -1,111 +1,111 @@
 {% extends "app.html" %}
 {% block app_content %}
-<h1>CI runs</h1>
-<div class="mt-4">
-  {% for reponame, runobjs in repo_runs_map.items() %}
-    <div class="row mb-5">
-      <h4>
-        Recent  CI runs for <strong>{{ reponame }}</strong>
-      </h4>
-      <!-- <hr class="border border-danger border-1 opacity-50"> -->
-      <!-- https://getbootstrap.com/docs/5.2/content/tables/#responsive-tables -->
-      <div class="table-responsive" style="margin-bottom: 50px">
-        <!-- wow, the width:100% on the table below is really important, otherwise
+  <h1>CI runs</h1>
+  <div class="mt-4">
+    {% for reponame, runobjs in repo_runs_map.items() %}
+      <div class="row mb-5">
+        <h4>
+          Recent  CI runs for <strong>{{ reponame }}</strong>
+        </h4>
+        <!-- <hr class="border border-danger border-1 opacity-50"> -->
+        <!-- https://getbootstrap.com/docs/5.2/content/tables/#responsive-tables -->
+        <div class="table-responsive" style="margin-bottom: 50px">
+          <!-- wow, the width:100% on the table below is really important, otherwise
      datatables might miscalculate the column widths, but only when using
      colspan in the header. I got that pointer in this thread:
      https://datatables.net/forums/discussion/comment/144435/#Comment_144435
      but otherwise spent way too much time debugging. This structure repeats,
      and only the _first_ table had properties
 -->
-        <table class="cb-runs-table table table-hover table-borderless small"
-               style="width:100%;
-                      display: none">
-          <thead>
-            {# https://datatables.net/examples/basic_init/complex_header.html #}
-            <tr>
-              <th scope="colgroup" colspan="4" style="padding-bottom:0;" class="">Run</th>
-              <th scope="colgroup" colspan="3" class="">Commit</th>
-            </tr>
-            <tr>
-              <!-- add tooltip, saying that this is DB insertion time -->
-              <th scope="col" style="width: 180px" class="cb-colgroup-run">creation time</th>
-              <th scope="col" class="cb-colgroup-run">results</th>
-              <th scope="col" class="reason-col cb-colgroup-run">reason</th>
-              <th scope="col" style="width: 150px" class="cb-colgroup-run">hardware</th>
-              <th scope="col" style="width: 170px" class="cb-colgroup-commit">author</th>
-              <th scope="col" class="commit-col cb-colgroup-commit" style="width: 90px">hash</th>
-              <th scope="col" class="cb-colgroup-commit">message</th>
-            </tr>
-          </thead>
-          <tbody class="table-group-divider">
-            {% for r in runobjs %}
-              <tr class="no-border">
-                <td>
-                  <code><a href="{{ url_for('app.run', run_id=r.run.id) }}">{{ r.ctime_for_table }}</a></code>
-                  {% if r.run.has_errors or r.run.error_info %}
-                    <i class="bi bi-exclamation-circle text-danger"
-                       data-toggle="tooltip"
-                       data-placement="top"
-                       title="This Run contains a benchmark result with an error, or is otherwise labeled as errored"></i>
-                  {% endif %}
-                </td>
-                <td>{{ r.result_count }}</td>
-                <td>
-                  {% if r.run.reason %}
-                    <div class="table-entry">{{ r.run.reason }}</div>
-                  {% else %}
-                    <div class="table-entry"></div>
-                  {% endif %}
-                </td>
-                <td>
-                  <span class="table-entry text-truncate d-inline-block"
-                        style="max-width: 140px">{{ r.run.hardware.name }}</span>
-                </td>
-                <td>
-                  <div class="table-entry">
-                    {% if r.run.commit is not none %}
-                      {% if r.run.commit.author_avatar_url is not none %}
-                        <img alt="avatar"
-                             src="{{ r.run.commit.author_avatar_url  }}"
-                             height="25"
-                             style="border-radius: 50%">
-                        &nbsp;
+          <table class="cb-runs-table table table-hover table-borderless small"
+                 style="width:100%;
+                        display: none">
+            <thead>
+              {# https://datatables.net/examples/basic_init/complex_header.html #}
+              <tr>
+                <th scope="colgroup" colspan="4" style="padding-bottom:0;" class="">Run</th>
+                <th scope="colgroup" colspan="3" class="">Commit</th>
+              </tr>
+              <tr>
+                <!-- add tooltip, saying that this is DB insertion time -->
+                <th scope="col" style="width: 180px" class="cb-colgroup-run">creation time</th>
+                <th scope="col" class="cb-colgroup-run">results</th>
+                <th scope="col" class="reason-col cb-colgroup-run">reason</th>
+                <th scope="col" style="width: 150px" class="cb-colgroup-run">hardware</th>
+                <th scope="col" style="width: 170px" class="cb-colgroup-commit">author</th>
+                <th scope="col" class="commit-col cb-colgroup-commit" style="width: 90px">hash</th>
+                <th scope="col" class="cb-colgroup-commit">message</th>
+              </tr>
+            </thead>
+            <tbody class="table-group-divider">
+              {% for r in runobjs %}
+                <tr class="no-border">
+                  <td>
+                    <code><a href="{{ url_for('app.run', run_id=r.run.id) }}">{{ r.ctime_for_table }}</a></code>
+                    {% if r.run.has_errors or r.run.error_info %}
+                      <i class="bi bi-exclamation-circle text-danger"
+                         data-toggle="tooltip"
+                         data-placement="top"
+                         title="This Run contains a benchmark result with an error, or is otherwise labeled as errored"></i>
+                    {% endif %}
+                  </td>
+                  <td>{{ r.result_count }}</td>
+                  <td>
+                    {% if r.run.reason %}
+                      <div class="table-entry">{{ r.run.reason }}</div>
+                    {% else %}
+                      <div class="table-entry"></div>
+                    {% endif %}
+                  </td>
+                  <td>
+                    <span class="table-entry text-truncate d-inline-block"
+                          style="max-width: 140px">{{ r.run.hardware.name }}</span>
+                  </td>
+                  <td>
+                    <div class="table-entry">
+                      {% if r.run.commit is not none %}
+                        {% if r.run.commit.author_avatar_url is not none %}
+                          <img alt="avatar"
+                               src="{{ r.run.commit.author_avatar_url  }}"
+                               height="25"
+                               style="border-radius: 50%">
+                          &nbsp;
+                        {% endif %}
+                        {{ r.run.commit.author_name }}
+                      {% else %}
+                        n/a
                       {% endif %}
-                      {{ r.run.commit.author_name }}
+                    </div>
+                  </td>
+                  <td>
+                    {% if r.run.commit is not none %}
+                      {% if r.run.commit.commit_url is not none %}
+                        <code><a href="{{ r.run.commit.commit_url }}">{{ r.run.commit.hash[:7] }}</a></code>
+                      {% else %}
+                        {# is this a valid scenario? when there's a hash, but no url? #}
+                        {{ r.run.commit.hash[:7] }}
+                      {% endif %}
+                      <!--NOTE: enable full commit has search while maintaining partial hash display -->
+                      <p style="display:none">{{ r.run.commit.hash }}</p>
                     {% else %}
                       n/a
                     {% endif %}
-                  </div>
-                </td>
-                <td>
-                  {% if r.run.commit is not none %}
-                    {% if r.run.commit.commit_url is not none %}
-                      <code><a href="{{ r.run.commit.commit_url }}">{{ r.run.commit.hash[:7] }}</a></code>
+                  </td>
+                  <td>
+                    {% if r.run.commit is not none %}
+                      {{ r.commit_message_short }}
                     {% else %}
-                      {# is this a valid scenario? when there's a hash, but no url? #}
-                      {{ r.run.commit.hash[:7] }}
+                      n/a
                     {% endif %}
-                    <!--NOTE: enable full commit has search while maintaining partial hash display -->
-                    <p style="display:none">{{ r.run.commit.hash }}</p>
-                  {% else %}
-                    n/a
-                  {% endif %}
-                </td>
-                <td>
-                  {% if r.run.commit is not none %}
-                    {{ r.commit_message_short }}
-                  {% else %}
-                    n/a
-                  {% endif %}
-                </td>
-              </tr>
-            {% endfor %}
-          </tbody>
-        </table>
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
       </div>
-    </div>
-  {% endfor %}
-</div>
+    {% endfor %}
+  </div>
 {% endblock %}
 {% block scripts %}
   {{ super() }}

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -1,12 +1,11 @@
 {% extends "app.html" %}
 {% block app_content %}
-  <h1 class="display-3 text-center"
-      style="margin: 40px 0 30px 0;
-             font-weight: 50">/ˈkɒnbɛnʧ/</h1>
+<h1>CI runs</h1>
+<div class="mt-4">
   {% for reponame, runobjs in repo_runs_map.items() %}
     <div class="row mb-5">
       <h4>
-        Recent runs for <strong>{{ reponame }}</strong>
+        Recent  CI runs for <strong>{{ reponame }}</strong>
       </h4>
       <!-- <hr class="border border-danger border-1 opacity-50"> -->
       <!-- https://getbootstrap.com/docs/5.2/content/tables/#responsive-tables -->
@@ -106,6 +105,7 @@
       </div>
     </div>
   {% endfor %}
+</div>
 {% endblock %}
 {% block scripts %}
   {{ super() }}

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -46,43 +46,59 @@
   </div>
   <div class="mt-5">
     <h3>Results</h3>
-    <p>All benchmark results that have submitted for this CI run:</p>
-    <table class="table results-in-run-table table-hover table-borderless small">
-      <thead>
-        <tr>
-          <th scope="col">benchmark start time</th>
-          <th scope="col" style="width: 120px">benchmark name</th>
-          <th scope="col">case permutation</th>
-          <th scope="col" style="width: 55px">mean</th>
-          <th scope="col" style="width: 55px">error</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for benchmark in benchmarks %}
+    <p> {{  benchmarks | length }} benchmark result(s) submitted for this CI run:</p>
+    <div class="mt-5">
+      <table class="table table-hover table-borderless results-in-run-table small"
+             style="width:100%;
+                    display: none">
+        <thead>
           <tr>
-            <td style="white-space: nowrap;">{{ benchmark.display_timestamp }}</td>
-            <td>
-              <a href="{{ url_for('app.batch', batch_id=benchmark.batch_id) }}">{{ benchmark.display_bmname }}</a>
-            </td>
-            <td>
-              <a href="{{ url_for('app.benchmark-result', benchmark_result_id=benchmark.id) }}">{{
-              benchmark.display_case_perm }}</a>
-            </td>
-            <td style="white-space: nowrap;">{{ benchmark.display_mean }}</td>
-            <td>
-              {% if benchmark.error %}
-                <a href="{{ url_for('app.benchmark-result', benchmark_result_id=benchmark.id) }}">
-                  <i class="glyphicon glyphicon-exclamation-sign text-danger"
-                     data-toggle="tooltip"
-                     data-placement="top"
-                     title="Has error">
-                  </i><span>Error</span></a>
+            <th scope="col" style="width: 120px">benchmark name</th>
+            <th scope="col" style="width: 150px">start time (UTC)</th>
+            <th scope="col">result</th>
+            <th scope="col">case permutation</th>
+            <!--<th scope="col" style="width: 10%">measurements</th>-->
+            <th scope="col" style="width: 8%">measurement</th>
+            <th scope="col" style="width: 10%">
+              rel err
+              <sup><i class="bi bi-info-circle"
+     data-bs-toggle="tooltip"
+     data-bs-title=" Relative standard error: standard error of the mean in relationship to the mean value. Only built when at least three samples are reported by this result. ">
+              </i></sup>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for result in benchmarks %}
+            <tr>
+              <td class="font-monospace">{{ result.display_bmname  }}</td>
+              <td class="font-monospace">{{ result.display_timestamp[:-4] }}</td>
+              <td class="font-monospace">
+                <a href="{{ url_for('app.benchmark-result', benchmark_result_id=result.id) }}">{{ result.id [:9] }}</a>
+              </td>
+              <td class="font-monospace">{{ result.display_case_perm}}</td>
+              <!--<td class="font-monospace">n/a</td>-->
+              <td class="font-monospace">
+
+                {% if result.error %}
+                <i class="bi bi-exclamation-circle text-danger"
+                   data-toggle="tooltip"
+                   data-placement="top"
+                   title="This result reported an error"></i>
+                {% else %}
+                {{ result.display_mean }}
                 {% endif %}
               </td>
+              <td class="font-monospace">n/a</td>
             </tr>
           {% endfor %}
         </tbody>
       </table>
+    </div>
+
+
+
+
     </div>
     <div class="mt-4">
       <form method="post" id="run-form">

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -2,36 +2,47 @@
 {% import 'bootstrap/wtf.html' as wtf %}
 {% block app_content %}
   <h1>CI run {{ run.id[:20] }}</h1>
-  <div class="mt-2">
-    Benchmarked code:
+  <div class="mt-4 cb-run-details-panel shadow-sm">
+    benchmarked code:
     <br>
     <ul>
-      <li>repository {{ run.commit.repository }}</li>
       <li>
-        commit <a href="{{ run.commit.url }}">{{ run.commit.display_message }}</a>
+        repository <code>{{ run.commit.display_repository }}</code>
       </li>
+      <li>commit {{ run.commit.html_anchor_and_msg | safe }}</li>
     </ul>
-    Created at: <code>{{ run.timestamp }}</code>, finished at: <code>{{ run.finished_timestamp }}</code>
+    created at: <code>{{ run.timestamp }}</code>, finished at: <code>{{ run.finished_timestamp }}</code>
     <br>
-    Error: <code>{{ run.error_type }}</code>
+    error: <code>{{ run.error_type }}</code>
     <br>
     {% if run.error_info %}
       error detail:
-      <br>
-      <pre>
-      {% for k,v in run.error_info.items() %}
-        {{ k }}:{{ v }}
-      {% endfor %}
-    </pre>
+      <a href="#"
+         class="dead-stock-params-toggle"
+         data-bs-toggle="collapse"
+         data-bs-target="#collapseErrorDetail"
+         aria-expanded="false"
+         aria-controls="collapseErrorDetail">toggle view</a>
+      <div class="collapse" id="collapseErrorDetail">
+        <div class="cb-infobox">
+          <pre>{{run.error_info_doc_for_ui}}</pre>
+        </div>
+      </div>
     {% endif %}
+    <br>
     {% if run.info %}
-      run info:
-      <br>
-      <pre>
-      {% for k,v in run.info.items() %}
-        {{ k }}:{{ v }}
-      {% endfor %}
-    </pre>
+      run information:
+      <a href="#"
+         class="dead-stock-params-toggle"
+         data-bs-toggle="collapse"
+         data-bs-target="#collapseRunInfo"
+         aria-expanded="false"
+         aria-controls="collapseRunInfo">toggle view</a>
+      <div class="collapse" id="collapseRunInfo">
+        <div class="cb-infobox">
+          <pre>{{run.info_json_doc_for_ui}}</pre>
+        </div>
+      </div>
     {% endif %}
   </div>
   <div class="mt-5">
@@ -46,7 +57,7 @@
   </div>
   <div class="mt-5">
     <h3>Results</h3>
-    <p> {{  benchmarks | length }} benchmark result(s) submitted for this CI run:</p>
+    <p>{{  benchmarks | length }} benchmark result(s) submitted for this CI run:</p>
     <div class="mt-5">
       <table class="table table-hover table-borderless results-in-run-table small"
              style="width:100%;
@@ -62,8 +73,8 @@
             <th scope="col" style="width: 10%">
               rel err
               <sup><i class="bi bi-info-circle"
-     data-bs-toggle="tooltip"
-     data-bs-title=" Relative standard error: standard error of the mean in relationship to the mean value. Only built when at least three samples are reported by this result. ">
+   data-bs-toggle="tooltip"
+   data-bs-title=" Relative standard error: standard error of the mean in relationship to the mean value. Only built when at least three samples are reported by this result. ">
               </i></sup>
             </th>
           </tr>
@@ -76,17 +87,16 @@
               <td class="font-monospace">
                 <a href="{{ url_for('app.benchmark-result', benchmark_result_id=result.id) }}">{{ result.id [:9] }}</a>
               </td>
-              <td class="font-monospace">{{ result.display_case_perm}}</td>
+              <td class="font-monospace">{{ result.display_case_perm }}</td>
               <!--<td class="font-monospace">n/a</td>-->
               <td class="font-monospace">
-
                 {% if result.error %}
-                <i class="bi bi-exclamation-circle text-danger"
-                   data-toggle="tooltip"
-                   data-placement="top"
-                   title="This result reported an error"></i>
+                  <i class="bi bi-exclamation-circle text-danger"
+                     data-toggle="tooltip"
+                     data-placement="top"
+                     title="This result reported an error"></i>
                 {% else %}
-                {{ result.display_mean }}
+                  {{ result.display_mean }}
                 {% endif %}
               </td>
               <td class="font-monospace">n/a</td>
@@ -95,26 +105,22 @@
         </tbody>
       </table>
     </div>
-
-
-
-
-    </div>
-    <div class="mt-4">
-      <form method="post" id="run-form">
-        {{ form.hidden_tag() }}
-        <input class="btn btn-outline-info btn-sm"
-               id="delete"
-               name="delete"
-               type="button"
-               value="Delete Run" />
-      </form>
-    </div>
-  {% endblock %}
-  {% block scripts %}
-    {{ super() }}
-    {{ resources | safe }}
-    <script type="text/javascript">
+  </div>
+  <div class="mt-4">
+    <form method="post" id="run-form">
+      {{ form.hidden_tag() }}
+      <input class="btn btn-outline-info btn-sm"
+             id="delete"
+             name="delete"
+             type="button"
+             value="Delete Run" />
+    </form>
+  </div>
+{% endblock %}
+{% block scripts %}
+  {{ super() }}
+  {{ resources | safe }}
+  <script type="text/javascript">
     // var table = $('#benchmarks').dataTable({
     //     "responsive": true,
     //     // Take rather precise control of layouting elements, put bottom elements
@@ -185,5 +191,5 @@
         $("#run-form").find("#delete").attr("data-cbcustom-message", "delete run: {{ run.id }}");
     });
 
-    </script>
-  {% endblock %}
+  </script>
+{% endblock %}


### PR DESCRIPTION
- in the results table show the result ID, link to result from there (unlink case perm)
- conceptualize a new "run info" panel, show it at the top, and make it visually separated
- in that panel, allow for toggling error detail, run information
- both, err and info structures are now exposed as what they are: a JSON doc
