### PR TITLE
kube-prom: dynamically set monitored namespaces

### DIFF
--- a/.buildkite/utils.sh
+++ b/.buildkite/utils.sh
@@ -165,8 +165,14 @@ deploy() {
 
   if [[ "$EKS_CLUSTER" == "vd-2" ]]; then
     export PROM_REMOTE_WRITE_CLUSTER_LABEL_VALUE="vd-2"
+    # The k8s namespaces that the Conbench web application lives in on this EKS
+    # cluster. This is EKS-cluster-specific config, i.e. not Conbench
+    # deployment-specific config. Namespaces monitored here are going to be
+    # monitored by kube-prometheus.
+    export KUBE_PROM_ADDITIONAL_NAMESPACE_STRING="'default', 'staging'"
   elif [[ "$EKS_CLUSTER" == "ursa-2" ]]; then
     export PROM_REMOTE_WRITE_CLUSTER_LABEL_VALUE="ursa-2"
+    export KUBE_PROM_ADDITIONAL_NAMESPACE_STRING="'default', 'velox'"
   fi
 
   # Prepare environment variables for configuring the remote_write forwarding

--- a/Makefile
+++ b/Makefile
@@ -342,6 +342,16 @@ jsonnet-kube-prom-manifests:
 			sed -i.bak "s|PROM_REMOTE_WRITE_CLUSTER_LABEL_VALUE|$${PROM_REMOTE_WRITE_CLUSTER_LABEL_VALUE}|g" \
 				_kpbuild/cb-kube-prometheus/conbench-flavor.jsonnet; \
 		fi
+	@if [ -z "$${KUBE_PROM_ADDITIONAL_NAMESPACE_STRING:=}" ]; then \
+			echo "KUBE_PROM_ADDITIONAL_NAMESPACE_STRING not set, use: 'default'"; \
+			sed -i.bak "s|KUBE_PROM_ADDITIONAL_NAMESPACE_STRING|'default'|g" \
+				_kpbuild/cb-kube-prometheus/conbench-flavor.jsonnet; \
+		else \
+			echo "KUBE_PROM_ADDITIONAL_NAMESPACE_STRING set, use in JSONNET: $$KUBE_PROM_ADDITIONAL_NAMESPACE_STRING" && \
+			sed -i.bak "s|KUBE_PROM_ADDITIONAL_NAMESPACE_STRING|$${KUBE_PROM_ADDITIONAL_NAMESPACE_STRING}|g" \
+				_kpbuild/cb-kube-prometheus/conbench-flavor.jsonnet; \
+		fi
+	cat _kpbuild/cb-kube-prometheus/conbench-flavor.jsonnet
 	cd _kpbuild/cb-kube-prometheus && \
 		wget https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/d3889807798d/build.sh -O build.sh
 	cd _kpbuild/cb-kube-prometheus && \

--- a/k8s/kube-prometheus/conbench-flavor.jsonnet
+++ b/k8s/kube-prometheus/conbench-flavor.jsonnet
@@ -30,7 +30,15 @@ local kp =
         // to act on it, but will fail with errors like
         // `User \"system:serviceaccount:monitoring:prometheus-k8s\" cannot list resource ...`
         // Also see https://github.com/prometheus-operator/kube-prometheus/blob/main/docs/monitoring-other-namespaces.md
-        namespaces: ['default', 'kube-system', 'monitoring', 'staging'],
+        // Deployment will fail if this contains a namespace that does not exist
+        // in the target environment.
+        // Note(JP): once again, string templating in this file is certainly
+        // not super cute. Set KUBE_PROM_ADDITIONAL_NAMESPACE_STRING, the way
+        // it's written below it's not optional to replace that placeholder.
+        // Minimally, replace it with e.g. "'default'" or "'default',
+        // 'staging'". Also note that in Conbench's CI pipeline a Makefile
+        // target is doing that replacement right before JSONNET build.
+        namespaces: ['kube-system', 'monitoring', KUBE_PROM_ADDITIONAL_NAMESPACE_STRING],
       },
       common+: {
         namespace: 'monitoring',


### PR DESCRIPTION
For #1390.

Not nice, but works!

Example:

```
$ export KUBE_PROM_ADDITIONAL_NAMESPACE_STRING="'default', 'velox'"
$ make jsonnet-kube-prom-manifests
...
        namespaces: ['kube-system', 'monitoring', 'default', 'velox'],
...
```


