### PR TITLE
api/runs/run_id: speed up query

### DIFF
--- a/conbench/api/runs.py
+++ b/conbench/api/runs.py
@@ -167,10 +167,13 @@ def _search_for_baseline_run(
             BenchmarkResult.timestamp >= earliest_commit_timestamp,  # a nice speedup
         )
         .order_by(
-            # Prefer this Run's run_reason
+            # Prefer this Run's run_reason,
             s.desc(BenchmarkResult.run_reason == contender_run_reason),
-            Commit.timestamp.desc(),  # then latest commit,
-            BenchmarkResult.timestamp.desc(),  # then latest BenchmarkResult timestamp
+            # then latest commit,
+            s.desc(Commit.sha != Commit.fork_point_sha),
+            Commit.timestamp.desc(),
+            # then latest BenchmarkResult timestamp
+            BenchmarkResult.timestamp.desc(),
         )
         .limit(1)
     )

--- a/conbench/entities/commit.py
+++ b/conbench/entities/commit.py
@@ -238,6 +238,7 @@ class Commit(Base, EntityMixin):
         # Get default branch commits before/including the fork point
         query = current_session.query(
             Commit.id.label("ancestor_id"),
+            Commit.sha.label("ancestor_hash"),
             Commit.timestamp.label("ancestor_timestamp"),
             s.sql.expression.literal(True, s.Boolean).label("on_default_branch"),
             s.func.concat("1_", Commit.timestamp).label("commit_order"),
@@ -251,6 +252,7 @@ class Commit(Base, EntityMixin):
         if self != fork_point_commit:
             branch_query = current_session.query(
                 Commit.id.label("ancestor_id"),
+                Commit.sha.label("ancestor_hash"),
                 Commit.timestamp.label("ancestor_timestamp"),
                 s.sql.expression.literal(False, s.Boolean).label("on_default_branch"),
                 s.func.concat("2_", Commit.timestamp).label("commit_order"),

--- a/conbench/tests/api/_fixtures.py
+++ b/conbench/tests/api/_fixtures.py
@@ -1,5 +1,5 @@
 import copy
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Tuple
 
 from ...db import _session as dbsession
@@ -268,6 +268,7 @@ def benchmark_result(
     data["run_id"] = run_id if run_id else _uuid()
     data["batch_id"] = batch_id if batch_id else _uuid()
     data["tags"]["name"] = name if name else _uuid()
+    data["timestamp"] = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
 
     if language:
         data["context"]["benchmark_language"] = language
@@ -402,6 +403,7 @@ def gen_fake_data(
     # Now populate a variety of different BenchmarkResults
     benchmark_results: List[BenchmarkResult] = []
     name = _uuid()
+    result_timestamp = datetime(2022, 1, 7)
 
     for data_or_error, commit_sha in [
         # first commit
@@ -431,6 +433,7 @@ def gen_fake_data(
         # some-context commit
         ([20.0, 20.1, 20.2], "sha"),
     ]:
+        result_timestamp += timedelta(seconds=1)
         commit = commits[commit_sha]
         if isinstance(data_or_error, list):
             benchmark_results.append(
@@ -440,7 +443,7 @@ def gen_fake_data(
                     name=name,
                     pull_request=commit.branch == "branch" if commit else False,
                     one_sample_no_mean=one_sample_no_mean,
-                    timestamp=datetime.now(timezone.utc).isoformat(),
+                    timestamp=result_timestamp,
                 )
             )
         else:
@@ -451,7 +454,7 @@ def gen_fake_data(
                     name=name,
                     pull_request=commit.branch == "branch" if commit else False,
                     one_sample_no_mean=one_sample_no_mean,
-                    timestamp=datetime.now(timezone.utc).isoformat(),
+                    timestamp=result_timestamp,
                 )
             )
 
@@ -467,11 +470,13 @@ def gen_fake_data(
         {"reason": "nightly"},
     ]:
         this_name = kwargs.pop("name", name)
+        result_timestamp += timedelta(seconds=1)
         benchmark_results.append(
             benchmark_result(
                 results=[5.1, 5.2, 5.3],
                 commit=commits["66666"],
                 name=this_name,
+                timestamp=result_timestamp,
                 **kwargs,
             )
         )

--- a/conbench/tests/api/test_results.py
+++ b/conbench/tests/api/test_results.py
@@ -401,15 +401,9 @@ class TestBenchmarkList(_asserts.ListEnforcer):
 
     def test_benchmark_list_filter_by_name_with_limit(self, client):
         self.authenticate(client)
-        _fixtures.benchmark_result(
-            name="bbb",
-            timestamp=datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
-        )
+        _fixtures.benchmark_result(name="bbb")
         time.sleep(1)
-        benchmark_result = _fixtures.benchmark_result(
-            name="bbb",
-            timestamp=datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
-        )
+        benchmark_result = _fixtures.benchmark_result(name="bbb")
         _fixtures.benchmark_result(name="ccc")
         response = client.get("/api/benchmarks/?name=bbb&limit=1")
         assert len(response.json) == 1
@@ -427,9 +421,6 @@ class TestBenchmarkList(_asserts.ListEnforcer):
         self.authenticate(client)
         _fixtures.benchmark_result()
         _fixtures.benchmark_result(
-            timestamp=(datetime.utcnow().replace(microsecond=0)).isoformat() + "Z",
-        )
-        _fixtures.benchmark_result(
             timestamp=(
                 datetime.utcnow().replace(microsecond=0) - timedelta(days=2)
             ).isoformat()
@@ -444,9 +435,7 @@ class TestBenchmarkList(_asserts.ListEnforcer):
     def test_benchmark_results_with_days_and_limit(self, client):
         self.authenticate(client)
         _fixtures.benchmark_result()
-        _fixtures.benchmark_result(
-            timestamp=(datetime.utcnow().replace(microsecond=0)).isoformat() + "Z",
-        )
+        _fixtures.benchmark_result()
         _fixtures.benchmark_result(
             timestamp=(
                 datetime.utcnow().replace(microsecond=0) - timedelta(days=2)
@@ -458,10 +447,7 @@ class TestBenchmarkList(_asserts.ListEnforcer):
 
     def test_benchmark_list_filter_by_name_with_daysand_limit(self, client):
         self.authenticate(client)
-        benchmark_result = _fixtures.benchmark_result(
-            name="bbb",
-            timestamp=datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
-        )
+        benchmark_result = _fixtures.benchmark_result(name="bbb")
         _fixtures.benchmark_result(
             name="bbb",
             timestamp=(
@@ -483,10 +469,6 @@ class TestBenchmarkList(_asserts.ListEnforcer):
     def test_benchmark_list_filter_by_run_reason_with_days_and_limit(self, client):
         self.authenticate(client)
         _fixtures.benchmark_result(reason="rolf")
-        _fixtures.benchmark_result(
-            timestamp=(datetime.utcnow().replace(microsecond=0)).isoformat() + "Z",
-            reason="rolf",
-        )
         _fixtures.benchmark_result(
             timestamp=(
                 datetime.utcnow().replace(microsecond=0) - timedelta(days=2)

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -405,15 +405,8 @@ class TestRunList(_asserts.ListEnforcer):
     public = True
 
     def _create(self):
-        # In this test class it's important to supply a timestamp of now() when creating
-        # BenchmarkResults because the list runs endpoint looks at the last 30 days of
-        # BenchmarkResults.
-        _fixtures.benchmark_result(
-            sha=_fixtures.PARENT, timestamp=datetime.now(timezone.utc).isoformat()
-        )
-        benchmark_result = _fixtures.benchmark_result(
-            timestamp=datetime.now(timezone.utc).isoformat()
-        )
+        _fixtures.benchmark_result(sha=_fixtures.PARENT)
+        benchmark_result = _fixtures.benchmark_result()
         return benchmark_result
 
     def test_run_list(self, client):
@@ -446,18 +439,10 @@ class TestRunList(_asserts.ListEnforcer):
         sha1 = _fixtures.CHILD
         sha2 = _fixtures.PARENT
         self.authenticate(client)
-        _fixtures.benchmark_result(
-            sha=_fixtures.PARENT, timestamp=datetime.now(timezone.utc).isoformat()
-        )
-        result_1 = _fixtures.benchmark_result(
-            timestamp=datetime.now(timezone.utc).isoformat()
-        )
-        _fixtures.benchmark_result(
-            sha=_fixtures.CHILD, timestamp=datetime.now(timezone.utc).isoformat()
-        )
-        result_2 = _fixtures.benchmark_result(
-            timestamp=datetime.now(timezone.utc).isoformat()
-        )
+        _fixtures.benchmark_result(sha=_fixtures.PARENT)
+        result_1 = _fixtures.benchmark_result()
+        _fixtures.benchmark_result(sha=_fixtures.CHILD)
+        result_2 = _fixtures.benchmark_result()
         response = client.get(f"/api/runs/?sha={sha1},{sha2}")
 
         self.assert_200_ok(response, contains=_expected_entity(result_1))
@@ -581,7 +566,7 @@ def test_get_candidate_baseline_runs():
             },
             "latest_default": {
                 "error": None,
-                "baseline_run_id": run_ids[9],
+                "baseline_run_id": run_ids[15],
                 "commits_skipped": [],
             },
         },
@@ -599,7 +584,7 @@ def test_get_candidate_baseline_runs():
             },
             "latest_default": {
                 "error": None,
-                "baseline_run_id": run_ids[9],
+                "baseline_run_id": run_ids[15],
                 "commits_skipped": [],
             },
         },
@@ -617,7 +602,7 @@ def test_get_candidate_baseline_runs():
             },
             "latest_default": {
                 "error": None,
-                "baseline_run_id": run_ids[9],
+                "baseline_run_id": run_ids[15],
                 "commits_skipped": [],
             },
         },
@@ -649,7 +634,7 @@ def test_get_candidate_baseline_runs():
             },
             "latest_default": {
                 "error": None,
-                "baseline_run_id": run_ids[9],
+                "baseline_run_id": run_ids[15],
                 "commits_skipped": [],
             },
         },
@@ -667,7 +652,7 @@ def test_get_candidate_baseline_runs():
             },
             "latest_default": {
                 "error": None,
-                "baseline_run_id": run_ids[9],
+                "baseline_run_id": run_ids[15],
                 "commits_skipped": [],
             },
         },

--- a/conbench/tests/api/test_runs.py
+++ b/conbench/tests/api/test_runs.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime, timezone
 
 from conbench.util import tznaive_dt_to_aware_iso8601_for_api
 

--- a/conbench/tests/app/test_runs.py
+++ b/conbench/tests/app/test_runs.py
@@ -118,7 +118,7 @@ class TestRunGet(_asserts.GetEnforcer):
         self._assert_baseline_link(
             response.text,
             "latest_default",
-            # earliest benchmark result on the latest default-branch commit
-            benchmark_results[9].run_id,
+            # latest benchmark result on the latest default-branch commit
+            benchmark_results[15].run_id,
             benchmark_results[3].run_id,
         )


### PR DESCRIPTION
This PR is a ~small~ internal change to speed up the query executed to find baseline runs for a given contender run.

It takes advantage of the new history fingerprint.