### PR TITLE
UI: c-bench/tinyplots: fix grouping of results into timeseries: use hardware checksum instead of ID

### DIFF
--- a/conbench/entities/hardware.py
+++ b/conbench/entities/hardware.py
@@ -62,6 +62,10 @@ class Machine(Hardware):
     __mapper_args__ = {"polymorphic_identity": "machine"}
 
     def generate_hash(self):
+        # Note(JP): this should simply be the digest of a popular hash
+        # function. With the custom scheme below it's difficult to use this
+        # hash programmatically as it has unpredictable length, charset, etc
+        # (user-given data is in it).
         return (
             self.name
             + "-"
@@ -108,6 +112,10 @@ class Cluster(Hardware):
     __mapper_args__ = {"polymorphic_identity": "cluster"}
 
     def generate_hash(self):
+        # Note(JP): this should simply be the digest of a popular hash
+        # function. With the custom scheme below it's difficult to use this
+        # hash programmatically as it has unpredictable length, charset, etc
+        # (user-given data is in it).
         return (
             self.name
             + "-"


### PR DESCRIPTION
This was motivated mainly by https://github.com/conbench/conbench/issues/1353.

That is, the main point of this patch is to use the "hardware checksum" instead of the "hardware ID" for grouping results into timeseries groups.

But: turns out what we call "hardware hash" in Conbench internals (and externals!) isn't a canonical hash/checksum. It can be a long string with various pieces of user-given data. That makes this "hash" difficult to work with in core data structures. One core data structure that we have is a 4-tuple where the hardware checksum is one of the four parameters.

Here, I have no opted for (quick and dirty) re-writing the Conbench hardware hash into a 'proper one'. A downside is now that in HTML source and JS source there is a string/id/hash that pops up which does _not_ match database contents.

We can make things more tidy as part of https://github.com/conbench/conbench/issues/1340.

