### PR TITLE
UI: tables: dynamically switch to scientific notation, better spacing

### DIFF
--- a/conbench/app/_util.py
+++ b/conbench/app/_util.py
@@ -1,6 +1,6 @@
 import flask as f
 
-from conbench.numstr import numstr
+from conbench.numstr import numstr_dyn
 
 from ..config import Config
 from ..hacks import set_display_benchmark_name, set_display_case_permutation
@@ -78,16 +78,13 @@ def set_display_mean(benchmark):
     This probably should be transitioned to SVS (not just mean). And depending
     on the context we may want to show/reveal raw data (with needless
     precision) _or_ limit precision (via sigfigs count) meaningfully.
-
-    Update: seems to be shown in a tabular view where a per-result value
-    is shown. 4 sigfigs are enough then.
     """
     if not benchmark["stats"]["mean"]:
         return ""
 
     unit = benchmark["stats"]["unit"]
     mean = float(benchmark["stats"]["mean"])
-    benchmark["display_mean"] = f"{numstr(mean, sigfigs=4)} {unit}"
+    benchmark["display_mean"] = f"{numstr_dyn(mean)} {unit}"
     # for html5 data order attr
     benchmark["mean_value"] = mean
 

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -19,7 +19,7 @@ from sqlalchemy.orm import Mapped, relationship
 import conbench.units
 import conbench.util
 from conbench.dbsession import current_session
-from conbench.numstr import numstr
+from conbench.numstr import numstr, numstr_dyn
 
 from ..entities._entity import (
     Base,
@@ -581,8 +581,8 @@ def ui_mean_and_uncertainty(values: List[float], unit: str) -> str:
         return "no data"
 
     if len(values) < 3:
-        # Show each sample with five significant figures.
-        return "; ".join(f"{numstr(v, sigfigs=5)} {unit}" for v in values)
+        # Show each sample with fewish significant figures.
+        return "; ".join(f"{numstr_dyn(v)} {unit}" for v in values)
 
     # Build sample standard deviation. Maybe we can also use the pre-built
     # value, but trust needs to be established first.

--- a/conbench/numstr.py
+++ b/conbench/numstr.py
@@ -52,9 +52,55 @@ import numpy as np
 # import sigfig
 
 
+def numstr_dyn(v: Union[float, int]) -> str:
+    """
+    Turn number into string. Limit the count of significant figures.
+    Dynamically switch to scientific notation for large numbers (larger 10**6)
+    and small numbers (smaller 10**-6).
+
+    Regarding precision: this is so far meant to be used in
+    overview/summary/tabular representation where the 'rough' measurement
+    result should be presented in a canonical/non-cryptical way. Higher
+    precision / raw data is available to the user elsewhere. precision/sigfigs
+    is no argument to this function at this point to hopefully achieve
+    consistency across UI.
+
+    >>> numstr.numstr_dyn(1.290823987290392)
+    '1.29082'
+    >>> numstr.numstr_dyn(1239127)
+    '1.24e+06'
+    >>> numstr.numstr_dyn(0.000000000023823987290392)
+    '2.38e-11'
+    >>> numstr.numstr_dyn(123912)
+    '123912'
+
+    """
+    if 10**6 > v > 10**-6:
+        return numstr(v, 6)
+    return numstr_exp(v, 2)
+
+
+def numstr_exp(v: Union[float, int], sigfigs: int = 2) -> str:
+    """
+    Turn number into string with scientific notation, limiting the count of
+    significant figures.
+
+    Examples:
+
+    >>> numstr.numstr_sn(123902901380912893, 2)
+    '1.24e+17'
+
+    The example shows that these may be considered three significant digits.
+
+    Trim "-" is documented with "trim trailing zeros and any trailing decimal
+    point"
+    """
+    return np.format_float_scientific(v, precision=sigfigs, trim="-", exp_digits=1)
+
+
 def numstr(v: Union[float, int], sigfigs: int = 5) -> str:
     """
-    Turn number into string while limiting the number of significant figures.
+    Turn number into string while limiting the count of significant figures.
 
     Examples:
 

--- a/conbench/static/app.css
+++ b/conbench/static/app.css
@@ -115,19 +115,22 @@ div.case-param-panel {
   border: 1px solid #4981C8aa;
 }
 
+table.results-in-run-table tbody tr td,
 table.c-bench-caseperm-table tbody tr td {
   font-family: var(--bs-font-monospace);
-  font-size: 12px;
+  font-size: 0.8rem;
 }
 
