### PR TITLE
POST benchmark result: do not require `times` and `time_unit` anymore

### DIFF
--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -987,24 +987,27 @@ class BenchmarkResultStatsSchema(marshmallow.Schema):
         },
     )
     times = marshmallow.fields.List(
+        # https://github.com/conbench/conbench/issues/1399
         marshmallow.fields.Decimal(allow_none=True),
-        required=True,
+        required=False,
         metadata={
             "description": conbench.util.dedent_rejoin(
                 """
-                A list of benchmark durations. If `data` is a duration measure,
-                this should be a duplicate of that object. The values should be
-                ordered in the order the iterations were executed (the first
-                element is the first iteration, the second element is the
-                second iteration, etc.). If an iteration did not complete but
-                others did and you want to send partial data, mark each
-                iteration that didn't complete as `null`.
+                Here, you can provide a list of benchmark durations. That can
+                make sense if `data` is not a duration measure.
 
-                You may populate both this field and the "error" field in the top level
-                of the benchmark result payload. In that case, this field measures
-                how long the benchmark took to run before the error occurred. These
-                values will not be compared to non-errored values in analyses and
-                comparisons.
+                Optional. If provided, must be a list of numbers. `null` is
+                allowed to represent a failed repetition.
+
+                The values should be ordered in the order the repetitions
+                executed (the first element corresponds to the first
+                repetition, the second element to the second repetition, etc).
+
+                The `time_unit` field (see below) should be provided, too.
+
+                Consider this as metadata. You can discover this field later
+                via API and UI, however Conbench as of today does not do
+                validation or analysis on the data.
                 """
             )
         },
@@ -1019,7 +1022,10 @@ class BenchmarkResultStatsSchema(marshmallow.Schema):
         },
     )
     time_unit = marshmallow.fields.String(
-        required=True,
+        # TODO/future: make this be intransparent metadata, and then later
+        # maybe offer custom metrics from that metadata.
+        # https://github.com/conbench/conbench/issues/1399
+        required=False,
         metadata={
             "description": "The unit of the times object (e.g. seconds, nanoseconds)"
         },

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -1160,7 +1160,7 @@
                         "type": "string",
                     },
                     "times": {
-                        "description": 'A list of benchmark durations. If `data` is a duration measure, this should be a duplicate of that object. The values should be ordered in the order the iterations were executed (the first element is the first iteration, the second element is the second iteration, etc.). If an iteration did not complete but others did and you want to send partial data, mark each iteration that didn\'t complete as `null`.  You may populate both this field and the "error" field in the top level of the benchmark result payload. In that case, this field measures how long the benchmark took to run before the error occurred. These values will not be compared to non-errored values in analyses and comparisons.',
+                        "description": "Here, you can provide a list of benchmark durations. That can make sense if `data` is not a duration measure.  Optional. If provided, must be a list of numbers. `null` is allowed to represent a failed repetition.  The values should be ordered in the order the repetitions executed (the first element corresponds to the first repetition, the second element to the second repetition, etc).  The `time_unit` field (see below) should be provided, too.  Consider this as metadata. You can discover this field later via API and UI, however Conbench as of today does not do validation or analysis on the data.",
                         "items": {"nullable": True, "type": "number"},
                         "type": "array",
                     },
@@ -1169,7 +1169,7 @@
                         "type": "string",
                     },
                 },
-                "required": ["data", "iterations", "time_unit", "times", "unit"],
+                "required": ["data", "iterations", "unit"],
                 "type": "object",
             },
             "BenchmarkResultUpdate": {

--- a/conbench/tests/api/test_results.py
+++ b/conbench/tests/api/test_results.py
@@ -1114,9 +1114,7 @@ class TestBenchmarkResultPost(_asserts.PostEnforcer):
 
         result["stats"] = {
             "data": (3, 5),
-            "times": [],  # key must be there as of now, validate more, change this.
             "unit": "s",
-            "time_unit": "s",
             # also see https://github.com/conbench/conbench/issues/813
             # https://github.com/conbench/conbench/issues/533
             "iterations": 3,  # number not yet validated, change this
@@ -1138,9 +1136,7 @@ class TestBenchmarkResultPost(_asserts.PostEnforcer):
         result = _fixtures.VALID_RESULT_PAYLOAD.copy()
         result["stats"] = {
             "data": samples,
-            "times": [],  # key must be there as of now, validate more, change this.
             "unit": "s",
-            "time_unit": "s",
             # also see https://github.com/conbench/conbench/issues/813
             # https://github.com/conbench/conbench/issues/533
             "iterations": len(samples),
@@ -1177,9 +1173,7 @@ class TestBenchmarkResultPost(_asserts.PostEnforcer):
         result = _fixtures.VALID_RESULT_PAYLOAD.copy()
         result["stats"] = {
             "data": samples,
-            "times": [],  # key must be there as of now, validate more, change this.
             "unit": "s",
-            "time_unit": "s",
             "iterations": len(samples),
             # Set some bogus aggregate.
             uekey: 3,
@@ -1203,9 +1197,7 @@ class TestBenchmarkResultPost(_asserts.PostEnforcer):
 
         result["stats"] = {
             "data": (3, 5),
-            "times": [],  # key must be there as of now, validate more, change this.
             "unit": "kg",
-            "time_unit": "foobar",
             # also see https://github.com/conbench/conbench/issues/813
             # https://github.com/conbench/conbench/issues/533
             "iterations": 2,  # number not yet validated, change this
@@ -1221,9 +1213,7 @@ class TestBenchmarkResultPost(_asserts.PostEnforcer):
 
         result["stats"] = {
             "data": (3, 5),
-            "times": [],  # key must be there as of now, validate more, change this.
             "unit": "b/s",  # means B/s, is rewritten
-            "time_unit": "foobar",
             # also see https://github.com/conbench/conbench/issues/813
             # https://github.com/conbench/conbench/issues/533
             "iterations": 2,  # number not yet validated, change this


### PR DESCRIPTION
For https://github.com/conbench/conbench/issues/1399 / https://github.com/conbench/conbench/issues/823. A long-standing discussion. Let's go one step ahead. Is this the right direction? Approximately, let's find out. That was analysis paralysis so far.