### PR TITLE
DB: history fingerprint migration: add primary key

### DIFF
--- a/migrations/versions/9bee3b519bf1_add_history_fingerprint.py
+++ b/migrations/versions/9bee3b519bf1_add_history_fingerprint.py
@@ -49,9 +49,11 @@ def upgrade():
     p("renaming temp table")
     op.execute("ALTER TABLE temp RENAME TO benchmark_result")
 
+    p("marking id as primary key")
+    op.execute("ALTER TABLE benchmark_result ADD PRIMARY KEY (id)")
+
     p("-- making columns non-nullable --")
     for colname in [
-        "id",
         "case_id",
         "info_id",
         "context_id",


### PR DESCRIPTION
I forgot to add this because alembic autogenerate doesn't check for it.