### PR TITLE
BMRT cache population, c-bench UI: start adding test infra and tests

### DIFF
--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -1161,6 +1161,7 @@ class _BenchmarkResultCreateSchema(marshmallow.Schema):
     )
     batch_id = marshmallow.fields.String(
         # this lacks specification and should probably not be required
+        # see https://github.com/conbench/conbench/issues/880
         required=True
     )
 

--- a/conbench/job.py
+++ b/conbench/job.py
@@ -364,7 +364,7 @@ def _fetch_and_cache_most_recent_results_guts(
     )
 
 
-def _periodically_fetch_last_n_benchmark_results() -> None:
+def _periodically_fetch_last_n_benchmark_results() -> threading.Thread:
     """
     Return right after having spawned a thread that triggers periodic action.
     """

--- a/conbench/metrics.py
+++ b/conbench/metrics.py
@@ -205,7 +205,7 @@ def periodically_set_q_rem() -> None:
                     log.debug("periodically_set_q_rem(): shut down")
                     return
 
-                time.sleep(0.1)
+                time.sleep(0.05)
 
             if gauge_gh_api_rem_set["first_value_seen"]:
                 # This process set an actual, meaningful value. Stop
@@ -217,6 +217,6 @@ def periodically_set_q_rem() -> None:
 
     # Create a threaddy zombie, no need to join it. It likely terminates
     # itself. If it doesn't that's OK, too.
-    t = threading.Thread(target=func)
+    t = threading.Thread(target=func, name="metrics-gauge-set")
     t.start()
     return t

--- a/conbench/metrics.py
+++ b/conbench/metrics.py
@@ -196,7 +196,7 @@ def periodically_set_q_rem() -> None:
         log.info("periodically_set_q_rem(): initiate")
         while True:
             # Delay for a bit until setting the gauge next time. But don't just
-            # sleep, to a busy sleep (responsive sleep loop that inspects
+            # sleep, do a busy sleep (responsive sleep loop that inspects
             # SHUTDOWN often_.
             deadline = time.monotonic() + 3
             while time.monotonic() < deadline:
@@ -205,7 +205,7 @@ def periodically_set_q_rem() -> None:
                     log.debug("periodically_set_q_rem(): shut down")
                     return
 
-                time.sleep(0.2)
+                time.sleep(0.1)
 
             if gauge_gh_api_rem_set["first_value_seen"]:
                 # This process set an actual, meaningful value. Stop
@@ -217,4 +217,6 @@ def periodically_set_q_rem() -> None:
 
     # Create a threaddy zombie, no need to join it. It likely terminates
     # itself. If it doesn't that's OK, too.
-    threading.Thread(target=func).start()
+    t = threading.Thread(target=func)
+    t.start()
+    return t

--- a/conbench/metrics.py
+++ b/conbench/metrics.py
@@ -175,7 +175,7 @@ def http_handler_name(r: flask.Request) -> str:
 gauge_gh_api_rem_set = {"first_value_seen": False}
 
 
-def periodically_set_q_rem() -> None:
+def periodically_set_q_rem() -> threading.Thread:
     """
     This function immediately returns after having spawned a thread.
 

--- a/conbench/tests/api/_fixtures.py
+++ b/conbench/tests/api/_fixtures.py
@@ -254,6 +254,8 @@ def benchmark_result(
     However, in general, this approach might divert the test suite form
     real-world relevance: our users cannot directly write to the database,
     either.
+
+    Now tracked here: https://github.com/conbench/conbench/issues/1431
     """
 
     data = copy.deepcopy(VALID_RESULT_PAYLOAD)

--- a/conbench/tests/app/test_conceptual_benchmark_views.py
+++ b/conbench/tests/app/test_conceptual_benchmark_views.py
@@ -1,5 +1,10 @@
+import time
+
 import pytest
 
+import conbench.job
+
+from ...tests.api import _fixtures
 from ...tests.app import _asserts
 
 
@@ -7,6 +12,28 @@ def assert_response_is_login_page(resp):
     assert resp.status_code == 200, (resp.status_code, resp.text)
     assert "<h4>Sign in</h4>" in resp.text, resp.text
     assert '<label for="password">Password</label>' in resp.text, resp.text
+
+
+benchmark_result_dict = {
+    "run_id": "1",
+    "batch_id": "1",
+    "timestamp": "2020-11-25T21:02:44Z",
+    "context": {},
+    # "info": {},
+    # "machine_info": {"foo": "bar"}, this should work, relax constraints
+    "machine_info": _fixtures.MACHINE_INFO,
+    "stats": {
+        "data": [
+            "0.099094",
+            "0.037129",
+        ],
+        "unit": "s",
+    },
+    "tags": {
+        "p1": "v1",
+        "name": "fun-benchmark",
+    },
+}
 
 
 class TestCBenchmarks(_asserts.AppEndpointTest):
@@ -20,3 +47,12 @@ class TestCBenchmarks(_asserts.AppEndpointTest):
         monkeypatch.setenv("BENCHMARKS_DATA_PUBLIC", "off")
         self.logout(client)
         assert_response_is_login_page(client.get(relpath, follow_redirects=True))
+
+    def test_cbench_no_data(self, client):
+        self.authenticate(client)
+        resp = client.post("/api/benchmark-results/", json=benchmark_result_dict)
+        assert resp.status_code == 201, resp.text
+
+        conbench.job.start_jobs()
+        time.sleep(10)
+        conbench.job.stop_jobs_join()


### PR DESCRIPTION
Before we do more or less significant work on DB schema I wanted to add a bit of test coverage for the c-bench UI which is fed from the BMRT cache.

Tracked by PFE-2013.