### PR TITLE
UI: landing page: query distinct runs from DB (address issue 1466)

### DIFF
--- a/conbench/api/runs.py
+++ b/conbench/api/runs.py
@@ -39,6 +39,7 @@ class RunAggregate:
 
     @functools.cached_property
     def display_commit_time(self) -> str:
+        # Note(JP): this is not the commit time
         return self.earliest_result.timestamp.strftime("%Y-%m-%d %H:%M:%S UTC")
 
     @functools.cached_property

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -906,6 +906,49 @@ def validate_and_augment_result_tags(userres: Any):
             )
 
 
+# Note(JP): This is a special "skip scan" query tailored for current
+# implementation details (PostgreSQL 15, current DB schema). It is designed to
+# quickly obtain one benchmark result row from results table, each result
+# having a unique run_id set. See
+# https://github.com/conbench/conbench/issues/1466 for more details and
+# background.
+_RECENT_RUNS_QUERY = """
+WITH RECURSIVE t AS (
+   (
+      SELECT *
+      FROM benchmark_result ORDER BY run_id LIMIT 1
+   )
+   UNION ALL
+   SELECT l.*
+   FROM t
+   CROSS JOIN LATERAL (
+      SELECT *
+      FROM   benchmark_result
+      WHERE  run_id > t.run_id
+      ORDER BY run_id
+      LIMIT  1
+      ) l
+   )
+SELECT * FROM t WHERE run_id IS NOT NULL
+ORDER BY timestamp desc
+LIMIT 500;
+"""
+
+
+def one_result_per_n_recent_runs() -> List[BenchmarkResult]:
+    from sqlalchemy.sql import text
+
+    bmrs = (
+        current_session.query(BenchmarkResult)
+        .from_statement(text(_RECENT_RUNS_QUERY))
+        .all()
+    )
+
+    log.info("found %s results", len(bmrs))
+
+    return bmrs
+
+
 def commit_fetch_info_and_create_in_db_if_not_exists(
     ghcommit: TypeCommitInfoGitHub,
 ) -> Commit:

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -543,6 +543,12 @@ class BenchmarkResult(Base, EntityMixin):
             return '<a href="#">n/a</a>'
         return f'<a href="{self.commit.commit_url}">{self.commit.hash[:7]}</a>'
 
+    @property
+    def ui_commit_short_msg(self) -> str:
+        if self.commit is None:
+            return "n/a"
+        return conbench.util.short_commit_msg(self.commit.message)
+
     @functools.cached_property
     def unitsymbol(self) -> Optional[conbench.units.TUnit]:
         """Return unit symbol or None if result indicates failure."""

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -44,7 +44,7 @@
               {% for result_for_run in results_for_runs %}
                 <tr class="no-border">
                   <td>
-                    <code><a href="{{ url_for('app.run', run_id=result_for_run.run_id) }}">{{ result_for_run.ui_time_started_at}}</a></code>
+                    <code><a href="{{ url_for('app.run', run_id=result_for_run.run_id) }}">{{ result_for_run.ui_time_started_at }}</a></code>
                   </td>
                   <!-- no efficient lookup built so far; can populate this from BMRT cache if we want to -->
                   <td></td>

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -2,7 +2,7 @@
 {% block app_content %}
   <h1>CI runs</h1>
   <div class="mt-3">
-    {% for reponame, runobjs in repo_runs_map.items() %}
+    {% for reponame, results_for_runs in reponame_result_map_sorted.items() %}
       <div class="row mb-5">
         <h4>
           Recent  CI runs for <strong>{{ reponame }}</strong>
@@ -27,8 +27,11 @@
                 <th scope="colgroup" colspan="3" class="">Commit</th>
               </tr>
               <tr>
-                <!-- add tooltip, saying that this is DB insertion time -->
-                <th scope="col" style="width: 180px" class="cb-colgroup-run">creation time</th>
+                <!-- add tooltip, saying that this is DB insertion time
+                update(jp): now this is more like "(a) result seen at.
+                "creation time" is kind of wrong
+              -->
+                <th scope="col" style="width: 180px" class="cb-colgroup-run">time</th>
                 <th scope="col" class="cb-colgroup-run">results</th>
                 <th scope="col" class="reason-col cb-colgroup-run">reason</th>
                 <th scope="col" style="width: 150px" class="cb-colgroup-run">hardware</th>
@@ -38,66 +41,55 @@
               </tr>
             </thead>
             <tbody class="table-group-divider">
-              {% for r in runobjs %}
+              {% for result_for_run in results_for_runs %}
                 <tr class="no-border">
                   <td>
