### PR TITLE
ci: work around webdriver manager (for issue #1364)

### DIFF
--- a/ci/screenshot.Dockerfile
+++ b/ci/screenshot.Dockerfile
@@ -12,10 +12,16 @@ RUN apt-get update && apt-get install -y -q --no-install-recommends \
 RUN pip install pip --upgrade
 RUN pip install selenium webdriver_manager && pip cache purge
 
+# Use static chromedriver version for now until webdriver manager is through
+# the hoops. Also see https://github.com/conbench/conbench/issues/1364
 # Install chrome driver manager into cache.
 # This will then lead to e.g.
 #    Driver [/root/.wdm/drivers/chromedriver/linux64/108.0.5359/chromedriver] found in cache
 # during execution.
-RUN python -c "from webdriver_manager.chrome import ChromeDriverManager; ChromeDriverManager().install()"
+#RUN python -c "from webdriver_manager.chrome import ChromeDriverManager; ChromeDriverManager().install()"
+RUN curl -fsSL -o /chromedriver.zip https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/115.0.5790.98/linux64/chromedriver-linux64.zip
+RUN unzip /chromedriver.zip
+RUN cd / && ls
+
 
 COPY screenshot.py .

--- a/ci/screenshot.py
+++ b/ci/screenshot.py
@@ -32,7 +32,8 @@ from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.by import By
-from webdriver_manager.chrome import ChromeDriverManager
+
+# from webdriver_manager.chrome import ChromeDriverManager
 
 # from selenium.webdriver.support.ui import WebDriverWait
 # from selenium.webdriver.common.by import By
@@ -241,9 +242,15 @@ def _get_driver():
 
     log.info("set up chromedriver with capabilities %s", wd_options.to_capabilities())
 
+    # A temporary fix for our CI (and linux devs :-) until
+    # https://github.com/SergeyPirogov/webdriver_manager/issues/536 is resolved
+    # upstream. Also see https://github.com/conbench/conbench/issues/1364.
+    # driver = webdriver.Chrome(service=Service(cdm.install()), options=wd_options)
     driver = webdriver.Chrome(
-        service=Service(ChromeDriverManager().install()), options=wd_options
+        service=Service(executable_path="/chromedriver-linux64/chromedriver"),
+        options=wd_options,
     )
+
     # The waiter is only optionally used later.
     # waiter = WebDriverWait(driver, 30)
     # Piggy-back waiter object on driver object, use a somewhat unique name


### PR DESCRIPTION
This addresses #1364. We can revert this once webdriver manager has released a patch.

I got a bit creative here with the goal to inject a "custom URL"; taking webdriver manager completely out of the picture. Gladly found https://selenium-python.readthedocs.io/api.html#module-selenium.webdriver.chrome.service and its `executable_path` argument.