### PR TITLE
benchalerts: stop using /api/runs links key

### DIFF
--- a/benchalerts/benchalerts/conbench_dataclasses.py
+++ b/benchalerts/benchalerts/conbench_dataclasses.py
@@ -30,6 +30,8 @@ class RunComparisonInfo:
 
     Parameters
     ----------
+    conbench_api_url
+        A URL to the Conbench API, ending in /api.
     contender_info
         The dict returned from Conbench when hitting /runs/{contender_run_id}. Contains
         info about the run's ID, commit, errors, links, etc.
@@ -48,6 +50,7 @@ class RunComparisonInfo:
         otherwise all this information is already in the compare_results.
     """
 
+    conbench_api_url: str
     contender_info: dict
     baseline_run_type: str
     compare_results: Optional[List[dict]] = None
@@ -194,8 +197,7 @@ class RunComparisonInfo:
     @property
     def app_url(self) -> str:
         """The base URL to use for links to the webapp, without a trailing slash."""
-        self_link: str = self.contender_info["links"]["self"]
-        return self_link.rsplit("/api/", 1)[0]
+        return self.conbench_api_url.rsplit("/api", 1)[0]
 
     @property
     def compare_path(self) -> Optional[str]:

--- a/benchalerts/benchalerts/pipeline_steps/conbench.py
+++ b/benchalerts/benchalerts/pipeline_steps/conbench.py
@@ -104,6 +104,7 @@ class GetConbenchZComparisonForRunsStep(AlertPipelineStep):
             raise
 
         run_comparison = RunComparisonInfo(
+            conbench_api_url=self.conbench_client._base_url,
             contender_info=contender_info,
             baseline_run_type=self.baseline_run_type.value,
         )

--- a/benchalerts/tests/integration_tests/test_alert_pipeline.py
+++ b/benchalerts/tests/integration_tests/test_alert_pipeline.py
@@ -91,8 +91,8 @@ def test_alert_pipeline(monkeypatch: pytest.MonkeyPatch, github_auth: str):
 
 There was 1 benchmark result indicating a performance regression:
 
-- Commit Run on `GitHub-runner-8-core` at [2023-02-28 18:08:51Z](http://velox-conbench.voltrondata.run/compare/runs/GHA-4286800623-1...GHA-4296026775-1/)
-  - [`velox_benchmark_basic_vector_fuzzer` (C++) with source=cpp-micro, suite=velox_benchmark_basic_vector_fuzzer](http://velox-conbench.voltrondata.run/compare/benchmarks/a128eb19cc9442409148c91f7fa18cdf...ff7a1a86df5a4d56b6dbfb006c13c638)
+- Commit Run on `GitHub-runner-8-core` at [2023-02-28 18:08:51Z](https://velox-conbench.voltrondata.run/compare/runs/GHA-4286800623-1...GHA-4296026775-1/)
+  - [`flatMap` (C++) with source=cpp-micro, suite=velox_benchmark_basic_vector_fuzzer](https://velox-conbench.voltrondata.run/compare/benchmarks/a128eb19cc9442409148c91f7fa18cdf...ff7a1a86df5a4d56b6dbfb006c13c638)
 
 The [full Conbench report](https://github.com/conbench/benchalerts/runs/RUN_ID) has more details."""
 

