### PR TITLE
UI: result-result comparison: show hardware checksum

### DIFF
--- a/conbench/api/_examples.py
+++ b/conbench/api/_examples.py
@@ -389,7 +389,6 @@ def _api_hardware_entity(
                 "list": "http://localhost/api/hardware/",
                 "self": "http://localhost/api/hardware/%s/" % hardware_id,
             },
-            "checksum": "diana-2-2-4-17179869184",
         }
     else:
         result = {

--- a/conbench/api/_examples.py
+++ b/conbench/api/_examples.py
@@ -389,6 +389,7 @@ def _api_hardware_entity(
                 "list": "http://localhost/api/hardware/",
                 "self": "http://localhost/api/hardware/%s/" % hardware_id,
             },
+            "checksum": "diana-2-2-4-17179869184",
         }
     else:
         result = {

--- a/conbench/entities/hardware.py
+++ b/conbench/entities/hardware.py
@@ -103,7 +103,7 @@ class Machine(Hardware):
             # result-result compare view in the UI and that is currently fed
             # from the API (API layer indirection: see
             # https://github.com/conbench/conbench/issues/1394).
-            "checksum": self.hash,
+            # "checksum": self.hash,
             "links": {
                 "list": f.url_for("api.hardwares", _external=True),
                 "self": f.url_for("api.hardware", hardware_id=self.id, _external=True),
@@ -138,7 +138,7 @@ class Cluster(Hardware):
             "info": self.info,
             "optional_info": self.optional_info,
             # See above; https://github.com/conbench/conbench/issues/1394
-            "checksum": self.hash,
+            # "checksum": self.hash,
         }
 
 

--- a/conbench/entities/hardware.py
+++ b/conbench/entities/hardware.py
@@ -98,6 +98,12 @@ class Machine(Hardware):
             "memory_bytes": self.memory_bytes,
             "gpu_count": self.gpu_count,
             "gpu_product_names": self.gpu_product_names,
+            # Note(JP): adding this to the public-facing API is not what I
+            # aimed for here, but I'd like to display that checksum in the
+            # result-result compare view in the UI and that is currently fed
+            # from the API (API layer indirection: see
+            # https://github.com/conbench/conbench/issues/1394).
+            "checksum": self.hash,
             "links": {
                 "list": f.url_for("api.hardwares", _external=True),
                 "self": f.url_for("api.hardware", hardware_id=self.id, _external=True),
@@ -131,6 +137,8 @@ class Cluster(Hardware):
             "type": self.type,
             "info": self.info,
             "optional_info": self.optional_info,
+            # See above; https://github.com/conbench/conbench/issues/1394
+            "checksum": self.hash,
         }
 
 

--- a/conbench/templates/compare-entity.html
+++ b/conbench/templates/compare-entity.html
@@ -138,6 +138,10 @@ matching fields between baseline and contender are aligned and mismatched fields
             <b>hardware</b>
             <div align="right" style="display:inline-block; float: right;">{{ baseline_run.hardware.name }}</div>
           </li>
+          <li class="list-group-item" style="overflow-y: auto;">
+            <b>hardware checksum</b>
+            <div align="right" style="display:inline-block; float: right;">{{ baseline_hardware_checksum }}</div>
+          </li>
         {% endif %}
         <li class="list-group-item list-group-item-secondary">measurement result</li>
         {% for k,v in baseline.stats.items() %}
@@ -231,6 +235,10 @@ matching fields between baseline and contender are aligned and mismatched fields
           <li class="list-group-item" style="overflow-y: auto;">
             <b>hardware</b>
             <div align="right" style="display:inline-block; float: right;">{{ contender_run.hardware.name }}</div>
+          </li>
+          <li class="list-group-item" style="overflow-y: auto;">
+            <b>hardware checksum</b>
+            <div align="right" style="display:inline-block; float: right;">{{ contender_hardware_checksum }}</div>
           </li>
         {% endif %}
         <li class="list-group-item list-group-item-secondary">measurement result</li>


### PR DESCRIPTION
This is for #1413, a follow-up from #1412.

Again I was significantly slowed down while trying to make a seemingly trivial change -- https://github.com/conbench/conbench/issues/1394.

First, I gave in and accepted I 'have to' change the HTTP API. Then I did that and realized that our tests are not quite ready to dynamically 'predict' the hardware checksum. So, I added in one more 'needless' DB query, just to have hardware checksum available _after_ lossz API layer re-serialization. You can follow me backing out of that approach by looking at commits.