### PR TITLE
UI: result view: add summary, explain history plot better

### DIFF
--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -508,7 +508,7 @@ def time_series_plot(
     current_benchmark_result: BenchmarkResult,
     run,
     height=420,
-    width=1100,
+    width=800,
     highlight_result_in_hist: Optional[Tuple[HistorySample, str]] = None,
 ):
     # log.info(

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -482,6 +482,7 @@ def gen_js_callback_click_on_glyph_show_run_details(repo_string):
         // TODO? show run timestamp, not only commit timestamp.
         var newHtml = \
             '<li>Result view: <a href="' + run_report_relurl + '">' + run_report_relurl + '</a></li>' +
+            '<li>Compare view (current and selected result): TODO' + "</li>" +
             '<li>Commit: ' + commit_repo_string + '</li>' +
             '<li>Commit message (truncated): ' + run_commit_msg_pfx + '</li>' +
             "<li>Commit timestamp: " + run_date_string + "</li>" +

--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -658,7 +658,7 @@ def time_series_plot(
     p.xaxis.formatter = get_date_format()
     p.xaxis.major_label_orientation = 1
     p.yaxis.axis_label = unit_str_for_plot_axis_label
-    p.xaxis.axis_label = "date of commit associated with the benchmark result"
+    p.xaxis.axis_label = ""
 
     multisample, multisample_count = _inspect_for_multisample(samples)
     label = "result (n=1)"

--- a/conbench/app/results.py
+++ b/conbench/app/results.py
@@ -264,6 +264,7 @@ class BenchmarkResultView(
             "benchmark-result.html",
             application=Config.APPLICATION_NAME,
             title="Benchmark",
+            # old and new, use `result` in template if possible.
             benchmark=result_dict,
             result=result_obj,
             run=run,

--- a/conbench/app/results.py
+++ b/conbench/app/results.py
@@ -265,6 +265,7 @@ class BenchmarkResultView(
             application=Config.APPLICATION_NAME,
             title="Benchmark",
             benchmark=result_dict,
+            result=result_obj,
             run=run,
             delete_form=delete_form,
             update_form=update_form,

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -515,8 +515,11 @@ class BenchmarkResult(Base, EntityMixin):
 
         return f"{hw.id[:4]}: " + hw.name
 
+    def ui_commit_url_anchor(self) -> str:
+        return f'<a href="{self.run.commit.commit_url}">{self.run.commit.hash[:7]}</a>'
 
-def ui_rel_sem(values: List[float]):
+
+def ui_rel_sem(values: List[float]) -> str:
     """
     The first string in the tuple is a stringified float for sorting in a
     table. The second string in the tuple is for display in the table, with

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -516,10 +516,12 @@ class BenchmarkResult(Base, EntityMixin):
         return f"{hw.id[:4]}: " + hw.name
 
     def ui_commit_url_anchor(self) -> str:
+        if self.run.commit is None:
+            return '<a href="#">n/a</a>'
         return f'<a href="{self.run.commit.commit_url}">{self.run.commit.hash[:7]}</a>'
 
 
-def ui_rel_sem(values: List[float]) -> str:
+def ui_rel_sem(values: List[float]) -> Tuple[str, str]:
     """
     The first string in the tuple is a stringified float for sorting in a
     table. The second string in the tuple is for display in the table, with

--- a/conbench/entities/commit.py
+++ b/conbench/entities/commit.py
@@ -138,10 +138,10 @@ class Commit(Base, EntityMixin):
     def commit_url(self) -> Optional[str]:
         """
         Return a URL string pointing to the commit, or None. The returned
-        string is guaranteed to start with 'http' and is guanrateed to not have
+        string is guaranteed to start with 'http' and is guaranteed to not have
         a trailing slash.
 
-        The `None` case is here because I think the database may contain emtpy
+        The `None` case is here because I think the database may contain empty
         strings.
 
         The URL path construction via /commit/{hash} is as of today

--- a/conbench/static/app.css
+++ b/conbench/static/app.css
@@ -174,8 +174,22 @@ div.offcanvas-cb-context pre {
   font-family: monospace;
 } */
 
+div.result-raw-data-container code {
+  color: #812570aa;
+}
 
+div.cb-bmr-summary-item {
+  padding-bottom: 13px;
+}
 
+div.cb-bmr-summary-item a {
+  text-decoration: none;
+}
+
+div.cb-bmr-summary-item a:hover {
+  font-weight: bold;
+
+}
 
 div.cb-tinyplot div.hardware {
   font-family: var(--bs-font-monospace);

--- a/conbench/templates/benchmark-result.html
+++ b/conbench/templates/benchmark-result.html
@@ -133,10 +133,12 @@
             <div align="right" style="display:inline-block; float: right;"><code>{{ benchmark.display_timestamp }}</code></div>
           </li>
           {% for k,v in benchmark.stats.items() %}
-            <li class="list-group-item" style="overflow-y: auto;">
-              <b>{{ k }}</b>
-              {% if v is not none %}<div align="right" style="display:inline-block; float: right;">{{ v }}</div>{% endif %}
-            </li>
+            {% if v is not none %}
+              <li class="list-group-item" style="overflow-y: auto;">
+                {{ k }}
+                <div align="right" style="display:inline-block; float: right;"><code>{{ v }}</code></div>
+              </li>
+            {% endif %}
           {% endfor %}
         {% endif %}
         <li class="list-group-item list-group-item-primary"> Raw tags (case permutation + name)</li>

--- a/conbench/templates/benchmark-result.html
+++ b/conbench/templates/benchmark-result.html
@@ -211,6 +211,10 @@
           {% endif %}
         {% endif %}
         <li class="list-group-item list-group-item-primary">Hardware (checksum is constant between results in history plot above)</li>
+        <li class="list-group-item" style="overflow-y: auto;">
+          <b>checksum</b>
+          <div align="right" style="display:inline-block; float: right;"><code>{{ result.run.hardware.hash }}</code></div>
+        </li>
         {% for k,v in run.hardware.items() %}
           <li class="list-group-item" style="overflow-y: auto;">
             <b>{{ k }}</b>

--- a/conbench/templates/benchmark-result.html
+++ b/conbench/templates/benchmark-result.html
@@ -206,14 +206,15 @@
             </li>
           {% endif %}
         {% endif %}
-        <li class="list-group-item list-group-item-primary">Hardware</li>
+        <li class="list-group-item list-group-item-primary">Hardware (checksum is constant between results in history plot above)</li>
         {% for k,v in run.hardware.items() %}
           <li class="list-group-item" style="overflow-y: auto;">
             <b>{{ k }}</b>
             <div align="right" style="display:inline-block; float: right;">{{ v }}</div>
           </li>
         {% endfor %}
-        <li class="list-group-item list-group-item-primary">Context</li>
+
+        <li class="list-group-item list-group-item-primary">Context (constant between results in history plot above)</li>
         {% for k,v in benchmark.context.items() %}
           <li class="list-group-item" style="overflow-y: auto;">
             <b>{{ k }}</b>
@@ -221,7 +222,7 @@
           </li>
         {% endfor %}
         {% if benchmark.info and benchmark.info|length > 1 %}
-          <li class="list-group-item list-group-item-primary">Additional Context Details</li>
+          <li class="list-group-item list-group-item-primary">Additional context (may vary between results in history plot above)</li>
           {% for k,v in benchmark.info.items() %}
             <li class="list-group-item" style="overflow-y: auto;">
               <b>{{ k }}</b>

--- a/conbench/templates/benchmark-result.html
+++ b/conbench/templates/benchmark-result.html
@@ -141,8 +141,8 @@
         {% if benchmark.stats %}
           <li class="list-group-item list-group-item-primary">Result</li>
           <li class="list-group-item" style="overflow-y: auto;">
-            <b>timestamp (start time)</b>
-            <div align="right" style="display:inline-block; float: right;">{{ benchmark.display_timestamp }}</div>
+            timestamp (usually the start time)
+            <div align="right" style="display:inline-block; float: right;"><code>{{ benchmark.display_timestamp }}</code></div>
           </li>
           {% for k,v in benchmark.stats.items() %}
             <li class="list-group-item" style="overflow-y: auto;">
@@ -226,7 +226,7 @@
         {% for k,v in run.hardware.items() %}
           <li class="list-group-item" style="overflow-y: auto;">
             <b>{{ k }}</b>
-            <div align="right" style="display:inline-block; float: right;">{{ v }}</div>
+            <div align="right" style="display:inline-block; float: right;"><code>{{ v }}</code></div>
           </li>
         {% endfor %}
 

--- a/conbench/templates/benchmark-result.html
+++ b/conbench/templates/benchmark-result.html
@@ -1,43 +1,47 @@
 {% extends "app.html" %}
 {% import 'bootstrap/wtf.html' as wtf %}
 {% block app_content %}
-
-
   <h4>
-   <strong>{{ benchmark.display_bmname }}</strong> / result {{ result.id[:15] }}...
+    <strong>{{ benchmark.display_bmname }}</strong> / result {{ result.id[:15] }}...
   </h4>
-
   <span class="fs-5"><code>{{ benchmark.display_case_perm }}</code></span>
   <div class="row">
     <div class="col-md-3 mt-3 p-3">
       <h4>summary</h4>
       <div class="mt-3 cb-bm-summary small shadow-sm">
         <div class="cb-bmr-summary-item">
-          <strong>status</strong><br>
-          <code>{% if result.is_failed %} failed {% else %} success {%endif%}</code>
+          <strong>status</strong>
+          <br>
+          <code>
+            {% if result.is_failed %}
+              failed
+            {% else %}
+              success
+            {% endif %}
+          </code>
         </div>
-
         <div class="cb-bmr-summary-item">
-          <strong>data</strong><br>
+          <strong>data</strong>
+          <br>
           <code>{{ result.ui_mean_and_uncertainty }}</code>
         </div>
-
         <div class="cb-bmr-summary-item">
-          <strong>benchmark date</strong><br>
+          <strong>benchmark date</strong>
+          <br>
           <code>{{ result.timestamp.strftime("%Y-%m-%d") }}</code>
         </div>
-
         <div class="cb-bmr-summary-item">
-          <strong>benchmarked code</strong><br>
+          <strong>benchmarked code</strong>
+          <br>
           <code>
             <a href="{{ result.run.commit.repo_url }}">{{ result.run.commit.repo_url }}</a>,
-            commit {{result.ui_commit_url_anchor() |safe }}
+            commit {{ result.ui_commit_url_anchor() |safe }}
             ({{ result.run.commit.timestamp.strftime("%Y-%m-%d") }})
           </code>
         </div>
-
         <div class="cb-bmr-summary-item">
-          <strong>hardware name</strong><br>
+          <strong>hardware name</strong>
+          <br>
           <code>{{ result.run.hardware.name }}</code>
         </div>
       </div>
@@ -49,8 +53,8 @@
     <div class="col-md-1"></div>
     <div class="col-md-8 mt-3 p-3">
       {% if history_plot_info.jsondoc is not none %}
-      <h4>historical evolution</h4>
-      <div class="mt-1" id="plot-history-0"></div>
+        <h4>historical evolution</h4>
+        <div class="mt-1" id="plot-history-0"></div>
         <div class="small">
           <div class="conbench-histplot-run-details" style="display: none;">
             <br />
@@ -66,17 +70,16 @@
             This plot shows the current result in historical context.
             The time axis shows the commit date (corresponds to code evolution).
             Think: along the plot everything is held constant except for the benchmarked code.
-            Click a data point (grey) in the plot to see a corresponding result summary.</div>
+            Click a data point (grey) in the plot to see a corresponding result summary.
+          </div>
         </div>
-    {% else %}
-      <div class="alert alert-info" role="alert">
-        Cannot display history plot for this benchmark result: {{ history_plot_info.reason_why_no_plot }}
-      </div>
-    {% endif %}
-
+      {% else %}
+        <div class="alert alert-info" role="alert">
+          Cannot display history plot for this benchmark result: {{ history_plot_info.reason_why_no_plot }}
+        </div>
+      {% endif %}
     </div>
   </div>
-
   <hr class="border border-danger border-1 opacity-50">
   <h4>raw data</h4>
   <div class="row">
@@ -90,19 +93,27 @@
       <ul class="list-group">
         <li class="list-group-item list-group-item-primary">Result details</li>
         <li class="list-group-item" style="overflow-y: auto;">
-          <b><base href="">benchmark name</b>
-          <div align="right" style="display:inline-block; float: right;"><code>{{ benchmark.display_bmname }}</code></a></div>
+          <b>benchmark name</b>
+          <div align="right" style="display:inline-block; float: right;">
+            <code>{{ benchmark.display_bmname }}</code>
+          </div>
         </li>
         <li class="list-group-item" style="overflow-y: auto;">
           <b>case parameter permutation</b>
-          <div align="right" style="display:inline-block; float: right;"><code>{{ benchmark.display_case_perm }}</code></div>
+          <div align="right" style="display:inline-block; float: right;">
+            <code>{{ benchmark.display_case_perm }}</code>
+          </div>
         </li>
         <li class="list-group-item" style="overflow-y: auto;">
           <b>submitted as part of CI run</b>
           <div align="right" style="display:inline-block; float: right;">
             <a href="{{ url_for('app.run', run_id=benchmark.run_id) }}">{{ benchmark.run_id }}</a> with name
-            <code>{% if run.name %}{{ run.name }}{% endif %}</code> and reason
-            <code>{% if run.reason %}{{ run.reason }}{% endif %}</code>
+            <code>
+              {% if run.name %}{{ run.name }}{% endif %}
+            </code> and reason
+            <code>
+              {% if run.reason %}{{ run.reason }}{% endif %}
+            </code>
           </div>
         </li>
         {% if benchmark.error %}
@@ -130,18 +141,22 @@
           <li class="list-group-item list-group-item-primary">Measurement result</li>
           <li class="list-group-item" style="overflow-y: auto;">
             timestamp (usually the start time)
-            <div align="right" style="display:inline-block; float: right;"><code>{{ benchmark.display_timestamp }}</code></div>
+            <div align="right" style="display:inline-block; float: right;">
+              <code>{{ benchmark.display_timestamp }}</code>
+            </div>
           </li>
           {% for k,v in benchmark.stats.items() %}
             {% if v is not none %}
               <li class="list-group-item" style="overflow-y: auto;">
                 {{ k }}
-                <div align="right" style="display:inline-block; float: right;"><code>{{ v }}</code></div>
+                <div align="right" style="display:inline-block; float: right;">
+                  <code>{{ v }}</code>
+                </div>
               </li>
             {% endif %}
           {% endfor %}
         {% endif %}
-        <li class="list-group-item list-group-item-primary"> Raw tags (case permutation + name)</li>
+        <li class="list-group-item list-group-item-primary">Raw tags (case permutation + name)</li>
         {% for k,v in benchmark.tags.items() %}
           <li class="list-group-item" style="overflow-y: auto;">
             <b>{{ k }}</b>
@@ -212,18 +227,23 @@
             </li>
           {% endif %}
         {% endif %}
-        <li class="list-group-item list-group-item-primary">Hardware (checksum is constant between results in history plot above)</li>
+        <li class="list-group-item list-group-item-primary">
+          Hardware (checksum is constant between results in history plot above)
+        </li>
         <li class="list-group-item" style="overflow-y: auto;">
           <b>checksum</b>
-          <div align="right" style="display:inline-block; float: right;"><code>{{ result.run.hardware.hash }}</code></div>
+          <div align="right" style="display:inline-block; float: right;">
+            <code>{{ result.run.hardware.hash }}</code>
+          </div>
         </li>
         {% for k,v in run.hardware.items() %}
           <li class="list-group-item" style="overflow-y: auto;">
             <b>{{ k }}</b>
-            <div align="right" style="display:inline-block; float: right;"><code>{{ v }}</code></div>
+            <div align="right" style="display:inline-block; float: right;">
+              <code>{{ v }}</code>
+            </div>
           </li>
         {% endfor %}
-
         <li class="list-group-item list-group-item-primary">Context (constant between results in history plot above)</li>
         {% for k,v in benchmark.context.items() %}
           <li class="list-group-item" style="overflow-y: auto;">
@@ -232,7 +252,9 @@
           </li>
         {% endfor %}
         {% if benchmark.info and benchmark.info|length > 1 %}
-          <li class="list-group-item list-group-item-primary">Additional context (may vary between results in history plot above)</li>
+          <li class="list-group-item list-group-item-primary">
+            Additional context (may vary between results in history plot above)
+          </li>
           {% for k,v in benchmark.info.items() %}
             <li class="list-group-item" style="overflow-y: auto;">
               <b>{{ k }}</b>

--- a/conbench/templates/benchmark-result.html
+++ b/conbench/templates/benchmark-result.html
@@ -1,49 +1,81 @@
 {% extends "app.html" %}
 {% import 'bootstrap/wtf.html' as wtf %}
 {% block app_content %}
-  <nav aria-label="breadcrumb">
+  <!-- <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
-      <li class="breadcrumb-item active">
-        <a href="{{ url_for('app.run', run_id=benchmark.run_id) }}">Run</a>
+      <li class="breadcrumb-item small">
+        <a href="{{ url_for('app.run', run_id=benchmark.run_id) }}">Run {{ benchmark.run_id[:9] }}...</a>
       </li>
-      <li class="breadcrumb-item active">
-        <a href="{{ url_for('app.batch', batch_id=benchmark.batch_id) }}">Batch</a>
-      </li>
-      <li class="breadcrumb-item active" aria-current="page">
+      <li class="breadcrumb-item active small" aria-current="page">
         <a href="{{ url_for('app.benchmark-result', benchmark_result_id=benchmark.id) }}">
-        Benchmark result {{ benchmark.id[:7] }}...</a>
+        Result {{ benchmark.id[:9] }}...</a>
       </li>
     </ol>
-  </nav>
-  <br />
-  {% if history_plot_info.jsondoc is not none %}
-    <h3>History plot for benchmark '{{ benchmark.display_bmname }}'</h3>
-    <p class="fst-italic fw-light">For a specific case permutation and hardware/context (see below)</p>
-    <!-- <div>{{ benchmark.display_case_perm }}</div> -->
-    <div class="mt-4" id="plot-history-0" align="center"></div>
-    <div class="row">
-      <div class="col-md-12" style="padding-top: 10px;">
-        Click on a benchmark result (grey point) in the plot to see a corresponding benchmark result summary.
-        <div class="conbench-histplot-run-details" style="display: none;">
-          <br />
-          <div class="panel panel-success">
-            <div class="panel-heading">Summary for selected benchmark (green data point in plot)</div>
-            <div class="panel-body">
-              <ul class="ul-histplot-run-details">
-              </ul>
+  </nav> -->
+
+
+  <h4>
+   <strong>{{ benchmark.display_bmname }}</strong> / result {{ result.id[:15] }}...
+  </h4>
+
+
+
+  <div class="row">
+    <div class="col-md-4 mt-5 p-3">
+      <div class="row cb-bm-summary small">
+        <dt class="col-sm-4">status</dt>
+        <dd class="col-sm-8"><code>{% if result.is_failed() %} failed {% else %} success {%endif%}</code></dd>
+
+        <dt class="col-sm-4">data</dt>
+        <dd class="col-sm-8"><code>{{ result.ui_mean_and_uncertainty }}</code></dd>
+
+        <dt class="col-sm-4">benchmark date</dt>
+        <dd class="col-sm-8"><code>{{ result.timestamp.strftime("%Y-%m-%d") }}</code></dd>
+
+        <dt class="col-sm-4">commit date </dt>
+        <dd class="col-sm-8"><code>{{ result.run.commit.timestamp.strftime("%Y-%m-%d") }}</code></dd>
+
+        <dt class="col-sm-4">commit hash</dt>
+        <dd class="col-sm-8"><code>{{ result.run.commit.hash[:8]}}</code></dd>
+
+        <dt class="col-sm-4">repo</dt>
+        <dd class="col-sm-8"><code>{{ result.run.commit.repo_url }}</code></dd>
+
+        <dt class="col-sm-4">hardware</dt>
+        <dd class="col-sm-8 text-truncate"><code>{{ result.run.hardware.name }}</code></dd>
+      </div>
+    </div>
+    <div class="col-md-8 mt-3 p-3">
+      {% if history_plot_info.jsondoc is not none %}
+      <div class="mt-4" id="plot-history-0"></div>
+      <div class="row">
+        <div class="col-md-12 pl-5 small">
+          Click on a benchmark result (grey point) in the plot to see a corresponding benchmark result summary.
+          <div class="conbench-histplot-run-details" style="display: none;">
+            <br />
+            <div class="panel panel-success">
+              <div class="panel-heading">Summary for selected benchmark (green data point in plot)</div>
+              <div class="panel-body">
+                <ul class="ul-histplot-run-details">
+                </ul>
+              </div>
             </div>
           </div>
         </div>
       </div>
+    {% else %}
+      <div class="alert alert-info" role="alert">
+        Cannot display history plot for this benchmark result: {{ history_plot_info.reason_why_no_plot }}
+      </div>
+    {% endif %}
+
     </div>
-  {% else %}
-    <div class="alert alert-info" role="alert">
-      Cannot display history plot for this benchmark result: {{ history_plot_info.reason_why_no_plot|safe }}
-    </div>
-  {% endif %}
-  <br />
+  </div>
+
+  <hr class="border border-danger border-1 opacity-50">
+
   <div class="row">
-    <div class="col-md-8">
+    <div class="col-md-8 mt-3">
       {{ wtf.quick_form(update_form, id="update-form", button_map={'toggle_distribution_change': update_button_color}) }}
     </div>
   </div>

--- a/conbench/templates/benchmark-result.html
+++ b/conbench/templates/benchmark-result.html
@@ -7,51 +7,67 @@
    <strong>{{ benchmark.display_bmname }}</strong> / result {{ result.id[:15] }}...
   </h4>
 
-
-
+  <span class="fs-5"><code>{{ benchmark.display_case_perm }}</code></span>
   <div class="row">
-    <div class="col-md-4 mt-5 p-3">
-      <div class="row cb-bm-summary small">
-        <dt class="col-sm-4">status</dt>
-        <dd class="col-sm-8"><code>{% if result.is_failed() %} failed {% else %} success {%endif%}</code></dd>
+    <div class="col-md-3 mt-3 p-3">
+      <h4>summary</h4>
+      <div class="mt-3 cb-bm-summary small shadow-sm">
+        <div class="cb-bmr-summary-item">
+          <strong>status</strong><br>
+          <code>{% if result.is_failed %} failed {% else %} success {%endif%}</code>
+        </div>
 
-        <dt class="col-sm-4">data</dt>
-        <dd class="col-sm-8"><code>{{ result.ui_mean_and_uncertainty }}</code></dd>
+        <div class="cb-bmr-summary-item">
+          <strong>data</strong><br>
+          <code>{{ result.ui_mean_and_uncertainty }}</code>
+        </div>
 
-        <dt class="col-sm-4">benchmark date</dt>
-        <dd class="col-sm-8"><code>{{ result.timestamp.strftime("%Y-%m-%d") }}</code></dd>
+        <div class="cb-bmr-summary-item">
+          <strong>benchmark date</strong><br>
+          <code>{{ result.timestamp.strftime("%Y-%m-%d") }}</code>
+        </div>
 
-        <dt class="col-sm-4">commit date </dt>
-        <dd class="col-sm-8"><code>{{ result.run.commit.timestamp.strftime("%Y-%m-%d") }}</code></dd>
+        <div class="cb-bmr-summary-item">
+          <strong>benchmarked code</strong><br>
+          <code>
+            <a href="{{ result.run.commit.repo_url }}">{{ result.run.commit.repo_url }}</a>,
+            commit {{result.ui_commit_url_anchor() |safe }}
+            ({{ result.run.commit.timestamp.strftime("%Y-%m-%d") }})
+          </code>
+        </div>
 
-        <dt class="col-sm-4">commit hash</dt>
-        <dd class="col-sm-8"><code>{{ result.run.commit.hash[:8]}}</code></dd>
-
-        <dt class="col-sm-4">repo</dt>
-        <dd class="col-sm-8"><code>{{ result.run.commit.repo_url }}</code></dd>
-
-        <dt class="col-sm-4">hardware</dt>
-        <dd class="col-sm-8 text-truncate"><code>{{ result.run.hardware.name }}</code></dd>
+        <div class="cb-bmr-summary-item">
+          <strong>hardware name</strong><br>
+          <code>{{ result.run.hardware.name }}</code>
+        </div>
+      </div>
+      <div class="text-muted fst-italic mt-1 small">
+        A brief summary for this result.
+        Find more detail in the raw data below.
       </div>
     </div>
+    <div class="col-md-1"></div>
     <div class="col-md-8 mt-3 p-3">
       {% if history_plot_info.jsondoc is not none %}
-      <div class="mt-4" id="plot-history-0"></div>
-      <div class="row">
-        <div class="col-md-12 pl-5 small">
-          Click on a benchmark result (grey point) in the plot to see a corresponding benchmark result summary.
+      <h4>historical evolution</h4>
+      <div class="mt-1" id="plot-history-0"></div>
+        <div class="small">
           <div class="conbench-histplot-run-details" style="display: none;">
             <br />
             <div class="panel panel-success">
-              <div class="panel-heading">Summary for selected benchmark (green data point in plot)</div>
+              <div class="panel-heading">Summary for selected result (green point in plot):</div>
               <div class="panel-body">
                 <ul class="ul-histplot-run-details">
                 </ul>
               </div>
             </div>
           </div>
+          <div class="text-muted fst-italic">
+            This plot shows the current result in historical context.
+            The time axis shows the commit date (corresponds to code evolution).
+            Think: along the plot everything is held constant except for the benchmarked code.
+            Click a data point (grey) in the plot to see a corresponding result summary.</div>
         </div>
-      </div>
     {% else %}
       <div class="alert alert-info" role="alert">
         Cannot display history plot for this benchmark result: {{ history_plot_info.reason_why_no_plot }}

--- a/conbench/templates/benchmark-result.html
+++ b/conbench/templates/benchmark-result.html
@@ -88,7 +88,7 @@
   <div class="row result-raw-data-container">
     <div class="col-md-6">
       <ul class="list-group">
-        <li class="list-group-item list-group-item-primary">Benchmark details</li>
+        <li class="list-group-item list-group-item-primary">Result details</li>
         <li class="list-group-item" style="overflow-y: auto;">
           <b>Benchmark name</b>
           <div align="right" style="display:inline-block; float: right;">
@@ -139,7 +139,7 @@
           {% endfor %}
         {% endif %}
         {% if benchmark.stats %}
-          <li class="list-group-item list-group-item-primary">Result</li>
+          <li class="list-group-item list-group-item-primary">Measurement result</li>
           <li class="list-group-item" style="overflow-y: auto;">
             timestamp (usually the start time)
             <div align="right" style="display:inline-block; float: right;"><code>{{ benchmark.display_timestamp }}</code></div>
@@ -151,7 +151,7 @@
             </li>
           {% endfor %}
         {% endif %}
-        <li class="list-group-item list-group-item-primary">Tags</li>
+        <li class="list-group-item list-group-item-primary"> Raw tags (case permutation + name)</li>
         {% for k,v in benchmark.tags.items() %}
           <li class="list-group-item" style="overflow-y: auto;">
             <b>{{ k }}</b>

--- a/conbench/templates/benchmark-result.html
+++ b/conbench/templates/benchmark-result.html
@@ -90,31 +90,19 @@
       <ul class="list-group">
         <li class="list-group-item list-group-item-primary">Result details</li>
         <li class="list-group-item" style="overflow-y: auto;">
-          <b>Benchmark name</b>
-          <div align="right" style="display:inline-block; float: right;">
-            <a href="{{ url_for('app.batch', batch_id=benchmark.batch_id ) }}">{{ benchmark.display_bmname }}</a>
-          </div>
+          <b><base href="">benchmark name</b>
+          <div align="right" style="display:inline-block; float: right;"><code>{{ benchmark.display_bmname }}</code></a></div>
         </li>
         <li class="list-group-item" style="overflow-y: auto;">
-          <b>Benchmark case permutation</b>
-          <div align="right" style="display:inline-block; float: right;">{{ benchmark.display_case_perm }}</div>
+          <b>case parameter permutation</b>
+          <div align="right" style="display:inline-block; float: right;"><code>{{ benchmark.display_case_perm }}</code></div>
         </li>
         <li class="list-group-item" style="overflow-y: auto;">
-          <b>Run ID</b>
+          <b>submitted as part of CI run</b>
           <div align="right" style="display:inline-block; float: right;">
-            <a href="{{ url_for('app.run', run_id=benchmark.run_id) }}">{{ benchmark.run_id }}</a>
-          </div>
-        </li>
-        <li class="list-group-item" style="overflow-y: auto;">
-          <b>Run name</b>
-          <div align="right" style="display:inline-block; float: right;">
-            {% if run.name %}{{ run.name }}{% endif %}
-          </div>
-        </li>
-        <li class="list-group-item" style="overflow-y: auto;">
-          <b>Run reason</b>
-          <div align="right" style="display:inline-block; float: right;">
-            {% if run.reason %}{{ run.reason }}{% endif %}
+            <a href="{{ url_for('app.run', run_id=benchmark.run_id) }}">{{ benchmark.run_id }}</a> with name
+            <code>{% if run.name %}{{ run.name }}{% endif %}</code> and reason
+            <code>{% if run.reason %}{{ run.reason }}{% endif %}</code>
           </div>
         </li>
         {% if benchmark.error %}

--- a/conbench/templates/benchmark-result.html
+++ b/conbench/templates/benchmark-result.html
@@ -1,17 +1,6 @@
 {% extends "app.html" %}
 {% import 'bootstrap/wtf.html' as wtf %}
 {% block app_content %}
-  <!-- <nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-      <li class="breadcrumb-item small">
-        <a href="{{ url_for('app.run', run_id=benchmark.run_id) }}">Run {{ benchmark.run_id[:9] }}...</a>
-      </li>
-      <li class="breadcrumb-item active small" aria-current="page">
-        <a href="{{ url_for('app.benchmark-result', benchmark_result_id=benchmark.id) }}">
-        Result {{ benchmark.id[:9] }}...</a>
-      </li>
-    </ol>
-  </nav> -->
 
 
   <h4>

--- a/conbench/templates/benchmark-result.html
+++ b/conbench/templates/benchmark-result.html
@@ -78,14 +78,14 @@
   </div>
 
   <hr class="border border-danger border-1 opacity-50">
-
+  <h4>raw data</h4>
   <div class="row">
     <div class="col-md-8 mt-3">
       {{ wtf.quick_form(update_form, id="update-form", button_map={'toggle_distribution_change': update_button_color}) }}
     </div>
   </div>
   <br />
-  <div class="row">
+  <div class="row result-raw-data-container">
     <div class="col-md-6">
       <ul class="list-group">
         <li class="list-group-item list-group-item-primary">Benchmark details</li>


### PR DESCRIPTION
This is quite a bit of UI work affecting the benchmark result view.

Mainly for #1355 and also for #829.

Quoting from #829:

> Concepts like benchmark name, case permutation should be self-evident from the page. The history plot shows a time axis, and we don't explain that these are commit creation (authoring) times. We can explain nicely what all the points shown in the plot have in common.

Some aspects:
- makes case permutation more obvious in heading
- shows summary with measurement result (reduced precision, and with unit)
- more usage of monospaced font, a little less boldness
- adjustment of terms

There's a bit more. See commit msgs and also screenshots:
[before (Arrow Conbench)](https://github.com/conbench/conbench/assets/265630/c246d69a-0a48-4877-84f4-486e07bd4e28)
[after (internal, sanitized)](https://github.com/conbench/conbench/assets/265630/0725d874-0666-4a71-a3b1-0c6248bfd497)

This probably provokes quite a bit of feedback which would be great. Let's get this in, and then see how this looks like in prod. Super happy to iterate.

