### PR TITLE
api POST cluster: create new clusters for new optional_infos

### DIFF
--- a/conbench/entities/_entity.py
+++ b/conbench/entities/_entity.py
@@ -64,7 +64,7 @@ def to_float(value):
     return float(value) if value is not None else None
 
 
-T = TypeVar("T")
+T = TypeVar("T", bound="EntityMixin")
 
 
 class EntityMixin(Generic[T]):

--- a/conbench/entities/hardware.py
+++ b/conbench/entities/hardware.py
@@ -114,10 +114,12 @@ class Cluster(Hardware):
 
     @classmethod
     def upsert(cls, **kwargs):
-        cluster = cls.first(name=kwargs["name"], info=kwargs["info"])
-        if cluster:
-            cluster.update(dict(optional_info=kwargs["optional_info"]))
-        else:
+        cluster = cls.first(
+            name=kwargs["name"],
+            info=kwargs["info"],
+            optional_info=kwargs["optional_info"],
+        )
+        if not cluster:
             cluster = cls.create(kwargs)
         return cluster
 

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -118,7 +118,7 @@ class Run(Base, EntityMixin):
             if "machine_info" in data
             else (Cluster, "cluster_info")
         )
-        hardware = hardware_type.upsert(**data.pop(field_name))
+        hardware = hardware_type.get_or_create(data.pop(field_name))
 
         user_given_commit_info: Optional[TypeCommitInfoGitHub] = data.pop(
             "github", None

--- a/conbench/tests/api/test_results.py
+++ b/conbench/tests/api/test_results.py
@@ -606,6 +606,7 @@ class TestBenchmarkResultPost(_asserts.PostEnforcer):
         new_id = response.json["id"]
         benchmark_result = BenchmarkResult.one(id=new_id)
         hardware_id = benchmark_result.run.hardware.id
+        hardware_hash = benchmark_result.run.hardware.hash
 
         # Post benchmarks for cluster-1 with different optional_info but the same cluster name and info
         payload = copy.deepcopy(self.valid_payload_for_cluster)
@@ -614,11 +615,16 @@ class TestBenchmarkResultPost(_asserts.PostEnforcer):
         response = client.post("/api/benchmarks/", json=payload)
         new_id = response.json["id"]
         benchmark_result = BenchmarkResult.one(id=new_id)
-        assert benchmark_result.run.hardware.id == hardware_id
+
+        # Confirm that a new hardware was created with new optional info...
+        assert benchmark_result.run.hardware.id != hardware_id
         assert (
             benchmark_result.run.hardware.optional_info
             == payload["cluster_info"]["optional_info"]
         )
+
+        # ...but the hash is the same since we didn't modify the cluster name or info
+        assert benchmark_result.run.hardware.hash == hardware_hash
 
     def test_create_benchmark_for_cluster_with_info_changed(self, client):
         # Post benchmarks for cluster-1


### PR DESCRIPTION
Fixes #1340. Now we will create a new Cluster row when a new cluster is POSTed with new optional_info. That way, old benchmark results can still be associated with the "correct" cluster optional info.