### PR TITLE
UI: run: make measurement sortable

### DIFF
--- a/conbench/app/_util.py
+++ b/conbench/app/_util.py
@@ -70,6 +70,8 @@ def set_display_time(benchmark):
 
 def set_display_mean(benchmark):
     """
+    this needs to go away. :)
+
     Unclear in which context this is being consumed: where is this displayed?
     Does it make sense to limit this to a certain number of significant digits?
 
@@ -86,6 +88,8 @@ def set_display_mean(benchmark):
     unit = benchmark["stats"]["unit"]
     mean = float(benchmark["stats"]["mean"])
     benchmark["display_mean"] = f"{numstr(mean, sigfigs=4)} {unit}"
+    # for html5 data order attr
+    benchmark["mean_value"] = mean
 
 
 def set_display_error(benchmark):

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -89,7 +89,7 @@
               </td>
               <td class="font-monospace">{{ result.display_case_perm }}</td>
               <!--<td class="font-monospace">n/a</td>-->
-              <td class="font-monospace">
+              <td class="font-monospace" data-order="{{ result.mean_value }}">
                 {% if result.error %}
                   <i class="bi bi-exclamation-circle text-danger"
                      data-toggle="tooltip"


### PR DESCRIPTION
For issue #1347. This is unit-unaware sorting, optimizing for a frequent special case.

When there is more than one unit in this column then this current sorting method doesn't quite make sense. But without this pragmatic patch it never quite makes sense.

