### PR TITLE
benchalerts: add benchmark name/language to notifications

### DIFF
--- a/benchalerts/benchalerts/message_formatting.py
+++ b/benchalerts/benchalerts/message_formatting.py
@@ -51,7 +51,7 @@ def _list_results(
                 benchmark_result.run_hardware,
             )
             previous_run_id = benchmark_result.run_id
-        out += f"\n  - [{benchmark_result.name}]({benchmark_result.link})"
+        out += f"\n  - [{benchmark_result.display_name}]({benchmark_result.link})"
 
     if out:
         out += "\n\n"

--- a/benchalerts/tests/integration_tests/test_alert_pipeline.py
+++ b/benchalerts/tests/integration_tests/test_alert_pipeline.py
@@ -92,7 +92,7 @@ def test_alert_pipeline(monkeypatch: pytest.MonkeyPatch, github_auth: str):
 There was 1 benchmark result indicating a performance regression:
 
 - Commit Run on `GitHub-runner-8-core` at [2023-02-28 18:08:51Z](http://velox-conbench.voltrondata.run/compare/runs/GHA-4286800623-1...GHA-4296026775-1/)
-  - [source=cpp-micro, suite=velox_benchmark_basic_vector_fuzzer](http://velox-conbench.voltrondata.run/compare/benchmarks/a128eb19cc9442409148c91f7fa18cdf...ff7a1a86df5a4d56b6dbfb006c13c638)
+  - [`velox_benchmark_basic_vector_fuzzer` (C++) with source=cpp-micro, suite=velox_benchmark_basic_vector_fuzzer](http://velox-conbench.voltrondata.run/compare/benchmarks/a128eb19cc9442409148c91f7fa18cdf...ff7a1a86df5a4d56b6dbfb006c13c638)
 
 The [full Conbench report](https://github.com/conbench/benchalerts/runs/RUN_ID) has more details."""
 

--- a/benchalerts/tests/unit_tests/expected_md/comment_errors_baselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_errors_baselines.md
@@ -3,15 +3,15 @@ Conbench analyzed the 3 benchmark runs on commit `abc`.
 There were 3 benchmark results with an error:
 
 - Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
-  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmark-results/some-benchmark-uuid-4)
-  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmark-results/some-benchmark-uuid-4)
+  - [`file-write` (Python) with snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmark-results/some-benchmark-uuid-4)
+  - [`file-write` (Python) with snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmark-results/some-benchmark-uuid-4)
 - and 1 more (see the report linked below)
 
 There were 3 benchmark results indicating a performance regression:
 
 - Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
-  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
-  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
+  - [`file-read` (Python) with snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
+  - [`file-read` (Python) with snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
 - and 1 more (see the report linked below)
 
 The [full Conbench report](https://github.com/github/hello-world/runs/4) has more details.

--- a/benchalerts/tests/unit_tests/expected_md/comment_regressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/comment_regressions.md
@@ -3,8 +3,8 @@ Conbench analyzed the 3 benchmark runs on commit `abc`.
 There were 2 benchmark results indicating a performance regression:
 
 - Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
-  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
-  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
+  - [`file-read` (Python) with snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
+  - [`file-read` (Python) with snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
 
 The [full Conbench report](https://github.com/github/hello-world/runs/4) has more details.
 

--- a/benchalerts/tests/unit_tests/expected_md/summary_errors_baselines.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_errors_baselines.md
@@ -5,9 +5,9 @@ Conbench analyzed the 3 benchmark runs on commit `abc`.
 These are errors that were caught while running the benchmarks. You can click each link to go to the Conbench entry for that benchmark, which might have more information about what the error was.
 
 - Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
-  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmark-results/some-benchmark-uuid-4)
-  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmark-results/some-benchmark-uuid-4)
-  - [snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmark-results/some-benchmark-uuid-4)
+  - [`file-write` (Python) with snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmark-results/some-benchmark-uuid-4)
+  - [`file-write` (Python) with snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmark-results/some-benchmark-uuid-4)
+  - [`file-write` (Python) with snappy, nyctaxi_sample, csv, arrow](http://localhost/benchmark-results/some-benchmark-uuid-4)
 
 ## Benchmarks with performance regressions
 
@@ -16,9 +16,9 @@ There were 3 possible performance regressions, according to the lookback z-score
 ### Benchmarks with regressions:
 
 - Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
-  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
-  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
-  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
+  - [`file-read` (Python) with snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
+  - [`file-read` (Python) with snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
+  - [`file-read` (Python) with snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
 
 ## All benchmark runs analyzed:
 

--- a/benchalerts/tests/unit_tests/expected_md/summary_regressions.md
+++ b/benchalerts/tests/unit_tests/expected_md/summary_regressions.md
@@ -7,8 +7,8 @@ There were 2 possible performance regressions, according to the lookback z-score
 ### Benchmarks with regressions:
 
 - Some Run Reason Run on `some-machine-name` at [2021-02-04 17:22:05.225583](http://localhost/compare/runs/some_baseline...some_contender/)
-  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
-  - [snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
+  - [`file-read` (Python) with snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
+  - [`file-read` (Python) with snappy, nyctaxi_sample, parquet, arrow](http://localhost/compare/benchmarks/some-benchmark-uuid-1...some-benchmark-uuid-3)
 
 ## All benchmark runs analyzed:
 


### PR DESCRIPTION
Fixes https://github.com/conbench/conbench/issues/1395.

This clarifies notifications by adding the benchmark name and language instead of just the case permutation parameters.