### PR TITLE
http path timeouts: new alignment

### DIFF
--- a/benchclients/python/benchclients/conbench.py
+++ b/benchclients/python/benchclients/conbench.py
@@ -49,8 +49,10 @@ class ConbenchClient(RetryingHTTPClient):
     # https://github.com/conbench/conbench/issues/806. One such
     # context-specific timeout constant is for a login request, see below.
     # Note: for now, this `timeout_long_running_requests` timeout constant
-    # applies to all requests unless specified otherwise.
-    timeout_long_running_requests = (3.5, 120)
+    # applies to all requests unless specified otherwise. This should be
+    # aligned with other timeout constants:
+    # https://github.com/conbench/conbench/issues/1384
+    timeout_long_running_requests = (3.5, 150)
 
     timeout_login_request = (3.5, 10)
 

--- a/conbench/gunicorn-conf.py
+++ b/conbench/gunicorn-conf.py
@@ -42,12 +42,14 @@ threads = 15
 # process per gunicorn, and a single HTTP request could render a single process
 # occupied. Keep a large value for now, for the case where all threads in the
 # process process genuine requests (which all take a while to respond to)
-timeout = 120
+timeout = 180
 
-# Also see https://github.com/conbench/conbench/issues/1156 I picked 70 because
-# that's longer than 60 (some cloud load balancers default to this). but it's
-# shorter than nginx' default of 75 seconds.
-keepalive = 70
+# Also see https://github.com/conbench/conbench/issues/1156; this must be
+# longer than ALB's idle timeout (if ALB is right in front of gunicorn, which
+# it is in our case -- ideally there should be nginx inbetween). Assume
+# ALB idle timeout is 160 s. Also see
+# https://github.com/conbench/conbench/issues/1384
+keepalive = 170
 
 # Reduce this from the default (1000), and have gunicorn reject further
 # TCP connections. This makes sense in terms of back-pressure.

--- a/k8s/conbench-cloud-ingress.templ.yml
+++ b/k8s/conbench-cloud-ingress.templ.yml
@@ -32,10 +32,16 @@ metadata:
     # will be ignored." That is preclisely what we want, a no-brainer
     # configuration parameter that disallows serving traffic via non-TLS.
     alb.ingress.kubernetes.io/ssl-redirect: '443'
-    # This is here mainly to take active control. Must be shorter than the
-    # timeout constant of the other end, see
-    # https://github.com/conbench/conbench/issues/1156
-    alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=50
+    # The ALB "idle timeout" Must be shorter than the TCP conn
+    # keepalive-related timeout constant of the other end, see
+    # https://github.com/conbench/conbench/issues/1156 -- Note that this is
+    # also what is elsewhere called a "request timeout", ALB sends a 504
+    # Gateway Timeout if the back-end does not return a response in this time
+    # window. That is, let's pick this to be longer than the timeout constant
+    # we use in reasonable clients. For example: client: 150 s, ALB idle
+    # timeout: 160 s, gunicorn keepalive timeout: 170 s gunicorn worker
+    # timeout: 180 s. Also see https://github.com/conbench/conbench/issues/1384
+    alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=160
     alb.ingress.kubernetes.io/certificate-arn: <CERTIFICATE_ARN>
   labels:
     app: conbench-ingress


### PR DESCRIPTION
For issue #1384.

```
150 s (client) -> 160 s (ALB idle timeout  -> 170 s (gunicorn tcp keepalive) -> 180 s (gunicorn worker timeout)
```
