### PR TITLE
UI: result-result comparison: more neutral comp, various tweaks

### DIFF
--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -112,7 +112,8 @@ class TimeSeriesPlotMixin:
                     "you asked to highlight the benchmark result with ID "
                     f"<kbd>{highlight_other_result.bmrid}</kbd> in this view. "
                     "However, that result is not part of the history of the "
-                    f"result <kbd>{current_benchmark_result.id}</kbd>",
+                    f"result <kbd>{current_benchmark_result.id}</kbd>. The "
+                    "two results are not directly comparable.",
                 )
             highlight_other = (
                 s_by_id[highlight_other_result.bmrid],

--- a/conbench/static/app.css
+++ b/conbench/static/app.css
@@ -36,7 +36,6 @@ select:focus {
 
 .c-bench-landing div.card a:hover {
   font-weight: bold;
-
 }
 
 /*
@@ -130,8 +129,24 @@ table.c-bench-caseperm-table th {
 }
 
 
+div.cb-title h1 {
+  /* reduce default mb*/
+  margin-bottom: 0.1rem;
+}
+
+div.cb-title div.cb-subtitle {
+  /* fine-tune alignment*/
+  margin-left: 3px;
+}
+
+div.cb-title hr {
+  color: #812570;
+  border-top: 1px solid;
+
+}
+
 div.cb-run-details-panel {
-  background-color: #00505033;
+  background-color: #00505019;
   padding: 15px;
 
 }

--- a/conbench/templates/app.html
+++ b/conbench/templates/app.html
@@ -1,3 +1,4 @@
+{% import "utils.jinja" as utils %}
 {% block doc -%}
   <!DOCTYPE html>
   <html lang="en">
@@ -103,7 +104,7 @@
             </div>
           {% endblock %}
           {% block content %}
-            <div class="container mt-5">
+            <div class="container mt-4">
               <!-- https://flask.palletsprojects.com/en/2.2.x/patterns/flashing/#flashing-with-categories -->
               {% with messages = get_flashed_messages(with_categories=true) %}
                 {% if messages %}

--- a/conbench/templates/benchmark-result.html
+++ b/conbench/templates/benchmark-result.html
@@ -1,10 +1,11 @@
 {% extends "app.html" %}
 {% import 'bootstrap/wtf.html' as wtf %}
 {% block app_content %}
-  <h4>
-    <strong>{{ benchmark.display_bmname }}</strong> / result {{ result.id }}
-  </h4>
-  <span class="fs-5"><code>{{ benchmark.display_case_perm }}</code></span>
+{{ utils.view_entity_title("benchmark result",  result.id) }}
+  <div>
+    <strong>{{ benchmark.display_bmname }}</strong> /
+    <code>{{ benchmark.display_case_perm }}</code>
+  </div>
   <div class="row">
     <div class="col-md-3 mt-3 p-3">
       <h4>summary</h4>

--- a/conbench/templates/benchmark-result.html
+++ b/conbench/templates/benchmark-result.html
@@ -1,7 +1,7 @@
 {% extends "app.html" %}
 {% import 'bootstrap/wtf.html' as wtf %}
 {% block app_content %}
-{{ utils.view_entity_title("benchmark result",  result.id) }}
+  {{ utils.view_entity_title("benchmark result",  result.id) }}
   <div>
     <strong>{{ benchmark.display_bmname }}</strong> /
     <code>{{ benchmark.display_case_perm }}</code>

--- a/conbench/templates/compare-entity.html
+++ b/conbench/templates/compare-entity.html
@@ -30,228 +30,223 @@ matching fields between baseline and contender are aligned and mismatched fields
   {% endif %}
 {% endmacro %}
 {% block app_content %}
-
-{{ utils.view_entity_title("comparing two results", "") }}
-
-
+  {{ utils.view_entity_title("comparing two results", "") }}
   <div class="row">
     <div class="col-md-6">
       <!-- what kind of plot is this supposed to be, especially given that
-        this might be displayed for run vs. run, result vs. result? -->
+  this might be displayed for run vs. run, result vs. result? -->
       <div id="plot" align="center"></div>
       <br />
     </div>
     <!--
-        Here was a table, but it was a bit broken, see
-        https://github.com/conbench/conbench/issues/1230
-        when comparing two benchmark results I think the history plot
-        and the tabular comparison of the result measurements are sufficient.
-        let's maybe re-activate it when we understand its value better.
-      -->
+  Here was a table, but it was a bit broken, see
+  https://github.com/conbench/conbench/issues/1230
+  when comparing two benchmark results I think the history plot
+  and the tabular comparison of the result measurements are sufficient.
+  let's maybe re-activate it when we understand its value better.
+-->
   </div>
   <h4>historical context</h4>
-
-
   {% if benchmark_result_history_plot_info.reason_why_no_plot %}
-    <p>Cannot display history plot: {{benchmark_result_history_plot_info.reason_why_no_plot | safe }}</p>
+    <p>Cannot display history plot: {{ benchmark_result_history_plot_info.reason_why_no_plot | safe }}</p>
   {% else %}
-
     Both results have been obtained for <span>
-      <strong>{{ baseline.display_bmname }}</strong> /
-      <code>{{ baseline.display_case_perm }}</code>
-    </span>; the following plot highlights both of them in context of other directly comparable results:
-    <div id="plot-history-0" align="center"></div>
+    <strong>{{ baseline.display_bmname }}</strong> /
+    <code>{{ baseline.display_case_perm }}</code>
+  </span>; the following plot highlights both of them in context of other directly comparable results:
+  <div id="plot-history-0" align="center"></div>
+{% endif %}
+<h4>raw comparison</h4>
+<div class="row mt-4">
+  {% if baseline %}
+    <div class="col-md-6">
+      <h5>
+        result <a href="{{ url_for('app.benchmark-result', benchmark_result_id=baseline.id) }}">{{ baseline.id }}</a>
+      </h5>
+      <ul class="list-group">
+        <li class="list-group-item list-group-item-secondary">overview</li>
+        <li class="list-group-item" style="overflow-y: auto;">
+          <b>time of benchmark</b>
+          <div align="right" style="display:inline-block; float: right;">{{ baseline.display_timestamp }}</div>
+        </li>
+        <li class="list-group-item" style="overflow-y: auto;">
+          <b>submitted as part of CI run</b>
+          <div align="right" style="display:inline-block; float: right;">
+            <a href="{{ url_for('app.run', run_id=baseline.run_id) }}">{{ baseline.run_id }}</a>
+          </div>
+        </li>
+        <li class="list-group-item" style="overflow-y: auto;">
+          <b>benchmark name</b>
+          <div align="right" style="display:inline-block; float: right;">
+            <a href="{{ url_for('app.batch', batch_id=baseline.batch_id ) }}">{{ baseline.display_bmname }}</a>
+          </div>
+        </li>
+        <li class="list-group-item" style="overflow-y: auto;">
+          <b>case permutation</b>
+          <div align="right" style="display:inline-block; float: right;">{{ baseline.display_case_perm }}</div>
+        </li>
+        {% if baseline_run %}
+          {% if baseline_run.commit.url %}
+            <li class="list-group-item" style="overflow-y: auto;">
+              <b>commit</b>
+              <div class="ellipsis-500"
+                   align="right"
+                   style="display:inline-block;
+                          float: right">
+                {% if baseline_run.commit.display_message %}
+                  <a href="{{ baseline_run.commit.url }}">{{ baseline_run.commit.display_message }}</a>
+                {% else %}
+                  <a href="{{ baseline_run.commit.url }}">{{ baseline_run.commit.sha }}</a>
+                {% endif %}
+              </div>
+            </li>
+          {% endif %}
+          {% if baseline_run.commit.display_timestamp %}
+            <li class="list-group-item" style="overflow-y: auto;">
+              <b>commit date</b>
+              <div align="right" style="display:inline-block; float: right;">{{ baseline_run.commit.display_timestamp }}</div>
+            </li>
+          {% endif %}
+          {% if baseline_run.commit.author_name %}
+            <li class="list-group-item" style="overflow-y: auto;">
+              <b>author</b>
+              <div align="right" style="display:inline-block; float: right;">
+                {{ baseline_run.commit.author_name }}
+                {% if baseline_run.commit.author_avatar %}
+                  <image src="{{ baseline_run.commit.author_avatar }}"
+                         height="30"
+                         style="border-radius: 50%" />
+                {% endif %}
+              </div>
+            </li>
+          {% endif %}
+          {% if baseline_run.commit.display_repository %}
+            <li class="list-group-item" style="overflow-y: auto;">
+              <b>repository</b>
+              <div align="right" style="display:inline-block; float: right;">
+                <a href="{{ baseline_run.commit.repository }}">{{ baseline_run.commit.display_repository }}</a>
+              </div>
+            </li>
+          {% endif %}
+          {% if baseline_run.commit.branch %}
+            <li class="list-group-item" style="overflow-y: auto;">
+              <b>branch</b>
+              <div align="right" style="display:inline-block; float: right;">{{ baseline_run.commit.branch }}</div>
+            </li>
+          {% endif %}
+          <li class="list-group-item" style="overflow-y: auto;">
+            <b>hardware</b>
+            <div align="right" style="display:inline-block; float: right;">{{ baseline_run.hardware.name }}</div>
+          </li>
+        {% endif %}
+        <li class="list-group-item list-group-item-secondary">measurement result</li>
+        {% for k,v in baseline.stats.items() %}
+          {% if v is not none %}
+            <li class="list-group-item" style="overflow-y: auto;">
+              <b>{{ k }}</b>
+              <div align="right" style="display:inline-block; float: right;">{{ v }}</div>
+            </li>
+          {% endif %}
+        {% endfor %}
+        {{ sections_with_different_fields(baseline, contender, baseline_run, contender_run, benchmark_to_display=baseline, run_to_display=baseline_run) }}
+      </ul>
+    </div>
   {% endif %}
-
-
-
-  <h4>raw comparison</h4>
-  <div class="row mt-4">
-    {% if baseline %}
-      <div class="col-md-6">
-        <h5>result <a href="{{ url_for('app.benchmark-result', benchmark_result_id=baseline.id) }}">{{ baseline.id }}</a></h5>
-        <ul class="list-group">
-          <li class="list-group-item list-group-item-secondary">overview</li>
-          <li class="list-group-item" style="overflow-y: auto;">
-            <b>time of benchmark</b>
-            <div align="right" style="display:inline-block; float: right;">{{ baseline.display_timestamp }}</div>
-          </li>
-          <li class="list-group-item" style="overflow-y: auto;">
-            <b>submitted as part of CI run</b>
-            <div align="right" style="display:inline-block; float: right;">
-              <a href="{{ url_for('app.run', run_id=baseline.run_id) }}">{{ baseline.run_id }}</a>
-            </div>
-          </li>
-          <li class="list-group-item" style="overflow-y: auto;">
-            <b>benchmark name</b>
-            <div align="right" style="display:inline-block; float: right;">
-              <a href="{{ url_for('app.batch', batch_id=baseline.batch_id ) }}">{{ baseline.display_bmname }}</a>
-            </div>
-          </li>
-          <li class="list-group-item" style="overflow-y: auto;">
-            <b>case permutation</b>
-            <div align="right" style="display:inline-block; float: right;">{{ baseline.display_case_perm }}</div>
-          </li>
-          {% if baseline_run %}
-            {% if baseline_run.commit.url %}
-              <li class="list-group-item" style="overflow-y: auto;">
-                <b>commit</b>
-                <div class="ellipsis-500"
-                     align="right"
-                     style="display:inline-block;
-                            float: right">
-                  {% if baseline_run.commit.display_message %}
-                    <a href="{{ baseline_run.commit.url }}">{{ baseline_run.commit.display_message }}</a>
-                  {% else %}
-                    <a href="{{ baseline_run.commit.url }}">{{ baseline_run.commit.sha }}</a>
-                  {% endif %}
-                </div>
-              </li>
-            {% endif %}
-            {% if baseline_run.commit.display_timestamp %}
-              <li class="list-group-item" style="overflow-y: auto;">
-                <b>commit date</b>
-                <div align="right" style="display:inline-block; float: right;">{{ baseline_run.commit.display_timestamp }}</div>
-              </li>
-            {% endif %}
-            {% if baseline_run.commit.author_name %}
-              <li class="list-group-item" style="overflow-y: auto;">
-                <b>author</b>
-                <div align="right" style="display:inline-block; float: right;">
-                  {{ baseline_run.commit.author_name }}
-                  {% if baseline_run.commit.author_avatar %}
-                    <image src="{{ baseline_run.commit.author_avatar }}"
-                           height="30"
-                           style="border-radius: 50%" />
-                  {% endif %}
-                </div>
-              </li>
-            {% endif %}
-            {% if baseline_run.commit.display_repository %}
-              <li class="list-group-item" style="overflow-y: auto;">
-                <b>repository</b>
-                <div align="right" style="display:inline-block; float: right;">
-                  <a href="{{ baseline_run.commit.repository }}">{{ baseline_run.commit.display_repository }}</a>
-                </div>
-              </li>
-            {% endif %}
-            {% if baseline_run.commit.branch %}
-              <li class="list-group-item" style="overflow-y: auto;">
-                <b>branch</b>
-                <div align="right" style="display:inline-block; float: right;">{{ baseline_run.commit.branch }}</div>
-              </li>
-            {% endif %}
+  {% if contender %}
+    <div class="col-md-6">
+      <h5>
+        result <a href="{{ url_for('app.benchmark-result', benchmark_result_id=baseline.id) }}">{{ contender.id }}</a>
+      </h5>
+      <ul class="list-group">
+        <li class="list-group-item list-group-item-secondary">overview</li>
+        <li class="list-group-item" style="overflow-y: auto;">
+          <b>time of benchmark</b>
+          <div align="right" style="display:inline-block; float: right;">{{ contender.display_timestamp }}</div>
+        </li>
+        <li class="list-group-item" style="overflow-y: auto;">
+          <b>submitted as part of CI run</b>
+          <div align="right" style="display:inline-block; float: right;">
+            <a href="{{ url_for('app.run', run_id=contender.run_id) }}">{{ contender.run_id }}</a>
+          </div>
+        </li>
+        <li class="list-group-item" style="overflow-y: auto;">
+          <b>benchmark name</b>
+          <div align="right" style="display:inline-block; float: right;">
+            <a href="{{ url_for('app.batch', batch_id=contender.batch_id ) }}">{{ contender.display_bmname }}</a>
+          </div>
+        </li>
+        <li class="list-group-item" style="overflow-y: auto;">
+          <b>case permutation</b>
+          <div align="right" style="display:inline-block; float: right;">{{ contender.display_case_perm }}</div>
+        </li>
+        {% if contender_run %}
+          {% if contender_run.commit.url %}
             <li class="list-group-item" style="overflow-y: auto;">
-              <b>hardware</b>
-              <div align="right" style="display:inline-block; float: right;">{{ baseline_run.hardware.name }}</div>
+              <b>commit</b>
+              <div class="ellipsis-500"
+                   align="right"
+                   style="display:inline-block;
+                          float: right">
+                {% if contender_run.commit.display_message %}
+                  <a href="{{ contender_run.commit.url }}">{{ contender_run.commit.display_message }}</a>
+                {% else %}
+                  <a href="{{ contender_run.commit.url }}">{{ contender_run.commit.sha }}</a>
+                {% endif %}
+              </div>
             </li>
           {% endif %}
-          <li class="list-group-item list-group-item-secondary">measurement result</li>
-          {% for k,v in baseline.stats.items() %}
-            {% if v is not none %}
+          {% if contender_run.commit.display_timestamp %}
+            <li class="list-group-item" style="overflow-y: auto;">
+              <b>commit date</b>
+              <div align="right" style="display:inline-block; float: right;">{{ contender_run.commit.display_timestamp }}</div>
+            </li>
+          {% endif %}
+          {% if contender_run.commit.author_name %}
+            <li class="list-group-item" style="overflow-y: auto;">
+              <b>author</b>
+              <div align="right" style="display:inline-block; float: right;">
+                {{ contender_run.commit.author_name }}
+                {% if contender_run.commit.author_avatar %}
+                  <image src="{{ contender_run.commit.author_avatar }}"
+                         height="30"
+                         style="border-radius: 50%" />
+                {% endif %}
+              </div>
+            </li>
+          {% endif %}
+          {% if contender_run.commit.display_repository %}
+            <li class="list-group-item" style="overflow-y: auto;">
+              <b>repository</b>
+              <div align="right" style="display:inline-block; float: right;">
+                <a href="{{ contender_run.commit.repository }}">{{ contender_run.commit.display_repository }}</a>
+              </div>
+            </li>
+          {% endif %}
+          {% if contender_run.commit.branch %}
+            <li class="list-group-item" style="overflow-y: auto;">
+              <b>branch</b>
+              <div align="right" style="display:inline-block; float: right;">{{ contender_run.commit.branch }}</div>
+            </li>
+          {% endif %}
+          <li class="list-group-item" style="overflow-y: auto;">
+            <b>hardware</b>
+            <div align="right" style="display:inline-block; float: right;">{{ contender_run.hardware.name }}</div>
+          </li>
+        {% endif %}
+        <li class="list-group-item list-group-item-secondary">measurement result</li>
+        {% for k,v in contender.stats.items() %}
+          {% if v is not none %}
             <li class="list-group-item" style="overflow-y: auto;">
               <b>{{ k }}</b>
               <div align="right" style="display:inline-block; float: right;">{{ v }}</div>
             </li>
-            {% endif %}
-          {% endfor %}
-          {{ sections_with_different_fields(baseline, contender, baseline_run, contender_run, benchmark_to_display=baseline, run_to_display=baseline_run) }}
-        </ul>
-      </div>
-    {% endif %}
-    {% if contender %}
-      <div class="col-md-6">
-        <h5>result <a href="{{ url_for('app.benchmark-result', benchmark_result_id=baseline.id) }}">{{ contender.id}}</a></h5>
-        <ul class="list-group">
-          <li class="list-group-item list-group-item-secondary">overview</li>
-          <li class="list-group-item" style="overflow-y: auto;">
-            <b>time of benchmark</b>
-            <div align="right" style="display:inline-block; float: right;">{{ contender.display_timestamp }}</div>
-          </li>
-          <li class="list-group-item" style="overflow-y: auto;">
-            <b>submitted as part of CI run</b>
-            <div align="right" style="display:inline-block; float: right;">
-              <a href="{{ url_for('app.run', run_id=contender.run_id) }}">{{ contender.run_id }}</a>
-            </div>
-          </li>
-          <li class="list-group-item" style="overflow-y: auto;">
-            <b>benchmark name</b>
-            <div align="right" style="display:inline-block; float: right;">
-              <a href="{{ url_for('app.batch', batch_id=contender.batch_id ) }}">{{ contender.display_bmname }}</a>
-            </div>
-          </li>
-          <li class="list-group-item" style="overflow-y: auto;">
-            <b>case permutation</b>
-            <div align="right" style="display:inline-block; float: right;">{{ contender.display_case_perm }}</div>
-          </li>
-          {% if contender_run %}
-            {% if contender_run.commit.url %}
-              <li class="list-group-item" style="overflow-y: auto;">
-                <b>commit</b>
-                <div class="ellipsis-500"
-                     align="right"
-                     style="display:inline-block;
-                            float: right">
-                  {% if contender_run.commit.display_message %}
-                    <a href="{{ contender_run.commit.url }}">{{ contender_run.commit.display_message }}</a>
-                  {% else %}
-                    <a href="{{ contender_run.commit.url }}">{{ contender_run.commit.sha }}</a>
-                  {% endif %}
-                </div>
-              </li>
-            {% endif %}
-            {% if contender_run.commit.display_timestamp %}
-              <li class="list-group-item" style="overflow-y: auto;">
-                <b>commit date</b>
-                <div align="right" style="display:inline-block; float: right;">{{ contender_run.commit.display_timestamp }}</div>
-              </li>
-            {% endif %}
-            {% if contender_run.commit.author_name %}
-              <li class="list-group-item" style="overflow-y: auto;">
-                <b>author</b>
-                <div align="right" style="display:inline-block; float: right;">
-                  {{ contender_run.commit.author_name }}
-                  {% if contender_run.commit.author_avatar %}
-                    <image src="{{ contender_run.commit.author_avatar }}"
-                           height="30"
-                           style="border-radius: 50%" />
-                  {% endif %}
-                </div>
-              </li>
-            {% endif %}
-            {% if contender_run.commit.display_repository %}
-              <li class="list-group-item" style="overflow-y: auto;">
-                <b>repository</b>
-                <div align="right" style="display:inline-block; float: right;">
-                  <a href="{{ contender_run.commit.repository }}">{{ contender_run.commit.display_repository }}</a>
-                </div>
-              </li>
-            {% endif %}
-            {% if contender_run.commit.branch %}
-              <li class="list-group-item" style="overflow-y: auto;">
-                <b>branch</b>
-                <div align="right" style="display:inline-block; float: right;">{{ contender_run.commit.branch }}</div>
-              </li>
-            {% endif %}
-            <li class="list-group-item" style="overflow-y: auto;">
-              <b>hardware</b>
-              <div align="right" style="display:inline-block; float: right;">{{ contender_run.hardware.name }}</div>
-            </li>
           {% endif %}
-          <li class="list-group-item list-group-item-secondary">measurement result</li>
-          {% for k,v in contender.stats.items() %}
-            {% if v is not none %}
-            <li class="list-group-item" style="overflow-y: auto;">
-              <b>{{ k }}</b>
-              <div align="right" style="display:inline-block; float: right;">{{ v }}</div>
-            </li>
-            {% endif %}
-          {% endfor %}
-          {{ sections_with_different_fields(baseline, contender, baseline_run, contender_run, benchmark_to_display=contender, run_to_display=contender_run) }}
-        </ul>
-      </div>
-    {% endif %}
-  </div>
+        {% endfor %}
+        {{ sections_with_different_fields(baseline, contender, baseline_run, contender_run, benchmark_to_display=contender, run_to_display=contender_run) }}
+      </ul>
+    </div>
+  {% endif %}
+</div>
 {% endblock %}
 {% block scripts %}
   {{ super() }}

--- a/conbench/templates/compare-entity.html
+++ b/conbench/templates/compare-entity.html
@@ -30,16 +30,10 @@ matching fields between baseline and contender are aligned and mismatched fields
   {% endif %}
 {% endmacro %}
 {% block app_content %}
-  <nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-      <li class="breadcrumb-item active">Compare</li>
-      <li class="breadcrumb-item active" aria-current="page">
-        <a href="{{ url_for('app.benchmark-result', benchmark_result_id=baseline_id) }}">baseline result</a>
-        ...
-        <a href="{{ url_for('app.benchmark-result', benchmark_result_id=contender_id) }}">contender result</a>
-      </li>
-    </ol>
-  </nav>
+
+{{ utils.view_entity_title("comparing two results", "") }}
+
+
   <div class="row">
     <div class="col-md-6">
       <!-- what kind of plot is this supposed to be, especially given that

--- a/conbench/templates/compare-entity.html
+++ b/conbench/templates/compare-entity.html
@@ -49,10 +49,22 @@ matching fields between baseline and contender are aligned and mismatched fields
         let's maybe re-activate it when we understand its value better.
       -->
   </div>
-  <div align="center">{{ baseline.display_bmname }}, {{ baseline.display_case_perm }}</div>
-  <div id="plot-history-0" align="center"></div>
-  <br />
-  <div class="row">
+  <h4>historical context</h4>
+
+
+  {% if benchmark_result_history_plot_info.reason_why_no_plot %}
+    <p>Cannot display history plot: {{benchmark_result_history_plot_info.reason_why_no_plot | safe }}</p>
+  {% else %}
+
+    Both results have been obtained for <span>
+      <strong>{{ baseline.display_bmname }}</strong> /
+      <code>{{ baseline.display_case_perm }}</code>
+    </span>; the following plot highlights both of them in context of other directly comparable results:
+    <div id="plot-history-0" align="center"></div>
+  {% endif %}
+
+
+
     {% if baseline %}
       <div class="col-md-6">
         <ul class="list-group">

--- a/conbench/templates/compare-entity.html
+++ b/conbench/templates/compare-entity.html
@@ -73,6 +73,8 @@ matching fields between baseline and contender are aligned and mismatched fields
         <ul class="list-group">
           <li class="list-group-item list-group-item-secondary">overview</li>
           <li class="list-group-item" style="overflow-y: auto;">
+            <b>time of benchmark</b>
+            <div align="right" style="display:inline-block; float: right;">{{ baseline.display_timestamp }}</div>
           </li>
           <li class="list-group-item" style="overflow-y: auto;">
             <b>submitted as part of CI run</b>
@@ -144,11 +146,6 @@ matching fields between baseline and contender are aligned and mismatched fields
               <div align="right" style="display:inline-block; float: right;">{{ baseline_run.hardware.name }}</div>
             </li>
           {% endif %}
-          <li class="list-group-item active">Result</li>
-          <li class="list-group-item" style="overflow-y: auto;">
-            <b>timestamp</b>
-            <div align="right" style="display:inline-block; float: right;">{{ baseline.display_timestamp }}</div>
-          </li>
           {% for k,v in baseline.stats.items() %}
             <li class="list-group-item" style="overflow-y: auto;">
               <b>{{ k }}</b>
@@ -165,6 +162,8 @@ matching fields between baseline and contender are aligned and mismatched fields
         <ul class="list-group">
           <li class="list-group-item list-group-item-secondary">overview</li>
           <li class="list-group-item" style="overflow-y: auto;">
+            <b>time of benchmark</b>
+            <div align="right" style="display:inline-block; float: right;">{{ contender.display_timestamp }}</div>
           </li>
           <li class="list-group-item" style="overflow-y: auto;">
             <b>submitted as part of CI run</b>
@@ -236,11 +235,6 @@ matching fields between baseline and contender are aligned and mismatched fields
               <div align="right" style="display:inline-block; float: right;">{{ contender_run.hardware.name }}</div>
             </li>
           {% endif %}
-          <li class="list-group-item active">Result</li>
-          <li class="list-group-item" style="overflow-y: auto;">
-            <b>timestamp</b>
-            <div align="right" style="display:inline-block; float: right;">{{ contender.display_timestamp }}</div>
-          </li>
           {% for k,v in contender.stats.items() %}
             <li class="list-group-item" style="overflow-y: auto;">
               <b>{{ k }}</b>

--- a/conbench/templates/compare-entity.html
+++ b/conbench/templates/compare-entity.html
@@ -65,6 +65,8 @@ matching fields between baseline and contender are aligned and mismatched fields
 
 
 
+  <h4>raw comparison</h4>
+  <div class="row mt-4">
     {% if baseline %}
       <div class="col-md-6">
         <ul class="list-group">

--- a/conbench/templates/compare-entity.html
+++ b/conbench/templates/compare-entity.html
@@ -146,11 +146,14 @@ matching fields between baseline and contender are aligned and mismatched fields
               <div align="right" style="display:inline-block; float: right;">{{ baseline_run.hardware.name }}</div>
             </li>
           {% endif %}
+          <li class="list-group-item list-group-item-secondary">measurement result</li>
           {% for k,v in baseline.stats.items() %}
+            {% if v is not none %}
             <li class="list-group-item" style="overflow-y: auto;">
               <b>{{ k }}</b>
-              {% if v is not none %}<div align="right" style="display:inline-block; float: right;">{{ v }}</div>{% endif %}
+              <div align="right" style="display:inline-block; float: right;">{{ v }}</div>
             </li>
+            {% endif %}
           {% endfor %}
           {{ sections_with_different_fields(baseline, contender, baseline_run, contender_run, benchmark_to_display=baseline, run_to_display=baseline_run) }}
         </ul>
@@ -235,11 +238,14 @@ matching fields between baseline and contender are aligned and mismatched fields
               <div align="right" style="display:inline-block; float: right;">{{ contender_run.hardware.name }}</div>
             </li>
           {% endif %}
+          <li class="list-group-item list-group-item-secondary">measurement result</li>
           {% for k,v in contender.stats.items() %}
+            {% if v is not none %}
             <li class="list-group-item" style="overflow-y: auto;">
               <b>{{ k }}</b>
-              {% if v is not none %}<div align="right" style="display:inline-block; float: right;">{{ v }}</div>{% endif %}
+              <div align="right" style="display:inline-block; float: right;">{{ v }}</div>
             </li>
+            {% endif %}
           {% endfor %}
           {{ sections_with_different_fields(baseline, contender, baseline_run, contender_run, benchmark_to_display=contender, run_to_display=contender_run) }}
         </ul>

--- a/conbench/templates/compare-entity.html
+++ b/conbench/templates/compare-entity.html
@@ -69,13 +69,10 @@ matching fields between baseline and contender are aligned and mismatched fields
   <div class="row mt-4">
     {% if baseline %}
       <div class="col-md-6">
+        <h5>result <a href="{{ url_for('app.benchmark-result', benchmark_result_id=baseline.id) }}">{{ baseline.id }}</a></h5>
         <ul class="list-group">
-          <li class="list-group-item active">Baseline</li>
+          <li class="list-group-item list-group-item-secondary">overview</li>
           <li class="list-group-item" style="overflow-y: auto;">
-            <b>result ID</b>
-            <div align="right" style="display:inline-block; float: right;">
-              <a href="{{ url_for('app.benchmark-result', benchmark_result_id=baseline.id) }}">{{ baseline.id }}</a>
-            </div>
           </li>
           <li class="list-group-item" style="overflow-y: auto;">
             <b>submitted as part of CI run</b>
@@ -164,13 +161,10 @@ matching fields between baseline and contender are aligned and mismatched fields
     {% endif %}
     {% if contender %}
       <div class="col-md-6">
+        <h5>result <a href="{{ url_for('app.benchmark-result', benchmark_result_id=baseline.id) }}">{{ contender.id}}</a></h5>
         <ul class="list-group">
-          <li class="list-group-item active">Contender</li>
+          <li class="list-group-item list-group-item-secondary">overview</li>
           <li class="list-group-item" style="overflow-y: auto;">
-            <b>result ID</b>
-            <div align="right" style="display:inline-block; float: right;">
-              <a href="{{ url_for('app.benchmark-result', benchmark_result_id=contender.id) }}">{{ contender.id }}</a>
-            </div>
           </li>
           <li class="list-group-item" style="overflow-y: auto;">
             <b>submitted as part of CI run</b>

--- a/conbench/templates/compare-entity.html
+++ b/conbench/templates/compare-entity.html
@@ -1,5 +1,5 @@
 {% extends "app.html" %}
-{# This macro displays Tags, Hardware, Context and Info fields in comparative view so
+{# This macro displays tags, Hardware, Context and Info fields in comparative view so
 matching fields between baseline and contender are aligned and mismatched fields and/or values are highlighted in red #}
 {% macro attribute_fields(fields, baseline_dict, contender_dict, dict_to_display) %}
   {% for field in fields %}
@@ -16,16 +16,16 @@ matching fields between baseline and contender are aligned and mismatched fields
     </li>
   {% endfor %}
 {% endmacro %}
-{# This macro displays Tags, Hardware, Context and Info sections for either baseline or contender #}
+{# This macro displays tags, Hardware, Context and Info sections for either baseline or contender #}
 {% macro sections_with_different_fields(baseline, contender, baseline_run, contender_run, benchmark_to_display, run_to_display) %}
-  <li class="list-group-item active">Tags</li>
+  <li class="list-group-item list-group-item-secondary">tags</li>
   {{ attribute_fields(tags_fields, baseline.tags, contender.tags, dict_to_display=benchmark_to_display.tags) }}
-  <li class="list-group-item active">Hardware</li>
+  <li class="list-group-item list-group-item-secondary">hardware</li>
   {{ attribute_fields(hardware_fields, baseline_run.hardware, contender_run.hardware, dict_to_display=run_to_display.hardware) }}
-  <li class="list-group-item active">Context</li>
+  <li class="list-group-item list-group-item-secondary">context</li>
   {{ attribute_fields(context_fields, baseline.context, contender.context, dict_to_display=benchmark_to_display.context) }}
   {% if benchmark_to_display.info and benchmark_to_display.info|length > 1 %}
-    <li class="list-group-item active">Additional Information</li>
+    <li class="list-group-item list-group-item-secondary">additional context</li>
     {{ attribute_fields(info_fields, baseline.info, contender.info, dict_to_display=benchmark_to_display.info) }}
   {% endif %}
 {% endmacro %}

--- a/conbench/templates/compare-entity.html
+++ b/conbench/templates/compare-entity.html
@@ -110,7 +110,7 @@ matching fields between baseline and contender are aligned and mismatched fields
             {% endif %}
             {% if baseline_run.commit.display_timestamp %}
               <li class="list-group-item" style="overflow-y: auto;">
-                <b>date</b>
+                <b>commit date</b>
                 <div align="right" style="display:inline-block; float: right;">{{ baseline_run.commit.display_timestamp }}</div>
               </li>
             {% endif %}
@@ -199,7 +199,7 @@ matching fields between baseline and contender are aligned and mismatched fields
             {% endif %}
             {% if contender_run.commit.display_timestamp %}
               <li class="list-group-item" style="overflow-y: auto;">
-                <b>date</b>
+                <b>commit date</b>
                 <div align="right" style="display:inline-block; float: right;">{{ contender_run.commit.display_timestamp }}</div>
               </li>
             {% endif %}

--- a/conbench/templates/compare-list.html
+++ b/conbench/templates/compare-list.html
@@ -1,7 +1,6 @@
 {% extends "app.html" %}
 {% block app_content %}
-{{ utils.view_entity_title("comparing result sets", "") }}
-
+  {{ utils.view_entity_title("comparing result sets", "") }}
   {% if baseline_run and contender_run %}
     <div class="row row-cols-md-2 g-4 mb-2">
       <div class="col">

--- a/conbench/templates/compare-list.html
+++ b/conbench/templates/compare-list.html
@@ -1,5 +1,7 @@
 {% extends "app.html" %}
 {% block app_content %}
+{{ utils.view_entity_title("comparing result sets", "") }}
+
   {% if baseline_run and contender_run %}
     <div class="row row-cols-md-2 g-4 mb-2">
       <div class="col">

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -1,7 +1,7 @@
 {% extends "app.html" %}
 {% block app_content %}
   <h1>CI runs</h1>
-  <div class="mt-4">
+  <div class="mt-3">
     {% for reponame, runobjs in repo_runs_map.items() %}
       <div class="row mb-5">
         <h4>

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -1,7 +1,7 @@
 {% extends "app.html" %}
 {% import 'bootstrap/wtf.html' as wtf %}
 {% block app_content %}
-  <h1>CI run {{ run.id[:20] }}</h1>
+  {{ utils.view_entity_title("CI run", run.id) }}
   <div class="mt-4 cb-run-details-panel shadow-sm">
     benchmarked code:
     <br>

--- a/conbench/templates/utils.jinja
+++ b/conbench/templates/utils.jinja
@@ -1,0 +1,7 @@
+{% macro view_entity_title(maintitle, subtitle) -%}
+<div class="cb-title">
+  <h1 class="display-6">{{maintitle}}</h2>
+  <div class="small text-muted cb-subtitle font-monospace">{{subtitle}}</div>
+  <hr>
+</div>
+{%- endmacro %}

--- a/conbench/templates/utils.jinja
+++ b/conbench/templates/utils.jinja
@@ -1,6 +1,6 @@
 {% macro view_entity_title(maintitle, subtitle) -%}
 <div class="cb-title">
-  <h1 class="display-6">{{maintitle}}</h2>
+  <h1 class="display-6">{{maintitle}}</h1>
   <div class="small text-muted cb-subtitle font-monospace">{{subtitle}}</div>
   <hr>
 </div>


### PR DESCRIPTION
This is mainly for #1369, but also:

- show history plot conditionally
- show info/err msg when history plot doesn't show (see screenshot below)
- devprod: use a macro for generating entity heading (just a tiny start)
- more small tweaks, see commit msgs


![Screenshot from 2023-07-21 12-40-27](https://github.com/conbench/conbench/assets/265630/525d2bb3-25f1-4aa1-8ecb-9bc86824deda)

The err msg needs tweaking, as it's now being used in a new context. That's fine, follow-up.