-                    <code><a href="{{ url_for('app.run', run_id=r.earliest_result.run_id) }}">{{ r.display_commit_time }}</a></code>
-                    {% if r.any_result_failed %}
-                      <i class="bi bi-exclamation-circle text-danger"
-                         data-toggle="tooltip"
-                         data-placement="top"
-                         title="This Run contains a benchmark result with an error"></i>
-                    {% endif %}
+                    <code><a href="{{ url_for('app.run', run_id=result_for_run.run_id) }}">{{ result_for_run.ui_time_started_at}}</a></code>
                   </td>
-                  <td>{{ r.result_count }}</td>
+                  <!-- no efficient lookup built so far; can populate this from BMRT cache if we want to -->
+                  <td></td>
                   <td>
-                    {% if r.earliest_result.run_reason %}
-                      <div class="table-entry">{{ r.earliest_result.run_reason }}</div>
+                    {% if result_for_run.run_reason %}
+                      <div class="table-entry">{{ result_for_run.run_reason }}</div>
                     {% else %}
                       <div class="table-entry"></div>
                     {% endif %}
                   </td>
                   <td>
                     <span class="table-entry text-truncate d-inline-block"
-                          style="max-width: 140px">{{ r.earliest_result.hardware.name }}</span>
+                          style="max-width: 140px">{{ result_for_run.hardware.name }}</span>
                   </td>
                   <td>
                     <div class="table-entry">
-                      {% if r.earliest_result.commit is not none %}
-                        {% if r.earliest_result.commit.author_avatar_url is not none %}
+                      {% if result_for_run.commit is not none %}
+                        {% if result_for_run.commit.author_avatar_url is not none %}
                           <img alt="avatar"
-                               src="{{ r.earliest_result.commit.author_avatar_url  }}"
+                               src="{{ result_for_run.commit.author_avatar_url  }}"
                                height="25"
                                style="border-radius: 50%">
                           &nbsp;
                         {% endif %}
-                        {{ r.earliest_result.commit.author_name }}
+                        {{ result_for_run.commit.author_name }}
                       {% else %}
                         n/a
                       {% endif %}
                     </div>
                   </td>
                   <td>
-                    {% if r.earliest_result.commit is not none %}
-                      {% if r.earliest_result.commit.commit_url is not none %}
-                        <code><a href="{{ r.earliest_result.commit.commit_url }}">{{ r.earliest_result.commit.hash[:7] }}</a></code>
+                    {% if result_for_run.commit is not none %}
+                      {% if result_for_run.commit.commit_url is not none %}
+                        <code><a href="{{ result_for_run.commit.commit_url }}">{{ result_for_run.commit.hash[:7] }}</a></code>
                       {% else %}
                         {# is this a valid scenario? when there's a hash, but no url? #}
-                        {{ r.earliest_result.commit.hash[:7] }}
+                        {{ result_for_run.commit.hash[:7] }}
                       {% endif %}
                       <!--NOTE: enable full commit has search while maintaining partial hash display -->
-                      <p style="display:none">{{ r.earliest_result.commit.hash }}</p>
+                      <p style="display:none">{{ result_for_run.commit.hash }}</p>
                     {% else %}
                       n/a
                     {% endif %}
                   </td>
-                  <td>
-                    {% if r.earliest_result.commit is not none %}
-                      {{ r.display_commit_msg }}
-                    {% else %}
-                      n/a
-                    {% endif %}
-                  </td>
+                  <td>{{ result_for_run.ui_commit_short_msg }}</td>
                 </tr>
               {% endfor %}
             </tbody>


### PR DESCRIPTION
This feeds the 'recent runs' listing on the landing page using a 'skip scan' query for efficiency, see #1466.

This patch mainly addresses the heap size / OOM challenges described in #1466: the result of this query (communicated to the web application) is a small number of result rows: `O(10^2)` instead of `O(10^6)`.

The result for this query is also generated rather quickly, which helps address a significant page load time issue (that we have not tracked in its own ticket here).

Cost of this approach (for now, maybe not fundamentally):

- unknown result count per run
- no guarantee about which result represents the run
- unknown "any result failed in this run?"


Future / thoughts:
- Measure: how does the page load time look for Arrow Conbench after this is deployed?
- Think: the method is still not ideal because for I think one DB query per result is emitted for fetching commit data. This will be addressed in future patches.
- The approximate result count per run can be fed from the BMRT cache
- The skip scan query result can be cached with small TTL (ideally with `result.commit` already being populated?)

