### PR TITLE
list runs API: change default to 14d, add query param

### DIFF
--- a/conbench/api/runs.py
+++ b/conbench/api/runs.py
@@ -196,7 +196,9 @@ class RunListAPI(ApiEndpoint):
     def get(self):
         """
         ---
-        description: Get a list of runs from the last 30 days of benchmark results.
+        description: |
+            Get a list of runs from the last few days of benchmark results (default 14
+            days).
         responses:
             "200": "RunList"
             "401": "401"
@@ -205,17 +207,24 @@ class RunListAPI(ApiEndpoint):
             name: sha
             schema:
               type: string
+          - in: query
+            name: days
+            schema:
+              type: integer
         tags:
           - Runs
         """
         sha_arg: Optional[str] = f.request.args.get("sha")
         commit_hashes = sha_arg.split(",") if sha_arg else None
 
+        days_arg: Optional[int] = f.request.args.get("days")
+        days = int(days_arg) if days_arg else 14
+
         return [
             self.serializer.one._dump(run.earliest_result, get_baseline_runs=False)
             for run in get_all_run_info(
                 min_time=datetime.datetime.now(datetime.timezone.utc)
-                - datetime.timedelta(days=30),
+                - datetime.timedelta(days=days),
                 max_time=datetime.datetime.now(datetime.timezone.utc),
                 commit_hashes=commit_hashes,
             )

--- a/conbench/api/runs.py
+++ b/conbench/api/runs.py
@@ -198,7 +198,7 @@ class RunListAPI(ApiEndpoint):
         ---
         description: |
             Get a list of runs from the last few days of benchmark results (default 14
-            days).
+            days; no more than 30 days).
         responses:
             "200": "RunList"
             "401": "401"

--- a/conbench/api/runs.py
+++ b/conbench/api/runs.py
@@ -219,6 +219,8 @@ class RunListAPI(ApiEndpoint):
 
         days_arg: Optional[int] = f.request.args.get("days")
         days = int(days_arg) if days_arg else 14
+        if days > 30:
+            self.abort_400_bad_request("days must be no more than 30")
 
         return [
             self.serializer.one._dump(run.earliest_result, get_baseline_runs=False)

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -1803,7 +1803,7 @@
         },
         "/api/runs/": {
             "get": {
-                "description": "Get a list of runs from the last few days of benchmark results (default 14\ndays).\n",
+                "description": "Get a list of runs from the last few days of benchmark results (default 14\ndays; no more than 30 days).\n",
                 "parameters": [
                     {"in": "query", "name": "sha", "schema": {"type": "string"}},
                     {"in": "query", "name": "days", "schema": {"type": "integer"}},

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -1803,9 +1803,10 @@
         },
         "/api/runs/": {
             "get": {
-                "description": "Get a list of runs from the last 30 days of benchmark results.",
+                "description": "Get a list of runs from the last few days of benchmark results (default 14\ndays).\n",
                 "parameters": [
-                    {"in": "query", "name": "sha", "schema": {"type": "string"}}
+                    {"in": "query", "name": "sha", "schema": {"type": "string"}},
+                    {"in": "query", "name": "days", "schema": {"type": "integer"}},
                 ],
                 "responses": {
                     "200": {"$ref": "#/components/responses/RunList"},

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -424,6 +424,12 @@ class TestRunList(_asserts.ListEnforcer):
         response = client.get("/api/runs/?days=1")
         self.assert_200_ok(response, contains=_expected_entity(result))
 
+    def test_run_list_too_many_days(self, client):
+        self.authenticate(client)
+        result = self._create()
+        response = client.get("/api/runs/?days=31")
+        self.assert_400_bad_request(response, "days must be no more than 30")
+
     def test_run_list_filter_by_sha(self, client):
         sha = _fixtures.CHILD
         self.authenticate(client)

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -426,9 +426,10 @@ class TestRunList(_asserts.ListEnforcer):
 
     def test_run_list_too_many_days(self, client):
         self.authenticate(client)
-        result = self._create()
         response = client.get("/api/runs/?days=31")
-        self.assert_400_bad_request(response, "days must be no more than 30")
+        self.assert_400_bad_request(
+            response, {"_errors": ["days must be no more than 30"]}
+        )
 
     def test_run_list_filter_by_sha(self, client):
         sha = _fixtures.CHILD

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -418,6 +418,12 @@ class TestRunList(_asserts.ListEnforcer):
         response = client.get("/api/runs/")
         self.assert_200_ok(response, contains=_expected_entity(result))
 
+    def test_run_list_different_days(self, client):
+        self.authenticate(client)
+        result = self._create()
+        response = client.get("/api/runs/?days=1")
+        self.assert_200_ok(response, contains=_expected_entity(result))
+
     def test_run_list_filter_by_sha(self, client):
         sha = _fixtures.CHILD
         self.authenticate(client)


### PR DESCRIPTION
This PR lowers the default time window searched during GET `/api/runs/` from 30d to 14d. It also adds a `?days=X` query parameter so that users can customize it.