### PR TITLE
DB: history fingerprint migration: switch to CTAS

### DIFF
--- a/migrations/versions/9bee3b519bf1_add_history_fingerprint.py
+++ b/migrations/versions/9bee3b519bf1_add_history_fingerprint.py
@@ -7,8 +7,13 @@ Create Date: 2023-08-29 19:33:34.654753
 """
 from datetime import datetime
 
-import sqlalchemy as sa
 from alembic import op
+
+
+def p(msg):
+    # I couldn't get logging to work quickly.
+    print(f"[{datetime.now().isoformat()}] {msg}")
+
 
 # revision identifiers, used by Alembic.
 revision = "9bee3b519bf1"
@@ -18,36 +23,75 @@ depends_on = None
 
 
 def upgrade():
-    print(f"{datetime.now()} adding column")
-    op.add_column(
-        "benchmark_result", sa.Column("history_fingerprint", sa.Text(), nullable=True)
-    )
-
-    print(f"{datetime.now()} backfilling")
+    # This backfill is large and expensive so let's use the "create table as select"
+    # strategy. I validated that the MD5(...) function in a Postgres DB produces the
+    # same result as the python generate_history_fingerprint() function.
+    p("creating temp table")
     op.execute(
         """
-        UPDATE benchmark_result SET history_fingerprint = MD5(
-            benchmark_result.case_id ||
-            benchmark_result.context_id ||
-            hardware.hash ||
-            benchmark_result.commit_repo_url
-        )
-        FROM hardware
-        WHERE benchmark_result.hardware_id = hardware.id
+        CREATE TABLE temp AS
+        SELECT
+            benchmark_result.*,
+            MD5(
+                benchmark_result.case_id ||
+                benchmark_result.context_id ||
+                hardware.hash ||
+                benchmark_result.commit_repo_url
+            ) AS history_fingerprint
+        FROM benchmark_result
+        LEFT JOIN hardware ON benchmark_result.hardware_id = hardware.id
         """
     )
 
-    print(f"{datetime.now()} making non-nullable")
-    op.alter_column("benchmark_result", "history_fingerprint", nullable=False)
+    p("dropping old table")
+    op.execute("DROP TABLE benchmark_result")
 
-    print(f"{datetime.now()} creating index")
-    op.create_index(
-        "benchmark_result_history_fingerprint_index",
-        "benchmark_result",
-        ["history_fingerprint"],
-        unique=False,
-    )
-    print(f"{datetime.now()} done")
+    p("renaming temp table")
+    op.execute("ALTER TABLE temp RENAME TO benchmark_result")
+
+    p("-- making columns non-nullable --")
+    for colname in [
+        "id",
+        "case_id",
+        "info_id",
+        "context_id",
+        "run_id",
+        "run_tags",
+        "commit_repo_url",
+        "hardware_id",
+        "history_fingerprint",
+        "timestamp",
+    ]:
+        p(colname)
+        op.alter_column("benchmark_result", colname, nullable=False)
+
+    p("-- recreating indexes --")
+    for colname in [
+        "batch_id",
+        "case_id",
+        "context_id",
+        "history_fingerprint",
+        "info_id",
+        "run_id",
+        "timestamp",
+    ]:
+        p(colname)
+        op.create_index(
+            f"benchmark_result_{colname}_index", "benchmark_result", [colname]
+        )
+
+    p("-- recreating foreign keys --")
+    for tablename in ["hardware", "commit", "case", "info", "context"]:
+        p(tablename)
+        op.create_foreign_key(
+            None,
+            "benchmark_result",
+            tablename,
+            [f"{tablename}_id"],
+            ["id"],
+        )
+
+    p("done")
 
 
 def downgrade():


### PR DESCRIPTION
The previous migration was taking way too long on the Arrow data. Thanks to @jgehrcke 's advice and helpful reading like https://stackoverflow.com/a/3361903, we'll try switching the migration logic to create a completely new table first.