### PR TITLE
DB: store commit repo URL on benchmark_result

### DIFF
--- a/conbench/api/_examples.py
+++ b/conbench/api/_examples.py
@@ -36,6 +36,7 @@ def _api_benchmark_entity(
     commit_id,
     parent_id,
     commit_type,  # "none", "known", "unknown"
+    commit_repo_url,
     branch,
     hardware_id,
     hardware_name,
@@ -130,6 +131,7 @@ def _api_benchmark_entity(
             links=False,
             is_unknown_commit=commit_type == "unknown",
         ),
+        "commit_repo_url": commit_repo_url,
         "hardware": _api_hardware_entity(
             hardware_id, hardware_name, hardware_type, links=False
         ),
@@ -504,6 +506,7 @@ BENCHMARK_ENTITY = _api_benchmark_entity(
     "some-commit-uuid-1",
     "some-parent-commit-uuid-1",
     "known",
+    "https://github.com/org/repo",
     "some_user_or_org:some_branch",
     "some-machine-uuid-1",
     "some-machine-name",

--- a/conbench/entities/commit.py
+++ b/conbench/entities/commit.py
@@ -42,10 +42,10 @@ _tloc = threading.local()
 
 
 class TypeCommitInfoGitHub(TypedDict):
-    # Guarantee: non-empty. A URL.
+    # Guarantee: non-empty. A URL without trailing slash.
     repo_url: str
-    # Guarantee: Non-empty.
-    commit_hash: str
+    # Guarantee: Non-empty or None
+    commit_hash: Optional[str]
     pr_number: Optional[int]
     # Guarantee: non-empty or None
     branch: Optional[str]
@@ -430,8 +430,10 @@ def get_github_commit_metadata(cinfo: TypeCommitInfoGitHub) -> Dict:
     requests.exceptions.RequestException.
 
     """
-    # repospec: in org/repo notation.
+    # Commit hash must be provided to use this function.
+    assert cinfo["commit_hash"]
 
+    # repospec: in org/repo notation.
     repospec = repository_to_name(cinfo["repo_url"])
 
     # `github.get_commit()` below may raise an exception if the GitHub

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -63,6 +63,7 @@
                                 "timestamp": "2021-02-25T01:02:51",
                                 "url": "https://github.com/org/repo/commit/02addad336ba19a654f9c857ede546331be7b631",
                             },
+                            "commit_repo_url": "https://github.com/org/repo",
                             "error": None,
                             "hardware": {
                                 "architecture_name": "x86_64",
@@ -172,6 +173,7 @@
                                     "timestamp": "2021-02-25T01:02:51",
                                     "url": "https://github.com/org/repo/commit/02addad336ba19a654f9c857ede546331be7b631",
                                 },
+                                "commit_repo_url": "https://github.com/org/repo",
                                 "error": None,
                                 "hardware": {
                                     "architecture_name": "x86_64",
@@ -281,6 +283,7 @@
                                 "timestamp": "2021-02-25T01:02:51",
                                 "url": "https://github.com/org/repo/commit/02addad336ba19a654f9c857ede546331be7b631",
                             },
+                            "commit_repo_url": "https://github.com/org/repo",
                             "error": None,
                             "hardware": {
                                 "architecture_name": "x86_64",
@@ -1091,7 +1094,7 @@
                     },
                     "github": {
                         "allOf": [{"$ref": "#/components/schemas/SchemaGitHubCreate"}],
-                        "description": "GitHub-flavored commit information.  Use this object to tell Conbench with which specific state of benchmarked code (repository identifier, commit hash) the BenchmarkResult is associated.  This property is optional. If not provided, it means that this benchmark result is not associated with any particular state of benchmarked code.  Not associating a benchmark result with commit information has special, limited purpose (pre-merge benchmarks, testing). It generally means that this benchmark result will not be considered for time series analysis along a commit tree.  TODO: allow for associating a benchmark result with a repository (URL), w/o providing commit information (cf. issue #1165).",
+                        "description": "GitHub-flavored commit information.  Use this object to tell Conbench with which specific state of benchmarked code (repository identifier, commit hash) the BenchmarkResult is associated.  The optionality of this object is deprecated. It will become required soon.",
                     },
                     "info": {
                         "description": "Optional.  Arbitrary metadata associated with this benchmark result.  Ignored when assembling timeseries across results (differences do not break history).  Must be a JSON object if provided. A flat string-string mapping is recommended (not yet enforced).  This can be useful for example for storing URLs pointing to build artifacts. You can also use this to store environmental properties that you potentially would like to review later (a compiler version, or runtime version), and generally any kind of information that can later be useful for debugging unexpected measurements.",
@@ -1341,7 +1344,7 @@
                         "type": "string",
                     },
                     "commit": {
-                        "description": "The commit hash of the benchmarked code.  Must not be an empty string.  Expected to be a known commit in the repository as specified by the `repository` URL property below.",
+                        "description": "The commit hash of the benchmarked code.  Must not be an empty string.  Expected to be a known commit in the repository as specified by the `repository` URL property below.  This property is optional. If not provided, it means that this benchmark result is not associated with a reproducible commit in the given repository.  Not associating a benchmark result with a commit hash has special, limited purpose (pre-merge benchmarks, testing). It generally means that this benchmark result will not be considered for time series analysis along a commit tree.",
                         "type": "string",
                     },
                     "pr_number": {
@@ -1354,7 +1357,7 @@
                         "type": "string",
                     },
                 },
-                "required": ["commit", "repository"],
+                "required": ["repository"],
                 "type": "object",
             },
             "UserCreate": {

--- a/migrations/versions/afe717e97b78_add_result_repo_col.py
+++ b/migrations/versions/afe717e97b78_add_result_repo_col.py
@@ -1,0 +1,25 @@
+"""add_result_repo_col
+
+Revision ID: afe717e97b78
+Revises: 2ee66194b9eb
+Create Date: 2023-08-24 15:21:19.938993
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "afe717e97b78"
+down_revision = "2ee66194b9eb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "benchmark_result", sa.Column("commit_repo_url", sa.Text(), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column("benchmark_result", "commit_repo_url")


### PR DESCRIPTION
Part of #1165. Steps 1 and 2 of [this plan](https://github.com/conbench/conbench/issues/1165#issuecomment-1690557411).

This PR adds a nullable `commit_repo_url` column to BenchmarkResult. This is populated by the user-given `["github"]["repository"]` in the `POST /api/benchmark-results` payload if given.

It also makes the `["github"]["commit"]` property optional in the same payload. This is so we can switch over clients that today submit `"github": null` in transient commit use cases to `"github": {"repository": "..."}` instead.