### PR TITLE
benchmark result submission API spec: make `info` optional, improve spec for `github`, `context`, misc

### DIFF
--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -222,7 +222,7 @@ class BenchmarkResult(Base, EntityMixin):
         # Create related DB entities if they do not exist yet.
         case = Case.get_or_create({"name": benchmark_name, "tags": tags})
         context = Context.get_or_create({"tags": userres["context"]})
-        info = Info.get_or_create({"tags": userres["info"]})
+        info = Info.get_or_create({"tags": userres.get("info", {})})
 
         # Create a corresponding `Run` entity in the database if it doesn't
         # exist yet. Use the user-given `id` (string) as primary key. If the

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -1285,7 +1285,21 @@ class _BenchmarkResultCreateSchema(marshmallow.Schema):
     context = marshmallow.fields.Dict(  # type: ignore[assignment]
         required=True,
         metadata={
-            "description": "Information about the context the benchmark was run in (e.g. compiler flags, benchmark langauge) that are reasonably expected to have an impact on benchmark performance. This information is expected to be the same across a number of benchmarks. (free-form JSON)"
+            "description": conbench.util.dedent_rejoin(
+                """
+                Required. Must be a JSON object (empty dictionary is allowed).
+
+                Relevant benchmark context (other than hardware/platform
+                details and benchmark case parameters).
+
+                Conbench requires this object to remain constant when doing
+                automated timeseries analysis (this breaks history).
+
+                Use this to store for example compiler flags or a runtime
+                version that you expect to have significant impact on
+                measurement results.
+                """
+            )
         },
     )
     info = marshmallow.fields.Dict(

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -36,7 +36,7 @@ from ..entities.commit import TypeCommitInfoGitHub
 from ..entities.context import Context
 from ..entities.hardware import ClusterSchema, MachineSchema
 from ..entities.info import Info
-from ..entities.run import Run, SchemaGitHubCreate
+from ..entities.run import Run, SchemaGitHubCreate, github_commit_info_descr
 
 log = logging.getLogger(__name__)
 
@@ -1120,8 +1120,6 @@ Currently-recognized keys that change Conbench behavior:
 hardware/case/context)? That is, when evaluating whether future results are regressions
 or improvements, should we treat data from before this result as incomparable?
 """
-
-from conbench.entities.run import github_commit_info_descr
 
 
 class _BenchmarkResultCreateSchema(marshmallow.Schema):

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -1121,6 +1121,8 @@ hardware/case/context)? That is, when evaluating whether future results are regr
 or improvements, should we treat data from before this result as incomparable?
 """
 
+from conbench.entities.run import github_commit_info_descr
+
 
 class _BenchmarkResultCreateSchema(marshmallow.Schema):
     run_id = marshmallow.fields.String(
@@ -1298,7 +1300,11 @@ class _BenchmarkResultCreateSchema(marshmallow.Schema):
             "description": "Benchmark results validation metadata (e.g., errors, validation types)."
         },
     )
-    github = marshmallow.fields.Nested(SchemaGitHubCreate(), required=False)
+    github = marshmallow.fields.Nested(
+        SchemaGitHubCreate(),
+        required=False,
+        metadata={"description": github_commit_info_descr},
+    )
     change_annotations = marshmallow.fields.Dict(
         required=False, metadata={"description": CHANGE_ANNOTATIONS_DESC}
     )

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -1276,7 +1276,9 @@ class _BenchmarkResultCreateSchema(marshmallow.Schema):
     optional_benchmark_info = marshmallow.fields.Dict(
         required=False,
         metadata={
-            "description": "Optional information about Benchmark results (e.g., telemetry links, logs links). These are unique to each benchmark that is run, but are information that aren't reasonably expected to impact benchmark performance. Helpful for adding debugging or additional links and context for a benchmark (free-form JSON)"
+            # TODO: remove this.
+            # https://github.com/conbench/conbench/issues/1424
+            "description": "Deprecated. Use `info` instead."
         },
     )
     # Note, this mypy error is interesting: Incompatible types in assignment

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -1289,9 +1289,29 @@ class _BenchmarkResultCreateSchema(marshmallow.Schema):
         },
     )
     info = marshmallow.fields.Dict(
-        required=True,
+        required=False,
         metadata={
-            "description": "Additional information about the context the benchmark was run in that is not expected to have an impact on benchmark performance (e.g. benchmark language version, compiler version). This information is expected to be the same across a number of benchmarks. (free-form JSON)"
+            "description": conbench.util.dedent_rejoin(
+                """
+                Optional.
+
+                Arbitrary metadata associated with this
+                benchmark result.
+
+                Ignored when assembling timeseries across results (differences
+                do not break history).
+
+                Must be a JSON object if provided. A flat string-string mapping
+                is recommended (not yet enforced).
+
+                This can be useful for example for storing URLs pointing to
+                build artifacts. You can also use this to store environmental
+                properties that you potentially would like to review later (a
+                compiler version, or runtime version), and generally any kind
+                of information that can later be useful for debugging
+                unexpected measurements.
+                """
+            )
         },
     )
     validation = marshmallow.fields.Dict(

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -1161,7 +1161,10 @@ class _BenchmarkResultCreateSchema(marshmallow.Schema):
             )
         },
     )
