### PR TITLE
ci: apply k8s ingress, service, servicemon cfg on ursa2

### DIFF
--- a/.buildkite/utils.sh
+++ b/.buildkite/utils.sh
@@ -130,7 +130,7 @@ deploy() {
     sed "s|{{CONBENCH_WEBAPP_IMAGE_SPEC}}|${IMAGE_SPEC}|g" | kubectl apply -f -
 
 
-  if [[ "$EKS_CLUSTER" == "vd-2" ]]; then
+  if [[ "$EKS_CLUSTER" == "vd-2" || "$EKS_CLUSTER" == "ursa-2" ]]; then
     # (Re-)apply ALB ingress config. Note(JP): if this results in re-creation
     # of the ALB then we need to out-of-band update an A record in Route53,
     # because we do not yet use k8s externalDNS features.
@@ -142,7 +142,7 @@ deploy() {
     kubectl apply -f k8s/conbench-service.yml
     kubectl apply -f k8s/conbench-service-monitor.yml
   else
-    echo "non-vd-2: skip k8s ingress and service patch (rely on name to still match: 'conbench-service')"
+    echo "skip k8s ingress and service patch (rely on name to still match: 'conbench-service')"
   fi
 
   # Note(JP); this might be nonobvious, but `rollout status` waits for


### PR DESCRIPTION
This patch changes the buildkite deploy pipeline for ursa-2 to exercise the following bits:
```
    cat k8s/conbench-cloud-ingress.templ.yml | \
      sed "s/<CERTIFICATE_ARN>/${CERTIFICATE_ARN}/g" | \
      sed "s/<CONBENCH_INTENDED_DNS_NAME>/${CONBENCH_INTENDED_DNS_NAME}/g" | \
        kubectl apply -f -

    kubectl apply -f k8s/conbench-service.yml
    kubectl apply -f k8s/conbench-service-monitor.yml
```

That has pretty vast (desired) impact across monitoring (Prometheus operator makes sense of the service monitor), service exposure (new ALB cfg+annotations will start to apply), networking (normal service object).

Upon first execution against conbench.ursa.dev this might result in downtime as of creating a new ALB which will then require updating DNS configuration. That's OK.