### PR TITLE
ci: minikube: bump k8s: 1.23 -> 1.26

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -207,7 +207,7 @@ jobs:
         id: minikube
         uses: medyagh/setup-minikube@e1ee887a96c50e34066a4bf9f172eb94ae69d454
         with:
-          kubernetes-version: v1.23.16
+          kubernetes-version: v1.26.7
           # By convention, both locally and in CI we call this mk-conbench.
           start-args: '--profile mk-conbench --extra-config=kubelet.cgroup-driver=systemd'
           cpus: max


### PR DESCRIPTION
We pinned this old version so far because some prod deployments were on old k8s. That has changed by now. That's good; kube-prometheus plans for more modern k8s.

https://github.com/prometheus-operator/kube-prometheus#compatibility

We currently use (a pinned commit on) the main branch of kube-prometheus, and should be running 1.26 or 1.27:

![image](https://github.com/conbench/conbench/assets/265630/abd44b9f-4df6-4ef4-b117-517abe96aeaf)