--- a/benchalerts/tests/unit_tests/conftest.py
+++ b/benchalerts/tests/unit_tests/conftest.py
@@ -66,6 +66,9 @@ def conbench_env(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("CONBENCH_PASSWORD", "password")
 
 
+mock_conbench_api_url = "http://localhost/api"
+
+
 @pytest.fixture
 def mock_comparison_info(request: SubRequest) -> FullComparisonInfo:
     """Mock a FullComparisonInfo, like something that might be output from a
@@ -131,6 +134,7 @@ def mock_comparison_info(request: SubRequest) -> FullComparisonInfo:
         return FullComparisonInfo(
             [
                 RunComparisonInfo(
+                    conbench_api_url=mock_conbench_api_url,
                     contender_info=_run(
                         has_errors=True, has_baseline=True, has_commit=True
                     ),
@@ -145,6 +149,7 @@ def mock_comparison_info(request: SubRequest) -> FullComparisonInfo:
         return FullComparisonInfo(
             [
                 RunComparisonInfo(
+                    conbench_api_url=mock_conbench_api_url,
                     contender_info=_run(
                         has_errors=True, has_baseline=False, has_commit=True
                     ),
@@ -159,6 +164,7 @@ def mock_comparison_info(request: SubRequest) -> FullComparisonInfo:
         return FullComparisonInfo(
             [
                 RunComparisonInfo(
+                    conbench_api_url=mock_conbench_api_url,
                     contender_info=_run(
                         has_errors=False, has_baseline=False, has_commit=True
                     ),
@@ -173,6 +179,7 @@ def mock_comparison_info(request: SubRequest) -> FullComparisonInfo:
         return FullComparisonInfo(
             [
                 RunComparisonInfo(
+                    conbench_api_url=mock_conbench_api_url,
                     contender_info=_run(
                         has_errors=False, has_baseline=False, has_commit=True
                     ),
@@ -181,6 +188,7 @@ def mock_comparison_info(request: SubRequest) -> FullComparisonInfo:
                     benchmark_results=_results(has_errors=False),
                 ),
                 RunComparisonInfo(
+                    conbench_api_url=mock_conbench_api_url,
                     contender_info=_run(
                         has_errors=False, has_baseline=True, has_commit=True
                     ),
@@ -189,6 +197,7 @@ def mock_comparison_info(request: SubRequest) -> FullComparisonInfo:
                     benchmark_results=None,
                 ),
                 RunComparisonInfo(
+                    conbench_api_url=mock_conbench_api_url,
                     contender_info=_run(
                         has_errors=False, has_baseline=True, has_commit=True
                     ),
@@ -202,6 +211,7 @@ def mock_comparison_info(request: SubRequest) -> FullComparisonInfo:
         return FullComparisonInfo(
             [
                 RunComparisonInfo(
+                    conbench_api_url=mock_conbench_api_url,
                     contender_info=_run(
                         has_errors=False, has_baseline=True, has_commit=True
                     ),
@@ -216,6 +226,7 @@ def mock_comparison_info(request: SubRequest) -> FullComparisonInfo:
         return FullComparisonInfo(
             [
                 RunComparisonInfo(
+                    conbench_api_url=mock_conbench_api_url,
                     contender_info=_run(
                         has_errors=False, has_baseline=False, has_commit=False
                     ),
@@ -232,6 +243,7 @@ def mock_comparison_info(request: SubRequest) -> FullComparisonInfo:
         return FullComparisonInfo(
             [
                 RunComparisonInfo(
+                    conbench_api_url=mock_conbench_api_url,
                     contender_info=_run(
                         has_errors=False, has_baseline=False, has_commit=True
                     ),

--- a/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_contender_wo_base.json
+++ b/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_contender_wo_base.json
@@ -36,15 +36,7 @@
             "os_version": "10.15.7",
             "type": "machine"
         },
-        "has_errors": true,
         "id": "some_contender",
-        "links": {
-            "baseline": null,
-            "commit": "http://localhost/api/commits/some-commit-uuid-1/",
-            "hardware": "http://localhost/api/hardware/some-machine-uuid-1/",
-            "list": "http://localhost/api/runs/",
-            "self": "http://localhost/api/runs/some-run-uuid-1/"
-        },
         "candidate_baseline_runs": {
             "fork_point": {
                 "baseline_run_id": null,
@@ -62,8 +54,10 @@
                 "error": "the contender run is the first commit"
             }
         },
-        "name": "some run name",
         "reason": "some run reason",
-        "timestamp": "2021-02-04T17:22:05.225583"
+        "timestamp": "2021-02-04T17:22:05.225583",
+        "tags": {
+            "fake": "tags"
+        }
     }
 }

--- a/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_no_commit.json
+++ b/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_no_commit.json
@@ -25,13 +25,7 @@
             "os_version": "10.15.7",
             "type": "machine"
         },
-        "has_errors": false,
         "id": "no_commit",
-        "links": {
-            "hardware": "http://localhost/api/hardware/some-machine-uuid-1/",
-            "list": "http://localhost/api/runs/",
-            "self": "http://localhost/api/runs/some-run-uuid-1/"
-        },
         "candidate_baseline_runs": {
             "fork_point": {
                 "baseline_run_id": null,
@@ -49,8 +43,10 @@
                 "error": "the contender run is not connected to the git graph"
             }
         },
-        "name": "some run name",
         "reason": "some run reason",
-        "timestamp": "2021-02-04T17:22:05.225583"
+        "timestamp": "2021-02-04T17:22:05.225583",
+        "tags": {
+            "fake": "tags"
+        }
     }
 }

--- a/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_sha_abc.json
+++ b/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_sha_abc.json
@@ -37,34 +37,12 @@
                 "os_version": "10.15.7",
                 "type": "machine"
             },
-            "has_errors": false,
             "id": "some_contender",
-            "links": {
-                "commit": "http://localhost/api/commits/some-commit-uuid-1/",
-                "hardware": "http://localhost/api/hardware/some-machine-uuid-1/",
-                "list": "http://localhost/api/runs/",
-                "self": "http://localhost/api/runs/some-run-uuid-1/"
-            },
-            "candidate_baseline_runs": {
-                "fork_point": {
-                    "baseline_run_id": null,
-                    "commits_skipped": null,
-                    "error": "the contender run is on the default branch"
-                },
-                "latest_default": {
-                    "baseline_run_id": null,
-                    "commits_skipped": null,
-                    "error": "the contender run is on the default branch"
-                },
-                "parent": {
-                    "baseline_run_id": null,
-                    "commits_skipped": [],
-                    "error": "the contender run is the first commit"
-                }
-            },
-            "name": "some run name",
             "reason": "some run reason",
-            "timestamp": "2021-02-04T17:22:05.225583"
+            "timestamp": "2021-02-04T17:22:05.225583",
+            "tags": {
+                "fake": "tags"
+            }
         }
     ]
 }

--- a/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_sha_no_baseline.json
+++ b/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_sha_no_baseline.json
@@ -37,34 +37,12 @@
                 "os_version": "10.15.7",
                 "type": "machine"
             },
-            "has_errors": false,
             "id": "contender_wo_base",
-            "links": {
-                "commit": "http://localhost/api/commits/some-commit-uuid-1/",
-                "hardware": "http://localhost/api/hardware/some-machine-uuid-1/",
-                "list": "http://localhost/api/runs/",
-                "self": "http://localhost/api/runs/some-run-uuid-1/"
-            },
-            "candidate_baseline_runs": {
-                "fork_point": {
-                    "baseline_run_id": null,
-                    "commits_skipped": null,
-                    "error": "the contender run is on the default branch"
-                },
-                "latest_default": {
-                    "baseline_run_id": null,
-                    "commits_skipped": null,
-                    "error": "the contender run is on the default branch"
-                },
-                "parent": {
-                    "baseline_run_id": null,
-                    "commits_skipped": [],
-                    "error": "the contender run is the first commit"
-                }
-            },
-            "name": "some run name",
             "reason": "some run reason",
-            "timestamp": "2021-02-04T17:22:05.225583"
+            "timestamp": "2021-02-04T17:22:05.225583",
+            "tags": {
+                "fake": "tags"
+            }
         }
     ]
 }

--- a/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_some_contender.json
+++ b/benchalerts/tests/unit_tests/mocked_responses/GET_conbench_runs_some_contender.json
@@ -36,15 +36,7 @@
             "os_version": "10.15.7",
             "type": "machine"
         },
-        "has_errors": false,
         "id": "some_contender",
-        "links": {
-            "baseline": "http://localhost/api/runs/some_baseline/",
-            "commit": "http://localhost/api/commits/some-commit-uuid-1/",
-            "hardware": "http://localhost/api/hardware/some-machine-uuid-1/",
-            "list": "http://localhost/api/runs/",
-            "self": "http://localhost/api/runs/some-run-uuid-1/"
-        },
         "candidate_baseline_runs": {
             "fork_point": {
                 "baseline_run_id": "some_baseline",
@@ -62,8 +54,10 @@
                 "error": null
             }
         },
-        "name": "some run name",
         "reason": "some run reason",
-        "timestamp": "2021-02-04T17:22:05.225583"
+        "timestamp": "2021-02-04T17:22:05.225583",
+        "tags": {
+            "fake": "tags"
+        }
     }
 }


### PR DESCRIPTION
I noticed that `benchalerts` was using one key from the runs API ("links") that was removed in #1450.