### PR TITLE
DB: make `benchmark_result.commit_repo_url` not null

### DIFF
--- a/conbench/api/results.py
+++ b/conbench/api/results.py
@@ -285,9 +285,9 @@ class BenchmarkListAPI(ApiEndpoint, BenchmarkValidationMixin):
             return resp400(str(exc))
 
         # Rely on the idea that the lookup
-        # `benchmark_result.commit.repo_url` always succeeds
+        # `benchmark_result.commit_repo_url` always succeeds
         conbench.metrics.COUNTER_BENCHMARK_RESULTS_INGESTED.labels(
-            repourl=benchmark_result.associated_commit_repo_url
+            repourl=benchmark_result.commit_repo_url
         ).inc()
         return self.response_201_created(self.serializer.one.dump(benchmark_result))
 

--- a/conbench/api/runs.py
+++ b/conbench/api/runs.py
@@ -253,16 +253,17 @@ def get_candidate_baseline_runs(
         )
 
     # The latest commit on the default branch that Conbench knows about
-    query = s.select(Commit).filter(Commit.sha == Commit.fork_point_sha)
+    query = (
+        s.select(Commit)
+        .filter(
+            Commit.sha == Commit.fork_point_sha,
+            Commit.repository == contender_benchmark_result.commit_repo_url,
+        )
+        .order_by(s.desc(Commit.timestamp))
+        .limit(1)
+    )
 
-    # TODO: how do we filter by repository if there's no commit?
-    # (For now we just choose the latest commit of any repository.)
-    if contender_commit:
-        query = query.filter(Commit.repository == contender_commit.repository)
-
-    latest_commit = current_session.scalars(
-        query.order_by(s.desc(Commit.timestamp)).limit(1)
-    ).first()
+    latest_commit = current_session.scalars(query).first()
     candidates["latest_default"] = _search_for_baseline_run(
         baseline_commit=latest_commit,
         contender_run_id=contender_benchmark_result.run_id,

--- a/conbench/app/index.py
+++ b/conbench/app/index.py
@@ -50,25 +50,17 @@ class Index(AppEndpoint, RunMixin):
             - datetime.timedelta(days=30),
             max_time=datetime.datetime.now(datetime.timezone.utc),
         )
-        # Note(JP): group runs by associated commit.repository value.
+        # Note(JP): group runs by associated repository value.
         reponame_runs_map: Dict[str, List[RunAggregate]] = defaultdict(list)
 
         for run in all_run_info:
-            rname = repo_url_to_display_name(
-                run.earliest_result.associated_commit_repo_url
-            )
+            rname = repo_url_to_display_name(run.earliest_result.commit_repo_url)
             reponame_runs_map[rname].append(run)
 
         # A quick decision for now, not set in stone: get a stable sort order
         # of repositories the way they are listed on that page; do this by
         # sorting alphabetically.
         reponame_runs_map_sorted = dict(sorted(reponame_runs_map.items()))
-
-        # Those runs without repo information "n/a" should for now not
-        # be at the top. Move this to the end of the (ordered) dict.
-        # See https://github.com/conbench/conbench/issues/1226
-        if "n/a" in reponame_runs_map_sorted:
-            reponame_runs_map_sorted["n/a"] = reponame_runs_map_sorted.pop("n/a")
 
         return self.page(reponame_runs_map_sorted)
 

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -82,8 +82,7 @@ class BenchmarkResult(Base, EntityMixin):
     commit: Mapped[Optional[Commit]] = relationship("Commit", lazy="joined")
 
     # Non-empty URL to the repository without trailing slash.
-    # Will be made non-nullable very soon.
-    commit_repo_url: Mapped[Optional[str]] = Nullable(s.Text)
+    commit_repo_url: Mapped[str] = NotNull(s.Text)
 
     hardware_id: Mapped[str] = NotNull(s.String(50), s.ForeignKey("hardware.id"))
     hardware: Mapped[Hardware] = relationship("Hardware", lazy="joined")
@@ -554,25 +553,6 @@ class BenchmarkResult(Base, EntityMixin):
         assert self.unit
 
         return conbench.units.legacy_convert(self.unit)
-
-    @property
-    def associated_commit_repo_url(self) -> str:
-        """
-        Always return a string. Return URL or "n/a".
-
-        This is for those consumers that absolutely need to have a string type
-        representation.
-        """
-        if self.commit_repo_url is not None:
-            return self.commit_repo_url
-
-        if self.commit and self.commit.repo_url is not None:
-            return self.commit.repo_url
-
-        # This means that the result is not associated with any commit, or it is
-        # associated with a legacy/invalid commit object in the database, one
-        # that does not have a repository URL set.
-        return "n/a"
 
 
 def ui_rel_sem(values: List[float]) -> Tuple[str, str]:

--- a/conbench/tests/api/_fixtures.py
+++ b/conbench/tests/api/_fixtures.py
@@ -233,7 +233,7 @@ def benchmark_result(
     empty_results=False,
     reason=None,
     one_sample_no_mean=False,
-    no_commit_hash=False,
+    repo_without_commit=None,
     timestamp=None,
 ):
     """Create BenchmarkResult and directly write to database.
@@ -279,8 +279,8 @@ def benchmark_result(
         data["github"]["commit"] = commit.sha
         data["github"]["repository"] = commit.repository
         data["github"]["branch"] = commit.branch
-    if no_commit_hash:
-        del data["github"]["commit"]
+    if repo_without_commit:
+        data["github"] = {"repository": repo_without_commit}
     if timestamp:
         data["timestamp"] = timestamp
 

--- a/conbench/tests/api/test_results.py
+++ b/conbench/tests/api/test_results.py
@@ -777,10 +777,6 @@ class TestBenchmarkResultPost(_asserts.PostEnforcer):
             benchmark_result.commit_repo_url
             == self.valid_payload["github"]["repository"]
         )
-        assert (
-            benchmark_result.associated_commit_repo_url
-            == self.valid_payload["github"]["repository"]
-        )
         return benchmark_result, new_id
 
     def test_create_no_commit_hash(self, client):

--- a/migrations/versions/167a97c81739_make_commit_repo_url_non_null.py
+++ b/migrations/versions/167a97c81739_make_commit_repo_url_non_null.py
@@ -1,0 +1,27 @@
+"""make_commit_repo_url_non_null
+
+Revision ID: 167a97c81739
+Revises: afe717e97b78
+Create Date: 2023-08-28 19:30:41.882672
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "167a97c81739"
+down_revision = "afe717e97b78"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "benchmark_result", "commit_repo_url", existing_type=sa.TEXT(), nullable=False
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "benchmark_result", "commit_repo_url", existing_type=sa.TEXT(), nullable=True
+    )


### PR DESCRIPTION
Addresses the core problem of #1165.

This PR makes the `benchmark_result.commit_repo_url` column not null. It also switches the `get_candidate_baseline_runs` logic to find the latest default-branch commit for the given benchmark result's repository, since that is now always known.