### PR TITLE
http api: compare endpoints: emit 429 when semaphore blocked

### DIFF
--- a/benchclients/python/benchclients/http.py
+++ b/benchclients/python/benchclients/http.py
@@ -398,8 +398,7 @@ class RetryingHTTPClient(ABC):
         status code alone?
         """
         if code == 429:
-            # Not yet emitted by Conbench, but that's the canonical way to
-            # signal "back off, retry soon".
+            # Canonical way to signal "back off, retry soon".
             return True
 
         # Retry upon any 5xx response, later maybe fine-tune by specific status

--- a/conbench/api/_resp.py
+++ b/conbench/api/_resp.py
@@ -14,6 +14,15 @@ def resp400(description: str) -> flask.Response:
     )
 
 
+def resp429(description: str) -> flask.Response:
+    return flask.make_response(
+        # This puts a JSON body into the response with a JSON object with one
+        # key, the description
+        flask.jsonify(description=description),
+        429,
+    )
+
+
 def json_response_for_byte_sequence(data: bytes, status_code: int) -> flask.Response:
     # Note(JP): it's documented that a byte sequence can be passed in:
     # https://flask.palletsprojects.com/en/2.2.x/api/#flask.Flask.make_response


### PR DESCRIPTION
This is for #1382.

Picked a really small timeout constant, could have done `(block=False)` instead -- but using the timeout constant I think is a tiny more elegant, because it can trivially be bumped -- maybe in the future we find that instead of forcing clients to go through an active retry cycle we _want_ to keep them waiting in line for a few seconds.

I manually tested that this works; I did not yet bother creating a test case for this (as it does require more or less precise concurrency control; we can easily do this in the future).