### PR TITLE
api/results: document run_reason arg

### DIFF
--- a/conbench/api/results.py
+++ b/conbench/api/results.py
@@ -140,6 +140,10 @@ class BenchmarkListAPI(ApiEndpoint, BenchmarkValidationMixin):
             to return them all in a single response; use that with caution:
             keep the number of run_ids low or equal to, unless you know better.
 
+            The `run_reason` argument can be provided to obtain benchmark
+            results for a specific run reason. Currently, this will return 55000
+            results.
+
         responses:
             "200": "BenchmarkList"
             "401": "401"
@@ -154,6 +158,10 @@ class BenchmarkListAPI(ApiEndpoint, BenchmarkValidationMixin):
               type: string
           - in: query
             name: run_id
+            schema:
+              type: string
+          - in: query
+            name: run_reason
             schema:
               type: string
         tags:

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -1406,11 +1406,12 @@
         },
         "/api/benchmarks/": {
             "get": {
-                "description": "Return a JSON array of benchmark results.\n\nNote that this endpoint does not provide on-the-fly change\ndetection analysis (lookback z-score method).\n\nBehavior at the time of writing (subject to change):\n\nBenchmark results are usually returned in order of their\ntimestamp property (user-given benchmark start time), newest first.\n\nWhen no argument is provided, the last 1000 benchmark results\nare emitted.\n\nThe `run_id` argument can be provided to obtain benchmark\nresults for one or more specific runs. This attempts to fetch\nall associated benchmark results from the database and tries\nto return them all in a single response; use that with caution:\nkeep the number of run_ids low or equal to, unless you know better.\n",
+                "description": "Return a JSON array of benchmark results.\n\nNote that this endpoint does not provide on-the-fly change\ndetection analysis (lookback z-score method).\n\nBehavior at the time of writing (subject to change):\n\nBenchmark results are usually returned in order of their\ntimestamp property (user-given benchmark start time), newest first.\n\nWhen no argument is provided, the last 1000 benchmark results\nare emitted.\n\nThe `run_id` argument can be provided to obtain benchmark\nresults for one or more specific runs. This attempts to fetch\nall associated benchmark results from the database and tries\nto return them all in a single response; use that with caution:\nkeep the number of run_ids low or equal to, unless you know better.\n\nThe `run_reason` argument can be provided to obtain benchmark\nresults for a specific run reason. Currently, this will return 55000\nresults.\n",
                 "parameters": [
                     {"in": "query", "name": "name", "schema": {"type": "string"}},
                     {"in": "query", "name": "batch_id", "schema": {"type": "string"}},
                     {"in": "query", "name": "run_id", "schema": {"type": "string"}},
+                    {"in": "query", "name": "run_reason", "schema": {"type": "string"}},
                 ],
                 "responses": {
                     "200": {"$ref": "#/components/responses/BenchmarkList"},


### PR DESCRIPTION
This PR documents the api/results `run_reason` arg we forgot to document earlier.