### PR TITLE
webapp: remove compare run picker

### DIFF
--- a/conbench/app/compare.py
+++ b/conbench/app/compare.py
@@ -14,7 +14,6 @@ from ..app.results import BenchmarkResultMixin, RunMixin
 from ..app.types import HighlightInHistPlot
 from ..config import Config
 from ..entities.benchmark_result import BenchmarkResult
-from ..entities.run import commit_hardware_run_map
 
 log = logging.getLogger(__name__)
 
@@ -108,7 +107,6 @@ class Compare(AppEndpoint, BenchmarkResultMixin, RunMixin, TimeSeriesPlotMixin):
             context_fields=all_keys(baseline, contender, "context"),
             info_fields=all_keys(baseline, contender, "info"),
             hardware_fields=all_keys(baseline_run, contender_run, "hardware"),
-            commit_hardware_run_map=commit_hardware_run_map(),
             contender_hardware_checksum=contender_hardware_checksum,
             baseline_hardware_checksum=baseline_hardware_checksum,
         )

--- a/conbench/entities/run.py
+++ b/conbench/entities/run.py
@@ -487,43 +487,6 @@ class RunSerializer:
     many = _Serializer(many=True)
 
 
-def commit_hardware_run_map():
-    """
-    Returns:
-    {
-        '246249 ARROW-15667: [R] Test development build with ARROW_BUILD_STATIC=OFF': {
-            'date': '2022-03-03',
-            'hardware': {
-                'cluster A': [('2022-05-13 21:36 commit: 2462492389a8f2ca286c481852c84ba1f0d0eff9', 'runid1')],
-                'machine A': [('2022-05-13 21:36 commit: 2462492389a8f2ca286c481852c84ba1f0d0eff9', 'runid2')]
-            }
-        }
-    }
-    """
-    runs = Run.search(
-        filters=[Commit.timestamp.isnot(None)],
-        joins=[Commit, Hardware],
-        order_by=Commit.timestamp.desc(),
-    )
-
-    results = {}
-
-    for run in runs:
-        commit = f"{run.commit.sha[:6]} {run.commit.message[:100]}{'...' if len(run.commit.message) > 100 else ''}"
-
-        if commit not in results:
-            commit_date = run.commit.timestamp.strftime("%Y-%m-%d")
-            results[commit] = {"date": commit_date, "hardware": {}}
-
-        if run.hardware.name not in results[commit]["hardware"]:
-            results[commit]["hardware"][run.hardware.name] = []
-
-        run_value = f"{run.timestamp.strftime('%Y-%m-%d %H:%M')} {run.name}"
-        results[commit]["hardware"][run.hardware.name].append((run_value, run.id))
-
-    return results
-
-
 class SchemaGitHubCreate(marshmallow.Schema):
     """
     GitHub-flavored commit info object

--- a/conbench/templates/compare-list.html
+++ b/conbench/templates/compare-list.html
@@ -165,36 +165,6 @@
     </table>
   </div>
 </div>
-<hr />
-<h4>Compare current contender run with another run:</h4>
-<br>
-<form>
-  <div class="form-group">
-    <label for="commit-date">Baseline Commit Date</label>
-    <input type="date" id="commit-date" name="commit-date" value="">
-  </div>
-  <div class="form-group">
-    <label for="baseline-commit">Baseline Commit</label>
-    <select class="custom-select" name="baseline-commit" id="baseline-commit">
-      <option value="" selected="selected">Please select baseline commit date</option>
-    </select>
-  </div>
-  <div class="form-group">
-    <label for="hardware">Hardware</label>
-    <select class="custom-select" name="hardware" id="hardware">
-      <option value="" selected="selected">Please select baseline commit first</option>
-    </select>
-  </div>
-  <div class="form-group">
-    <label for="run-name">Run Name</label>
-    <select class="custom-select" name="run-name" id="run-name">
-      <option value="" selected="selected">Please select hardware first</option>
-    </select>
-  </div>
-</form>
-<form name="compare-runs" id="compare-runs"  method="get" action="">
-  <button type="submit" class="btn btn-primary">Submit</button>
-</form>
 {% endblock %}
 {% block scripts %}
   {{ super() }}
@@ -253,45 +223,5 @@
           },
         });
 
-    // Note(JP): maybe this is for the "compare current contender run to
-    // another run" form. Who uses that? Why is this workflow important?
-    window.onload = function () {
-      var commitHardwareRunMap = {{ commit_hardware_run_map|tojson|safe }};
-      var commitDate = document.getElementById("commit-date");
-      var baselineCommit = document.getElementById("baseline-commit");
-      var hardware = document.getElementById("hardware");
-      var runName = document.getElementById("run-name");
-
-      commitDate.onchange = function () {
-        runName.length = 1;
-        hardware.length = 1;
-        baselineCommit.length = 1
-        for (var commit in commitHardwareRunMap) {
-          if (commitHardwareRunMap[commit]["date"] == commitDate.value) {
-            baselineCommit.options[baselineCommit.options.length] = new Option(commit, commit);
-          }
-        }
-      }
-
-      baselineCommit.onchange = function () {
-        runName.length = 1;
-        hardware.length = 1;
-        for (var hardware_name in commitHardwareRunMap[this.value]["hardware"]) {
-          hardware.options[hardware.options.length] = new Option(hardware_name, hardware_name);
-        }
-      }
-      hardware.onchange = function () {
-        runName.length = 1;
-        var runs = commitHardwareRunMap[baselineCommit.value]["hardware"][this.value];
-        for (var i = 0; i < runs.length; i++) {
-          runName.options[runName.options.length] = new Option(runs[i][0], runs[i][1]);
-        }
-      }
-    }
-
-    document.getElementById('run-name').onchange = function () {
-      var action = window.location.protocol + "//" + window.location.host + "/compare/runs/" + this.value + "..." + "{{ contender_run.id }}";
-      document.getElementById('compare-runs').action = action;
-    };
   </script>
 {% endblock %}


### PR DESCRIPTION
I don't believe anyone uses this picker from the `/compare/runs/` page, especially now that the "candidate baseline runs" functionality is in the UI.

