### PR TITLE
benchalerts: always display all runs in check summary

### DIFF
--- a/benchalerts/benchalerts/message_formatting.py
+++ b/benchalerts/benchalerts/message_formatting.py
@@ -59,6 +59,20 @@ def _list_results(
     return out
 
 
+def _all_runs(full_comparison: FullComparisonInfo) -> str:
+    """Create a Markdown list of all runs analyzed."""
+    out = "## All benchmark runs analyzed:\n"
+    for comparison in full_comparison.run_comparisons:
+        out += "\n"
+        out += _run_bullet(
+            comparison.contender_reason,
+            comparison.contender_datetime,
+            comparison.contender_link,
+            comparison.contender_hardware_name,
+        )
+    return out
+
+
 class Alerter:
     """A class to generate default messages and statuses for alerting. You can override
     any methods for your project's custom settings.
@@ -147,7 +161,7 @@ class Alerter:
             if build_url:
                 summary += f" See the [build logs]({build_url}) for more information."
             # exit early
-            return summary
+            return summary + "\n\n" + _all_runs(full_comparison)
 
         if full_comparison.results_with_errors:
             summary += self.clean(
@@ -177,7 +191,7 @@ class Alerter:
                 """
             )
             # exit early
-            return summary
+            return summary + "\n\n" + _all_runs(full_comparison)
 
         pluralizer = _Pluralizer(full_comparison.results_with_z_regressions)
         were = pluralizer.were
@@ -194,17 +208,7 @@ class Alerter:
             summary += "### Benchmarks with regressions:"
             summary += _list_results(full_comparison.results_with_z_regressions)
 
-        summary += "## All benchmark runs analyzed:\n"
-        for comparison in full_comparison.run_comparisons:
-            summary += "\n"
-            summary += _run_bullet(
-                comparison.contender_reason,
-                comparison.contender_datetime,
-                comparison.contender_link,
-                comparison.contender_hardware_name,
-            )
-
-        return summary
+        return summary + _all_runs(full_comparison)
 
     def github_check_details(
         self, full_comparison: FullComparisonInfo

--- a/benchalerts/tests/unit_tests/expected_md/summary_errors_nobaselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_errors_nobaselines.md
@@ -14,4 +14,9 @@ There weren't enough matching historic runs in Conbench to make a call on whethe
 
 To use the lookback z-score method of determining regressions, there need to be at least two historic runs on the default branch which, when compared to one of the runs on the contender commit, are on the same hardware, and have at least one of the same benchmark case and context pairs.
 
+## All benchmark runs analyzed:
+
+- Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+- Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+
 This message was generated from pytest.

--- a/benchalerts/tests/unit_tests/expected_md/summary_noerrors_nobaselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_noerrors_nobaselines.md
@@ -6,4 +6,9 @@ There weren't enough matching historic runs in Conbench to make a call on whethe
 
 To use the lookback z-score method of determining regressions, there need to be at least two historic runs on the default branch which, when compared to one of the runs on the contender commit, are on the same hardware, and have at least one of the same benchmark case and context pairs.
 
+## All benchmark runs analyzed:
+
+- Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+- Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+
 This message was generated from pytest.

--- a/benchalerts/tests/unit_tests/expected_md/summary_noresults.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_noresults.md
@@ -2,4 +2,8 @@ Conbench analyzed the 1 benchmark run on commit `abc`.
 
 None of the specified runs had any associated benchmark results. See the [build logs](https://austin.something) for more information.
 
+## All benchmark runs analyzed:
+
+- Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/runs/some_contender)
+
 This message was generated from pytest.


### PR DESCRIPTION
Fixes #1351. A small change to add more information to the GitHub Check in certain cases.