### PR TITLE
API POST result: require github prop again

### DIFF
--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -244,15 +244,13 @@ class BenchmarkResult(Base, EntityMixin):
         else:
             hardware = Cluster.get_or_create(userres["cluster_info"])
 
-        user_given_commit_info: Optional[TypeCommitInfoGitHub] = userres.get("github")
-        repo_url = None
+        user_given_commit_info: TypeCommitInfoGitHub = userres["github"]
+        repo_url = user_given_commit_info["repo_url"]
         commit = None
-        if user_given_commit_info is not None:
-            repo_url = user_given_commit_info["repo_url"]
-            if user_given_commit_info["commit_hash"] is not None:
-                commit = commit_fetch_info_and_create_in_db_if_not_exists(
-                    user_given_commit_info
-                )
+        if user_given_commit_info["commit_hash"] is not None:
+            commit = commit_fetch_info_and_create_in_db_if_not_exists(
+                user_given_commit_info
+            )
 
         result_data_for_db["run_id"] = userres["run_id"]
         result_data_for_db["run_tags"] = userres.get("run_tags") or {}
@@ -1661,18 +1659,15 @@ class _BenchmarkResultCreateSchema(marshmallow.Schema):
     )
     github = marshmallow.fields.Nested(
         SchemaGitHubCreate(),
-        required=False,
+        required=True,
         metadata={
             "description": conbench.util.dedent_rejoin(
                 """
-                GitHub-flavored commit information.
+                GitHub-flavored commit information. Required.
 
                 Use this object to tell Conbench with which specific state of
-                benchmarked code (repository identifier, commit hash) the
+                benchmarked code (repository identifier, possible commit hash) the
                 BenchmarkResult is associated.
-
-                The optionality of this object is deprecated. It will become required
-                soon.
                 """
             )
         },

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -1094,7 +1094,7 @@
                     },
                     "github": {
                         "allOf": [{"$ref": "#/components/schemas/SchemaGitHubCreate"}],
-                        "description": "GitHub-flavored commit information.  Use this object to tell Conbench with which specific state of benchmarked code (repository identifier, commit hash) the BenchmarkResult is associated.  The optionality of this object is deprecated. It will become required soon.",
+                        "description": "GitHub-flavored commit information. Required.  Use this object to tell Conbench with which specific state of benchmarked code (repository identifier, possible commit hash) the BenchmarkResult is associated.",
                     },
                     "info": {
                         "description": "Optional.  Arbitrary metadata associated with this benchmark result.  Ignored when assembling timeseries across results (differences do not break history).  Must be a JSON object if provided. A flat string-string mapping is recommended (not yet enforced).  This can be useful for example for storing URLs pointing to build artifacts. You can also use this to store environmental properties that you potentially would like to review later (a compiler version, or runtime version), and generally any kind of information that can later be useful for debugging unexpected measurements.",
@@ -1139,7 +1139,14 @@
                         "type": "object",
                     },
                 },
-                "required": ["batch_id", "context", "run_id", "tags", "timestamp"],
+                "required": [
+                    "batch_id",
+                    "context",
+                    "github",
+                    "run_id",
+                    "tags",
+                    "timestamp",
+                ],
                 "type": "object",
             },
             "BenchmarkResultStats": {

--- a/conbench/tests/api/_fixtures.py
+++ b/conbench/tests/api/_fixtures.py
@@ -233,7 +233,7 @@ def benchmark_result(
     empty_results=False,
     reason=None,
     one_sample_no_mean=False,
-    no_github=False,
+    no_commit_hash=False,
     timestamp=None,
 ):
     """Create BenchmarkResult and directly write to database.
@@ -279,15 +279,14 @@ def benchmark_result(
         data["github"]["commit"] = commit.sha
         data["github"]["repository"] = commit.repository
         data["github"]["branch"] = commit.branch
-    if no_github:
-        del data["github"]
+    if no_commit_hash:
+        del data["github"]["commit"]
     if timestamp:
         data["timestamp"] = timestamp
 
     # do at least a bit of what the HTTP path would do; this ensures that the
     # output type is TypeCommitInfoGitHub
-    if "github" in data:
-        data["github"] = _github_commit_info_schema.load(data["github"])
+    data["github"] = _github_commit_info_schema.load(data["github"])
 
     if results is not None:
         unit = unit if unit else "s"

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -97,7 +97,7 @@ class TestRunGet(_asserts.GetEnforcer):
 
     def test_get_run_without_commit(self, client):
         self.authenticate(client)
-        result = _fixtures.benchmark_result(no_github=True)
+        result = _fixtures.benchmark_result(no_commit_hash=True)
         response = client.get(f"/api/runs/{result.run_id}/")
         expected = _expected_entity(
             result,
@@ -833,7 +833,7 @@ def test_get_candidate_baseline_runs():
     benchmark_result_missing_commit = _fixtures.benchmark_result(
         name=benchmark_results[1].case.name,
         results=[1, 2, 3],
-        no_github=True,
+        no_commit_hash=True,
     )
     assert benchmark_result_missing_commit.commit is None
     actual_baseline_run_dict = get_candidate_baseline_runs(

--- a/conbench/tests/app/test_results.py
+++ b/conbench/tests/app/test_results.py
@@ -81,7 +81,7 @@ class TestBenchmarkResultGet(_asserts.GetEnforcer):
 
         # Post a benchmark without a commit
         payload = _fixtures.VALID_RESULT_PAYLOAD.copy()
-        del payload["github"]
+        del payload["github"]["commit"]
         post_response = client.post("/api/benchmarks/", json=payload)
         assert post_response.status_code == 201
 

--- a/conbench/tests/app/test_results.py
+++ b/conbench/tests/app/test_results.py
@@ -1,3 +1,4 @@
+import copy
 import re
 
 import pytest
@@ -80,7 +81,7 @@ class TestBenchmarkResultGet(_asserts.GetEnforcer):
         self.authenticate(client)
 
         # Post a benchmark without a commit
-        payload = _fixtures.VALID_RESULT_PAYLOAD.copy()
+        payload = copy.deepcopy(_fixtures.VALID_RESULT_PAYLOAD)
         del payload["github"]["commit"]
         post_response = client.post("/api/benchmarks/", json=payload)
         assert post_response.status_code == 201

--- a/conbench/tests/app/test_runs.py
+++ b/conbench/tests/app/test_runs.py
@@ -45,7 +45,7 @@ class TestRunGet(_asserts.GetEnforcer):
 
         # Post a benchmark without a commit
         payload = copy.deepcopy(_fixtures.VALID_RESULT_PAYLOAD)
-        del payload["github"]
+        del payload["github"]["commit"]
         response = client.post("/api/benchmarks/", json=payload)
         assert response.status_code == 201
 


### PR DESCRIPTION
This PR is part of #1165 and makes the `github` property required to post a benchmark result. This is so that each benchmark result is associated with a repository, even if it's not associated with a reproducible commit in that repository.