### PR TITLE
benchadapt: fix github handling

### DIFF
--- a/benchadapt/python/benchadapt/result.py
+++ b/benchadapt/python/benchadapt/result.py
@@ -2,7 +2,7 @@ import datetime
 import uuid
 import warnings
 from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, Literal, Optional, Union
+from typing import Any, Dict
 
 from . import _machine_info
 

--- a/benchadapt/python/benchadapt/run.py
+++ b/benchadapt/python/benchadapt/run.py
@@ -1,7 +1,7 @@
 import uuid
 import warnings
 from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from . import _machine_info
 


### PR DESCRIPTION
This should have been part of
- https://github.com/conbench/conbench/pull/1453

but I forgot. 🙂 

This PR makes `benchadapt` also able to handle `"github": {"repository": "..."}` (without `"commit"`) and goes a step further to enforce that you always have to provide it, instead of providing None, during transient commit use cases.