### PR TITLE
kube-prom: do not use custom storage class

### DIFF
--- a/k8s/kube-prometheus/conbench-flavor.jsonnet
+++ b/k8s/kube-prometheus/conbench-flavor.jsonnet
@@ -77,35 +77,40 @@ local kp =
     prometheus+: {
       prometheus+: {
         spec+: {
+          // NOTE(JP): leave this outcommented for all environments until
+          // we are ready to use the aws-ebs-csi-driver method (or comparable
+          // on GCP, where persistent volumes are after all automatically
+          // provisioned). Goal: do not use custom storage class anymore,
+          // this was a fun exercise but is too brittle.
           // https://github.com/prometheus-operator/kube-prometheus/blob/117ce2f8b51621ccb480e8bdd712ae21e92b744e/examples/prometheus-pvc.jsonnet
           // vd-2 in mind. Almost ephemeral setup. But we want to retain
           // data across kube-prometheus updates. Use short retention and tiny
           // persistent volumes.
-          retention: '12d',
+          // retention: '12d',
           // <comment-used-by-ci: pvc-start>
-          storage: {
-            volumeClaimTemplate: {
-              apiVersion: 'v1',
-              kind: 'PersistentVolumeClaim',
-              spec: {
-                accessModes: ['ReadWriteOnce'],
-                // 6 days vs 9Gi? I have no idea, but sounds roughly reasonable
-                // given the not-too-big-data-rate we expect. But we have to
-                // see, and measure: easy, there is a dashboard for that. Note:
-                // think of this as an advanced buffer. This is an ephemeral
-                // system that should write data out to a more long-term
-                // storage-optimized system.
-                resources: { requests: { storage: '9Gi' } },
-                // storageClassName: 'gp2'. aws-ebs-csi-driver method was a bit
-                // mad. EBS-backed "local storage" to on vd-2 nodes however
-                // works. Manually exposed ext4-formatted partitions to k8s
-                // with a rather beautiful setup using the Local Persistent
-                // Volume CSI Driver, offering a storage class which is for
-                // now called 'fundisk-elb-backed' because fun und such.
-                storageClassName: 'fundisk-elb-backed',
-              },
-            },
-          },
+          // storage: {
+          //   volumeClaimTemplate: {
+          //     apiVersion: 'v1',
+          //     kind: 'PersistentVolumeClaim',
+          //     spec: {
+          //       accessModes: ['ReadWriteOnce'],
+          //       // 6 days vs 9Gi? I have no idea, but sounds roughly reasonable
+          //       // given the not-too-big-data-rate we expect. But we have to
+          //       // see, and measure: easy, there is a dashboard for that. Note:
+          //       // think of this as an advanced buffer. This is an ephemeral
+          //       // system that should write data out to a more long-term
+          //       // storage-optimized system.
+          //       resources: { requests: { storage: '9Gi' } },
+          //       // storageClassName: 'gp2'. aws-ebs-csi-driver method was a bit
+          //       // mad. EBS-backed "local storage" to on vd-2 nodes however
+          //       // works. Manually exposed ext4-formatted partitions to k8s
+          //       // with a rather beautiful setup using the Local Persistent
+          //       // Volume CSI Driver, offering a storage class which is for
+          //       // now called 'fundisk-elb-backed' because fun und such.
+          //       storageClassName: 'fundisk-elb-backed',
+          //     },
+          //   },
+          // },
           // <comment-used-by-ci: pvc-end>
           // Required for de-duplicating (and preventing double billing) on
           // the receivind end (Grafana Cloud) when sending from more than one


### PR DESCRIPTION
Internal ticket PFE-1980. The manual EBS-based setup is brittle, broke various times, and each time needed manual cleanup. Now we have a place to push (some of) the data out, and can make the cluster-local buffer less persistent, temporarily at least.

As the next step we can use the aws-ebs-csi-driver technique again to get the best of both worlds:
- cluster-local persistence (of all timeseries, with useful retention time (30 days, for example)
- external persistence of a subset