### PR TITLE
benchalerts: switch to new ConbenchClient

### DIFF
--- a/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
+++ b/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
@@ -13,15 +13,12 @@
 # limitations under the License.
 
 import pytest
-from benchclients.conbench import LegacyConbenchClient
 
 from benchalerts.pipeline_steps.conbench import (
     BaselineRunCandidates,
     GetConbenchZComparisonForRunsStep,
     GetConbenchZComparisonStep,
 )
-
-ConbenchClient = LegacyConbenchClient
 
 
 @pytest.mark.parametrize(
@@ -64,11 +61,8 @@ def test_GetConbenchZComparisonStep(
             "https://github.com/conbench/conbench/issues/745 means timeouts cause this to fail"
         )
     monkeypatch.setenv("CONBENCH_URL", conbench_url)
-    cb = ConbenchClient()
     step = GetConbenchZComparisonStep(
-        commit_hash=commit_hash,
-        baseline_run_type=BaselineRunCandidates.parent,
-        conbench_client=cb,
+        commit_hash=commit_hash, baseline_run_type=BaselineRunCandidates.parent
     )
     full_comparison = step.run_step(previous_outputs={})
     assert len(full_comparison.run_comparisons) == expected_len
@@ -83,11 +77,8 @@ def test_GetConbenchZComparisonStep(
 
 def test_no_runs_found(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("CONBENCH_URL", "https://conbench.ursa.dev/")
-    cb = ConbenchClient()
     step = GetConbenchZComparisonForRunsStep(
-        run_ids=["not found"],
-        baseline_run_type=BaselineRunCandidates.parent,
-        conbench_client=cb,
+        run_ids=["not found"], baseline_run_type=BaselineRunCandidates.parent
     )
     full_comparison = step.run_step(previous_outputs={})
     assert full_comparison.run_comparisons == []

--- a/benchalerts/tests/unit_tests/mocks.py
+++ b/benchalerts/tests/unit_tests/mocks.py
@@ -18,6 +18,7 @@ from typing import List, Tuple
 
 import pytest
 import requests
+from benchclients.conbench import ConbenchClient
 from requests.adapters import HTTPAdapter
 
 from benchclients import log
@@ -81,6 +82,15 @@ class MockAdapter(HTTPAdapter):
             raise Exception(f"Mock response not found at {response_path}")
 
         return MockResponse.from_file(response_path)
+
+
+class MockConbenchClient(ConbenchClient):
+    def __init__(self):
+        super().__init__()
+        self.session.mount("https://", MockAdapter())
+
+    def _login_or_raise(self) -> None:
+        pass
 
 
 def check_posted_markdown(

--- a/benchalerts/tests/unit_tests/test_alert_pipeline.py
+++ b/benchalerts/tests/unit_tests/test_alert_pipeline.py
@@ -1,13 +1,10 @@
 import pytest
-from benchclients.conbench import LegacyConbenchClient
 
 import benchalerts.pipeline_steps as steps
 from benchalerts import AlertPipeline
 from benchalerts.integrations.github import GitHubRepoClient
 
-from .mocks import MockAdapter
-
-ConbenchClient = LegacyConbenchClient
+from .mocks import MockAdapter, MockConbenchClient
 
 
 @pytest.mark.parametrize("github_auth", ["app"], indirect=True)
@@ -16,9 +13,7 @@ def test_reasonable_pipeline(conbench_env, github_auth):
     repo = "some/repo"
     build_url = "https://google.com"
 
-    conbench_client = ConbenchClient(
-        adapter=MockAdapter(),
-    )
+    conbench_client = MockConbenchClient()
     github_client = GitHubRepoClient(repo=repo, adapter=MockAdapter())
 
     pipeline = AlertPipeline(

--- a/benchalerts/tests/unit_tests/test_pipeline_steps/test_conbench.py
+++ b/benchalerts/tests/unit_tests/test_pipeline_steps/test_conbench.py
@@ -1,5 +1,4 @@
 import pytest
-from benchclients.conbench import LegacyConbenchClient
 
 from benchalerts.pipeline_steps.conbench import (
     BaselineRunCandidates,
@@ -7,9 +6,7 @@ from benchalerts.pipeline_steps.conbench import (
     GetConbenchZComparisonStep,
 )
 
-from ..mocks import MockAdapter
-
-ConbenchClient = LegacyConbenchClient
+from ..mocks import MockConbenchClient
 
 
 def test_GetConbenchZComparisonForRunsStep(conbench_env):
@@ -17,7 +14,7 @@ def test_GetConbenchZComparisonForRunsStep(conbench_env):
         run_ids=["some_contender"],
         baseline_run_type=BaselineRunCandidates.fork_point,
         z_score_threshold=500,
-        conbench_client=ConbenchClient(adapter=MockAdapter()),
+        conbench_client=MockConbenchClient(),
     )
     res = step.run_step(previous_outputs={})
     assert res
@@ -29,7 +26,7 @@ def test_runs_comparison_fails_when_no_baseline(
     step = GetConbenchZComparisonForRunsStep(
         run_ids=["contender_wo_base"],
         baseline_run_type=BaselineRunCandidates.fork_point,
-        conbench_client=ConbenchClient(adapter=MockAdapter()),
+        conbench_client=MockConbenchClient(),
     )
     res = step.run_step(previous_outputs={})
     assert res
@@ -40,7 +37,7 @@ def test_runs_comparison_without_commit(conbench_env, caplog: pytest.LogCaptureF
     step = GetConbenchZComparisonForRunsStep(
         run_ids=["no_commit"],
         baseline_run_type=BaselineRunCandidates.latest_default,
-        conbench_client=ConbenchClient(adapter=MockAdapter()),
+        conbench_client=MockConbenchClient(),
     )
     res = step.run_step(previous_outputs={})
     assert res
@@ -50,7 +47,7 @@ def test_runs_comparison_skips_runs_not_found(conbench_env):
     step = GetConbenchZComparisonForRunsStep(
         run_ids=["contender_wo_base", "not_found"],
         baseline_run_type=BaselineRunCandidates.latest_default,
-        conbench_client=ConbenchClient(adapter=MockAdapter()),
+        conbench_client=MockConbenchClient(),
     )
     res = step.run_step(previous_outputs={})
     assert len(res.run_comparisons) == 1
@@ -61,7 +58,7 @@ def test_GetConbenchZComparisonStep(conbench_env):
         commit_hash="abc",
         baseline_run_type=BaselineRunCandidates.fork_point,
         z_score_threshold=500,
-        conbench_client=ConbenchClient(adapter=MockAdapter()),
+        conbench_client=MockConbenchClient(),
     )
     res = step.run_step(previous_outputs={})
     assert res
@@ -71,7 +68,7 @@ def test_comparison_doesnt_fail_when_no_runs(conbench_env):
     step = GetConbenchZComparisonStep(
         commit_hash="no_runs",
         baseline_run_type=BaselineRunCandidates.fork_point,
-        conbench_client=ConbenchClient(adapter=MockAdapter()),
+        conbench_client=MockConbenchClient(),
     )
     res = step.run_step(previous_outputs={})
     assert res
@@ -83,7 +80,7 @@ def test_comparison_warns_when_no_baseline(
     step = GetConbenchZComparisonStep(
         commit_hash="no_baseline",
         baseline_run_type=BaselineRunCandidates.fork_point,
-        conbench_client=ConbenchClient(adapter=MockAdapter()),
+        conbench_client=MockConbenchClient(),
     )
     res = step.run_step(previous_outputs={})
     assert res

--- a/benchclients/python/tests/unit_tests/test_conbench.py
+++ b/benchclients/python/tests/unit_tests/test_conbench.py
@@ -17,13 +17,11 @@ from benchclients.conbench import ConbenchClientException
 
 from benchclients import ConbenchClient
 
-from .mocks import MockAdapter
-
 
 class TestConbenchClient:
     @property
     def cb(self):
-        return ConbenchClient(adapter=MockAdapter())
+        return ConbenchClient()
 
     def test_conbench_fails_missing_env(self, missing_conbench_env):
         with pytest.raises(ConbenchClientException, match="CONBENCH_URL"):


### PR DESCRIPTION
Fixes #1186.

This PR switches `benchalerts` off of the `LegacyConbenchClient` onto the new `ConbenchClient` with better logging and retry logic.