### PR TITLE
ui: compare view: adjust help text for z-score sign

### DIFF
--- a/conbench/templates/compare-list.html
+++ b/conbench/templates/compare-list.html
@@ -86,7 +86,8 @@
     <p>
       Whether the contender does better or worse than the reference is indicated by sign:
       a negative sign (for both, <code>change</code> and <code>z-score</code>) reflects the direction of degradation, a positive sign reflects the direction of improvement.
-      The directionality is derived from the user-given unit (units other than s, i/s, B/s are <a href="https://github.com/conbench/conbench/issues/1335">not yet well supported</a>).
+      The directionality is derived from the user-given unit
+      (e.g., for a duration measured in seconds "less is better", and for throughput measured in Bytes per second "more is better").
     </p>
     <p>
       Further methodological details are described in the


### PR DESCRIPTION
After the consolidation work around units we can remove this caveat from the help text. This is for PFE-2025.