-    batch_id = marshmallow.fields.String(required=True)
+    batch_id = marshmallow.fields.String(
+        # this lacks specification and should probably not be required
+        required=True
+    )
 
     # `AwareDateTime` with `default_timezone` set to UTC: naive datetimes are
     # set this timezone.

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -42,6 +42,29 @@ from ..entities.hardware import (
 log = logging.getLogger(__name__)
 
 
+# This is used in two places.
+github_commit_info_descr = conbench.util.dedent_rejoin(
+    """
+    GitHub-flavored commit information.
+
+    Use this object to tell Conbench with which specific state of benchmarked
+    code (repository identifier, commit hash) the BenchmarkResult is
+    associated.
+
+    This property is optional. If not provided, it means that this benchmark
+    result is not associated with any particular state of benchmarked code.
+
+    Not associating a benchmark result with commit information has special,
+    limited purpose (pre-merge benchmarks, testing). It generally means that
+    this benchmark result will not be considered for time series analysis along
+    a commit tree.
+
+    TODO: allow for associating a benchmark result with a repository (URL), w/o
+    providing commit information (cf. issue #1165).
+    """
+)
+
+
 @dataclasses.dataclass
 class _CandidateBaselineSearchResult:
     """Information about the search for a candidate baseline run, and the result of the
@@ -698,18 +721,7 @@ class _RunFacadeSchemaCreate(marshmallow.Schema):
     github = marshmallow.fields.Nested(
         SchemaGitHubCreate(),
         required=False,
-        metadata={
-            "description": conbench.util.dedent_rejoin(
-                """
-                Use this object to tell Conbench with which commit the
-                Run/BenchmarkResult is associated.
-
-                This field can be left out for testing purposes. Note however
-                that commit information is required for powering valuable
-                Conbench capabilities.
-                """
-            )
-        },
+        metadata={"description": github_commit_info_descr},
     )
     machine_info = marshmallow.fields.Nested(MachineSchema().create, required=False)
     cluster_info = marshmallow.fields.Nested(ClusterSchema().create, required=False)

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -68,6 +68,7 @@ class BMRTBenchmarkResult:
     svs_type: str
     unit: str
     benchmark_name: str
+    # POSIX timestamp
     started_at: float
     hardware_checksum: str
     hardware_name: str

--- a/conbench/tests/api/_asserts.py
+++ b/conbench/tests/api/_asserts.py
@@ -46,7 +46,7 @@ class ApiEndpointTest:
         assert r.json is None, r.json
 
     def assert_400_bad_request(self, r, message):
-        assert r.status_code == 400, r.status_code
+        assert r.status_code == 400, f"{r.status_code}\n{r.text}"
         assert r.content_type == "application/json", r.content_type
         assert r.json == {
             "code": 400,

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -1055,16 +1055,19 @@
                         "description": "Precisely one of `machine_info` and `cluster_info` must be provided. The data is however ignored when the Run (referred to by `run_id`) was previously created.",
                     },
                     "context": {
-                        "description": "Information about the context the benchmark was run in (e.g. compiler flags, benchmark langauge) that are reasonably expected to have an impact on benchmark performance. This information is expected to be the same across a number of benchmarks. (free-form JSON)",
+                        "description": "Required. Must be a JSON object (empty dictionary is allowed).  Relevant benchmark context (other than hardware/platform details and benchmark case parameters).  Conbench requires this object to remain constant when doing automated timeseries analysis (this breaks history).  Use this to store for example compiler flags or a runtime version that you expect to have significant impact on measurement results.",
                         "type": "object",
                     },
                     "error": {
                         "description": 'Details about an error that occurred while the benchmark was running (free-form JSON).  You may populate both this field and the "data" field of the "stats" object. In that case, the "data" field measures the metric\'s values before the error occurred. Those values will not be compared to non-errored values in analyses and comparisons.',
                         "type": "object",
                     },
-                    "github": {"$ref": "#/components/schemas/SchemaGitHubCreate"},
+                    "github": {
+                        "allOf": [{"$ref": "#/components/schemas/SchemaGitHubCreate"}],
+                        "description": "GitHub-flavored commit information.  Use this object to tell Conbench with which specific state of benchmarked code (repository identifier, commit hash) the BenchmarkResult is associated.  This property is optional. If not provided, it means that this benchmark result is not associated with any particular state of benchmarked code.  Not associating a benchmark result with commit information has special, limited purpose (pre-merge benchmarks, testing). It generally means that this benchmark result will not be considered for time series analysis along a commit tree.  TODO: allow for associating a benchmark result with a repository (URL), w/o providing commit information (cf. issue #1165).",
+                    },
                     "info": {
-                        "description": "Additional information about the context the benchmark was run in that is not expected to have an impact on benchmark performance (e.g. benchmark language version, compiler version). This information is expected to be the same across a number of benchmarks. (free-form JSON)",
+                        "description": "Optional.  Arbitrary metadata associated with this benchmark result.  Ignored when assembling timeseries across results (differences do not break history).  Must be a JSON object if provided. A flat string-string mapping is recommended (not yet enforced).  This can be useful for example for storing URLs pointing to build artifacts. You can also use this to store environmental properties that you potentially would like to review later (a compiler version, or runtime version), and generally any kind of information that can later be useful for debugging unexpected measurements.",
                         "type": "object",
                     },
                     "machine_info": {
@@ -1072,7 +1075,7 @@
                         "description": "Precisely one of `machine_info` and `cluster_info` must be provided. The data is however ignored when the Run (referred to by `run_id`) was previously created.",
                     },
                     "optional_benchmark_info": {
-                        "description": "Optional information about Benchmark results (e.g., telemetry links, logs links). These are unique to each benchmark that is run, but are information that aren't reasonably expected to impact benchmark performance. Helpful for adding debugging or additional links and context for a benchmark (free-form JSON)",
+                        "description": "Deprecated. Use `info` instead.",
                         "type": "object",
                     },
                     "run_id": {
@@ -1102,14 +1105,7 @@
                         "type": "object",
                     },
                 },
-                "required": [
-                    "batch_id",
-                    "context",
-                    "info",
-                    "run_id",
-                    "tags",
-                    "timestamp",
-                ],
+                "required": ["batch_id", "context", "run_id", "tags", "timestamp"],
                 "type": "object",
             },
             "BenchmarkResultStats": {
@@ -1322,7 +1318,7 @@
                     },
                     "github": {
                         "allOf": [{"$ref": "#/components/schemas/SchemaGitHubCreate"}],
-                        "description": "Use this object to tell Conbench with which commit the Run/BenchmarkResult is associated.  This field can be left out for testing purposes. Note however that commit information is required for powering valuable Conbench capabilities.",
+                        "description": "GitHub-flavored commit information.  Use this object to tell Conbench with which specific state of benchmarked code (repository identifier, commit hash) the BenchmarkResult is associated.  This property is optional. If not provided, it means that this benchmark result is not associated with any particular state of benchmarked code.  Not associating a benchmark result with commit information has special, limited purpose (pre-merge benchmarks, testing). It generally means that this benchmark result will not be considered for time series analysis along a commit tree.  TODO: allow for associating a benchmark result with a repository (URL), w/o providing commit information (cf. issue #1165).",
                     },
                     "id": {"type": "string"},
                     "info": {"description": "Run's metadata", "type": "object"},

--- a/conbench/tests/api/test_results.py
+++ b/conbench/tests/api/test_results.py
@@ -378,9 +378,10 @@ class TestBenchmarkResultPost(_asserts.PostEnforcer):
         _fixtures.VALID_RESULT_PAYLOAD_WITH_ITERATION_ERROR
     )
     required_fields = [
-        "batch_id",
+        "batch_id",  # why is this required?
         "context",
-        "info",
+        # should this be optional in the future? grouping results in a run can
+        # be convenient, but should not be necessary.
         "run_id",
         "tags",
         "timestamp",

--- a/conbench/tests/app/_asserts.py
+++ b/conbench/tests/app/_asserts.py
@@ -16,11 +16,13 @@ class AppEndpointTest:
     def login(self, client, email, password):
         response = client.get("/login/")
         csrf_token = self.get_csrf_token(response)
-        return client.post(
+        resp = client.post(
             "/login/",
             data=dict(email=email, password=password, csrf_token=csrf_token),
             follow_redirects=True,
         )
+        assert resp.status_code == 200, f"got {resp.status_code}:\n" + resp.text
+        return resp
 
     def logout(self, client):
         client.get("/logout/")


### PR DESCRIPTION
For #1424 and #838.

While working on tests for c-bench UI I wanted to submit benchmark results and came around a number of smaller topics that we touched on before, but didn't pull through (e.g., https://github.com/conbench/conbench/pull/1134#discussion_r1172771186).

This patch:

- clarifies what the absence of the `github` key means
- makes `info` optional
- recommends to use `info` instead of  `optional_benchmark_info`
- clarifies what `context` is to be used for
- does a few tiny things more, see commit msgs / diff.



