### PR TITLE
benchmark result submission: require one of known units

### DIFF
--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -912,19 +912,28 @@ class BenchmarkResultStatsSchema(marshmallow.Schema):
             # present?
             "description": conbench.util.dedent_rejoin(
                 """
-                A list of benchmark results (e.g. durations, throughput). This
-                will be used as the main + only metric for regression and
-                improvement. The values should be ordered in the order the
-                iterations were executed (the first element is the first
-                iteration, the second element is the second iteration, etc.).
-                If an iteration did not complete but others did and you want to
-                send partial data, mark each iteration that didn't complete as
-                `null`.
+                A list of measurement results (e.g. duration, throughput).
 
-                You may populate both this field and the "error" field in the top level
-                of the benchmark result payload. In that case, this field measures
-                the metric's values before the error occurred. These values will not be
-                compared to non-errored values in analyses and comparisons.
+                Each value in this list is meant to correspond to one
+                repetition of ideally the exact same measurement.
+
+                We recommend to repeat a measurement N times (3-6) for enabling
+                systematic stability analysis.
+
+                Values are expected to be ordered in the order the
+                iterations/repetitions were executed (the first element
+                corresponds to the first repetition, the second element is the
+                second repetition, etc.).
+
+                Values must be numeric or `null`: if one repetition failed but
+                others did not you can mark the failed repetition as `null`.
+
+                Note that you may populate both this field and the "error"
+                field in the top level of the benchmark result payload.
+
+                If any of the values in `data` is `null` or if the `error`
+                field is set then Conbench will not include any of the reported
+                data in automated analyses.
                 """
             )
         },
@@ -957,7 +966,9 @@ class BenchmarkResultStatsSchema(marshmallow.Schema):
         # strings are/were allowed to be injected. TODO: be more strict.
         # Require users to provide a unit (non-zero length string)./
         required=True,
-        metadata={"description": "The unit of the data object (e.g. seconds, B/s)"},
+        metadata={
+            "description": "The unit of the measurement result (object (e.g. seconds, B/s)"
+        },
     )
     time_unit = marshmallow.fields.String(
         required=True,

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -1115,7 +1115,7 @@
             "BenchmarkResultStats": {
                 "properties": {
                     "data": {
-                        "description": "A list of benchmark results (e.g. durations, throughput). This will be used as the main + only metric for regression and improvement. The values should be ordered in the order the iterations were executed (the first element is the first iteration, the second element is the second iteration, etc.). If an iteration did not complete but others did and you want to send partial data, mark each iteration that didn't complete as `null`.  You may populate both this field and the \"error\" field in the top level of the benchmark result payload. In that case, this field measures the metric's values before the error occurred. These values will not be compared to non-errored values in analyses and comparisons.",
+                        "description": 'A list of measurement results (e.g. duration, throughput).  Each value in this list is meant to correspond to one repetition of ideally the exact same measurement.  We recommend to repeat a measurement N times (3-6) for enabling systematic stability analysis.  Values are expected to be ordered in the order the iterations/repetitions were executed (the first element corresponds to the first repetition, the second element is the second repetition, etc.).  Values must be numeric or `null`: if one repetition failed but others did not you can mark the failed repetition as `null`.  Note that you may populate both this field and the "error" field in the top level of the benchmark result payload.  If any of the values in `data` is `null` or if the `error` field is set then Conbench will not include any of the reported data in automated analyses.',
                         "items": {"nullable": True, "type": "number"},
                         "type": "array",
                     },
@@ -1165,7 +1165,7 @@
                         "type": "array",
                     },
                     "unit": {
-                        "description": "The unit of the data object (e.g. seconds, B/s)",
+                        "description": "The unit of the measurement result (object (e.g. seconds, B/s)",
                         "type": "string",
                     },
                 },

--- a/conbench/units.py
+++ b/conbench/units.py
@@ -1,0 +1,51 @@
+"""
+Historically, Conbench allowed users to submit any unit string together with
+measurement values.
+
+This is an attempt to impose constraints. Conbench business logic can then use
+properties like `less_is_better` and `long` from the lookup table below.
+
+Note that b/s is transparently rewritten to B/s in benchmark_results.py (before
+DB insertion).
+
+Also see https://github.com/conbench/conbench/issues/1335.
+
+About names, descriptions and hard questions about plural vs singular there
+is lovely inspiration in the following resources:
+https://www.nist.gov/pml/special-publication-811/nist-guide-si-chapter-9-rules-and-style-conventions-spelling-unit-names
+https://en.wikipedia.org/wiki/Data-rate_units
+https://english.stackexchange.com/questions/22082/are-units-in-english-singular-or-plural
+https://physics.stackexchange.com/questions/172039/usage-of-singular-or-plural-si-base-units-when-written-in-both-symbol-as-well-as
+https://physics.stackexchange.com/questions/384187/can-units-be-plural
+https://physics.nist.gov/cuu/Units/checklist.html
+https://forum.thefreedictionary.com/postst144586_singular-or-plural.aspx
+"""
+
+# Map canonical symbol (established short handle) to canonical long name of a
+# unit, and unit properties.
+# TODO: allow for extending this via config.
+
+KNOWN_UNITS = {
+    "B/s": {
+        "long": "bytes per second",
+        "less_is_better": False,
+    },
+    "s": {
+        "long": "seconds",
+        "less_is_better": True,
+    },
+    "ns": {
+        "long": "nanoseconds",
+        "less_is_better": True,
+    },
+    "i/s": {
+        # iterations per second? items per second? Here, we define it as
+        # iterations per second which is more general than items per second.
+        "long": "iterations per second",
+        "less_is_better": False,
+    },
+}
+
+
+KNOWN_UNIT_SYMBOLS = list(KNOWN_UNITS.keys())
+KNOWN_UNIT_SYMBOLS_STR = ", ".join(KNOWN_UNIT_SYMBOLS)


### PR DESCRIPTION
This is for #1335.


Next up:
- use `less_is_better` and `long` in code
- work on HTTP API docs to automatically show list of supported units