### PR TITLE
benchmark result `stats` object: make `iterations` optional

### DIFF
--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -733,11 +733,10 @@ def validate_and_aggregate_samples(stats_usergiven: Any):
                         stats_usergiven,
                     )
 
-    # Clarify that these are meant as 'micro benchmark iterations', can be
-    # None or int.
-    micro_bm_iterations: Optional[int] = None
-    if stats_usergiven["iterations"] is not None:
-        micro_bm_iterations = stats_usergiven["iterations"]
+    # The next line explicitly encodes our updated thinking:
+    # - `iterations` key is optional
+    # - if provided, number is meant as 'micro benchmark iteration' count
+    micro_bm_iterations: Optional[int] = stats_usergiven.get("iterations")
 
     if len(samples) == 1:
         if micro_bm_iterations == 1:
@@ -1040,7 +1039,7 @@ class BenchmarkResultStatsSchema(marshmallow.Schema):
         # TODO: make this not required, and clarify that these are
         # microbenchmark iterations, stored as metadata.
         # https://github.com/conbench/conbench/issues/1398
-        required=True,
+        required=False,
         metadata={
             "description": (
                 "Here you can optionally store the number of microbenchmark "

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -1169,7 +1169,7 @@
                         "type": "string",
                     },
                 },
-                "required": ["data", "iterations", "unit"],
+                "required": ["data", "unit"],
                 "type": "object",
             },
             "BenchmarkResultUpdate": {

--- a/conbench/tests/api/test_results.py
+++ b/conbench/tests/api/test_results.py
@@ -731,6 +731,7 @@ class TestBenchmarkResultPost(_asserts.PostEnforcer):
                 "os_name": ["Missing data for required field."],
                 "os_version": ["Field may not be null."],
             },
+            "stats": {"extra": ["Unknown field."]},
         }
         self.assert_400_bad_request(response, message)
 

--- a/conbench/tests/api/test_results.py
+++ b/conbench/tests/api/test_results.py
@@ -1121,9 +1121,6 @@ class TestBenchmarkResultPost(_asserts.PostEnforcer):
         result["stats"] = {
             "data": samples,
             "unit": "s",
-            # also see https://github.com/conbench/conbench/issues/813
-            # https://github.com/conbench/conbench/issues/533
-            "iterations": len(samples),
         }
 
         resp = client.post("/api/benchmark-results/", json=result)
@@ -1158,7 +1155,6 @@ class TestBenchmarkResultPost(_asserts.PostEnforcer):
         result["stats"] = {
             "data": samples,
             "unit": "s",
-            "iterations": len(samples),
             # Set some bogus aggregate.
             uekey: 3,
         }
@@ -1173,6 +1169,10 @@ class TestBenchmarkResultPost(_asserts.PostEnforcer):
         bmrdict = resp.json
 
         if len(samples) < 3:
+            # "be liberal in what you accept"; confirm that information has
+            # been dropped (was not put into the database): for example,
+            # when stddev is provided for two samples then it's not stored,
+            # and not returned
             assert bmrdict["stats"][uekey] is None
 
     def test_create_result_bad_unit(self, client):
@@ -1182,9 +1182,6 @@ class TestBenchmarkResultPost(_asserts.PostEnforcer):
         result["stats"] = {
             "data": (3, 5),
             "unit": "kg",
-            # also see https://github.com/conbench/conbench/issues/813
-            # https://github.com/conbench/conbench/issues/533
-            "iterations": 2,  # number not yet validated, change this
         }
 
         resp = client.post("/api/benchmark-results/", json=result)
@@ -1198,9 +1195,6 @@ class TestBenchmarkResultPost(_asserts.PostEnforcer):
         result["stats"] = {
             "data": (3, 5),
             "unit": "b/s",  # means B/s, is rewritten
-            # also see https://github.com/conbench/conbench/issues/813
-            # https://github.com/conbench/conbench/issues/533
-            "iterations": 2,  # number not yet validated, change this
         }
 
         resp = client.post("/api/benchmark-results/", json=result)

--- a/conbench/tests/api/test_results.py
+++ b/conbench/tests/api/test_results.py
@@ -714,7 +714,6 @@ class TestBenchmarkResultPost(_asserts.PostEnforcer):
     def test_nested_schema_validation(self, client):
         self.authenticate(client)
         data = copy.deepcopy(self.valid_payload)
-        del data["stats"]["iterations"]
         del data["github"]["commit"]
         del data["machine_info"]["os_name"]
         data["machine_info"]["os_version"] = None
@@ -731,10 +730,6 @@ class TestBenchmarkResultPost(_asserts.PostEnforcer):
                 "extra": ["Unknown field."],
                 "os_name": ["Missing data for required field."],
                 "os_version": ["Field may not be null."],
-            },
-            "stats": {
-                "extra": ["Unknown field."],
-                "iterations": ["Missing data for required field."],
             },
         }
         self.assert_400_bad_request(response, message)


### PR DESCRIPTION
This is for https://github.com/conbench/conbench/issues/1417. I have updated a small set of tests to cover/make use of the new behavior.