+/*
 table.c-bench-caseperm-table td.casepermstring {
   font-size: 12px;
 }
 
+
 table.c-bench-caseperm-table th {
   font-size: 12px;
 }
-
+*/
 
 div.cb-title h1 {
   /* reduce default mb*/
@@ -260,8 +263,8 @@ table.dataTable a {
 
 }
 
-table.dataTable  {
-
+.brutal-break {
+  word-break: break-all;
 }
 
 .pagination {

--- a/conbench/templates/c-benchmark-cases.html
+++ b/conbench/templates/c-benchmark-cases.html
@@ -62,7 +62,7 @@
   </div>
 {% endif %}
 <div class="mt-3">
-  <table class="table table-hover conbench-datatable c-bench-caseperm-table"
+  <table class="table table-hover conbench-datatable c-bench-caseperm-table small"
          style="width:100%;
                 display: none">
     <thead>

--- a/conbench/templates/compare-list.html
+++ b/conbench/templates/compare-list.html
@@ -120,10 +120,10 @@
         {% for c in comparisons %}
           {% if (c.contender is not none) and (c.baseline is not none) %}
             <tr>
-              <td>
+              <td class="brutal-break">
                 <div>{{ c.baseline.benchmark_name }}</div>
               </td>
-              <td>
+              <td class="brutal-break">
                 <a href="{{ c.compare_benchmarks_url }}">
                   <div>{{ c.baseline.case_permutation }}</div>
                 </a>
@@ -235,6 +235,14 @@
           // default sort order: by z-score count, lowest first (regressions first)
           "order": [[5, 'asc']],
           "columnDefs": [{ "orderable": true }],
+          "columns": [
+            { "width": "25%" }, // force max 20 %, also requires brutal-break
+            null, // you get the rest (case perm string), also requires brutal-break
+            { "width": "12%" },
+            { "width": "12%" },
+            { "width": "9%" },
+            { "width": "7%" }
+          ],
           initComplete: function () {
             var api = this.api();
                 // reveal only after DOM modification is complete (reduce loading

--- a/conbench/templates/run.html
+++ b/conbench/templates/run.html
@@ -64,13 +64,12 @@
                     display: none">
         <thead>
           <tr>
-            <th scope="col" style="width: 120px">benchmark name</th>
-            <th scope="col" style="width: 150px">start time (UTC)</th>
+            <th scope="col">benchmark name</th>
+            <th scope="col">start time (UTC)</th>
             <th scope="col">result</th>
             <th scope="col">case permutation</th>
-            <!--<th scope="col" style="width: 10%">measurements</th>-->
-            <th scope="col" style="width: 8%">measurement</th>
-            <th scope="col" style="width: 10%">
+            <th scope="col">measurement</th>
+            <th scope="col">
               rel err
               <sup><i class="bi bi-info-circle"
    data-bs-toggle="tooltip"
@@ -82,12 +81,12 @@
         <tbody>
           {% for result in benchmarks %}
             <tr>
-              <td class="font-monospace">{{ result.display_bmname  }}</td>
+              <td class="font-monospace brutal-break">{{ result.display_bmname  }}</td>
               <td class="font-monospace">{{ result.display_timestamp[:-4] }}</td>
               <td class="font-monospace">
                 <a href="{{ url_for('app.benchmark-result', benchmark_result_id=result.id) }}">{{ result.id [:9] }}</a>
               </td>
-              <td class="font-monospace">{{ result.display_case_perm }}</td>
+              <td class="font-monospace brutal-break">{{ result.display_case_perm }}</td>
               <!--<td class="font-monospace">n/a</td>-->
               <td class="font-monospace" data-order="{{ result.mean_value }}">
                 {% if result.error %}
@@ -151,7 +150,17 @@
 
       // default sort order: by z-score count, lowest first (regressions first)
       "order": [[0, 'asc']],
-      "columnDefs": [{ "orderable": true }],
+      "columnDefs": [
+        { "orderable": true },
+      ],
+      "columns": [
+        { "width": "20%" }, // force max 20 %, also requires brutal-break
+        { "width": "15%" },
+        { "width": "9%" },
+        null,               // you get the rest (case perm string), also requires brutal-break
+        { "width": "12%" },
+        { "width": "7%" }
+      ],
       initComplete: function () {
         var api = this.api();
             // reveal only after DOM modification is complete (reduce loading


### PR DESCRIPTION
This is work towards https://github.com/conbench/conbench/issues/1380. See commit messages!

This does not yet help directly for #1380 because we need to do #1334 first.

It's noteworthy that within a column this may still result in tiny inconsistencies, fundamentally. Nothing we can/want to do against this. That is because we format each number independently, instead of choosing constant formatting for all numbers in a column.

We have to do this because within one of these colums there might be results from a variety of different benchmark methods, i.e. we cannot assume a certain unit or order of magnitude.

I just wanted to have clarified that maximum numeric/formatting/unit homogeneity across a column in the UI is not the goal here, i.e. some comparisons may require really looking at number and unit).
