### PR TITLE
landing page: show result count again, cache _get_recent_runs() result briefly

### DIFF
--- a/conbench/app/index.py
+++ b/conbench/app/index.py
@@ -99,6 +99,87 @@ def repo_url_to_display_name(url: Optional[str]) -> str:
     return p.strip("/")
 
 
+# Cache the return value for the last few minutes minutes. See docstring for
+# discussion. In local dev with only few results / runs in the database this
+# cache reduces landing page response generation time from 300 ms to 10 ms.
+# This cache applies to all request-serving threads in this gunicorn worker
+# process (each single-process container replica maintains its own cache).
+@lru_cache_with_ttl(ttl=300)
+def _get_recent_runs() -> List["RunForDisplay"]:
+    """
+    As of the time of writing, the UI landing page wants to show the "N most
+    recent CI runs". Since removal of the Run table we still want retain that.
+
+    For now, we do this by getting (any) one result for all of the N most
+    recently seen run IDs (each CI run may be associated with O(10**3) results;
+    it is therefore not feasible to fetch all last-bigN-run-related
+    BenchmarkResult objects each time we render the landing page).
+
+    Ideally, with the "one result row per run" approach, a single small-ish DB
+    query response yields _all_ data necessary to display information about the
+    N most recently seen CI runs. However, there are limitations to this
+    approach.
+
+    -  The one result-per-run that we get from the DB is not necessarily the
+       earliest result. It may be, as of the current implementation, but this
+       isn't guaranteed for now. The meaning of "time" for a Run is a bit
+       ambiguous (albeit, still useful). Assumption: around the time where this
+       one result was submitted, all other results for the same run were
+       submitted, too.
+
+    -  As of the DB query used we cannot answer if "any result in this run
+       failed?". That is, the notion of "a failed run" is not currently on the
+       UI landing page anymore. We discussed that this is okay; an expected
+       outcome as of not representing each CI run in its own DB table anymore.
+
+    -  Letting the DB count results-per-run easily is too much work. Also see
+       https://github.com/conbench/conbench/issues/977. However, the BMRT cache
+       (built for other purpose) knows a per-run result count estimate for many
+       of the most recent runs. Feed that per-run result count from there. For
+       the last few runs (or all of them; depends on usage pattern) the data is
+       is mostly a small number of minutes out of date. At the cache boundary,
+       the per-run count is permanently wrong (single run partially represented
+       in BMRT cache, true for probably just one of many runs). All that is
+       fine, the UI does not claim real time truth in that regard. In the vast
+       majority of the cases we want a ~correct result count per run only for
+       the last ~10 runs, and that is provided by this approach.
+
+    -  The result count from the BMRT cache is built as of today using only
+       non-errored results.
+
+    -  At the time of writing, per-result hardware and commit information still
+       requires reaching out to other DB tables. Attribute lookups result in
+       O(N) SELECT statements being issued. It makes therefore sense to cache
+       the return value of this function for a small number of minutes.
+    """
+
+    # Get one result per run from DB. Expect results to be sorted in time, most
+    # recent first.
+    bmrs = fetch_one_result_per_n_recent_runs()
+
+    runs_for_display: List[RunForDisplay] = []
+
+    for bmr in bmrs:
+        result_count = "n/a"
+        if bmr.run_id in bmrt_cache["by_run_id"]:
+            result_count = str(len(bmrt_cache["by_run_id"]))
+
+        runs_for_display.append(
+            RunForDisplay(
+                run_id=bmr.run_id,
+                time_for_table=bmr.timestamp.strftime("%Y-%m-%d %H:%M:%S UTC"),
+                repo_url=bmr.commit_repo_url,
+                commit_message_short=bmr.ui_commit_short_msg,
+                result_count=result_count,
+                commit=bmr.commit,  # this may emit a DB query
+                run_reason=bmr.run_reason if bmr.run_reason else "n/a",
+                hardware_name=bmr.hardware.name,  # this may emit a DB query
+            )
+        )
+
+    return runs_for_display
+
+
 @dataclass
 class RunForDisplay:
     # Note(JP). dataclass tailored for displaying per-run information in the

--- a/conbench/app/index.py
+++ b/conbench/app/index.py
@@ -99,6 +99,23 @@ def repo_url_to_display_name(url: Optional[str]) -> str:
     return p.strip("/")
 
 
+@dataclass
+class RunForDisplay:
+    # Note(JP). dataclass tailored for displaying per-run information in the
+    # UI. Note that for VSCode support for Python variable types and
+    # auto-completion in a jinja2 templates is not yet there:
+    # https://github.com/microsoft/pylance-release/discussions/4090
+    run_id: str
+    time_for_table: str
+    commit_message_short: str
+    repo_url: str
+    # result count is str because it may also be "n/a"
+    result_count: str
+    hardware_name: str
+    run_reason: str
+    commit: Optional[Commit]
+
+
 view = Index.as_view("index")
 rule("/", view_func=view, methods=["GET"])
 rule("/index/", view_func=view, methods=["GET"])

--- a/conbench/app/index.py
+++ b/conbench/app/index.py
@@ -1,15 +1,20 @@
 import logging
 from collections import defaultdict
+from dataclasses import dataclass
 from typing import Dict, List, Optional
 from urllib.parse import urlparse
 
 import flask
 
+from conbench.bmrt import bmrt_cache
+from conbench.cachetools import lru_cache_with_ttl
+
 from ..app import rule
 from ..app._endpoint import AppEndpoint, authorize_or_terminate
 from ..app.results import RunMixin
 from ..config import Config
-from ..entities.benchmark_result import BenchmarkResult, one_result_per_n_recent_runs
+from ..entities.benchmark_result import fetch_one_result_per_n_recent_runs
+from ..entities.commit import Commit
 
 log = logging.getLogger(__name__)
 
@@ -27,12 +32,12 @@ def _cloud_lb_health_check_shortcut() -> Optional[flask.Response]:
 
 
 class Index(AppEndpoint, RunMixin):
-    def page(self, reponame_result_map_sorted):
+    def page(self, reponame_runs_map_sorted):
         return self.render_template(
             "index.html",
             application=Config.APPLICATION_NAME,
             title="Home",
-            reponame_result_map_sorted=reponame_result_map_sorted,
+            reponame_runs_map_sorted=reponame_runs_map_sorted,
             # Note(JP): search_value is not consumed in template
             # search_value=f.request.args.get("search"),
         )
@@ -43,29 +48,22 @@ class Index(AppEndpoint, RunMixin):
         if resp is not None:
             return resp
 
-        # Get (any?) one result for all of the N most recently seen run IDs.
-        # This is not necessarily the earliest result. It may be, as of the
-        # current implementation, but this isn't guaranteed for now. Also, as
-        # of the DB query used we cannot answer if "any result in this run
-        # failed?", i.e. the notion of "a failed run" is not on the UI landing
-        # page anymore.
-        bmrs = one_result_per_n_recent_runs()
+        # bmrs = fetch_one_result_per_n_recent_runs()
+
+        runs_for_display = _get_recent_runs()
 
         # Note(JP): group one-result-per-run by associated repository value.
-        reponame_result_map: Dict[str, List[BenchmarkResult]] = defaultdict(list)
+        reponame_rd_map: Dict[str, List[RunForDisplay]] = defaultdict(list)
 
-        for r in bmrs:
-            rname = repo_url_to_display_name(r.commit_repo_url)
-            reponame_result_map[rname].append(r)
+        for rd in runs_for_display:
+            reponame = repo_url_to_display_name(rd.repo_url)
+            reponame_rd_map[reponame].append(rd)
 
         # A quick decision for now, not set in stone: get a stable sort order
         # of repositories the way they are listed on that page; do this by
         # sorting alphabetically.
-        reponame_result_map_sorted = dict(sorted(reponame_result_map.items()))
-
-        # log.info(reponame_result_map_sorted)
-
-        return self.page(reponame_result_map_sorted)
+        reponame_runs_map_sorted = dict(sorted(reponame_rd_map.items()))
+        return self.page(reponame_runs_map_sorted)
 
 
 def repo_url_to_display_name(url: Optional[str]) -> str:

--- a/conbench/app/index.py
+++ b/conbench/app/index.py
@@ -48,8 +48,11 @@ class Index(AppEndpoint, RunMixin):
         if resp is not None:
             return resp
 
-        # bmrs = fetch_one_result_per_n_recent_runs()
-
+        # _get_recent_runs() uses a return value cache base don the stdlib LRU
+        # cache module. Clear that cache during testing; the lru_cache
+        # decorator has added a `cache_clear()` method to the func object.
+        if Config.TESTING:
+            _get_recent_runs.cache_clear()
         runs_for_display = _get_recent_runs()
 
         # Note(JP): group one-result-per-run by associated repository value.

--- a/conbench/cachetools.py
+++ b/conbench/cachetools.py
@@ -2,9 +2,13 @@ import time
 from functools import lru_cache, wraps
 
 
-def lru_cache_with_ttl(maxsize=128, typed=False, ttl=60):
+def lru_cache_with_ttl(maxsize=None, typed=False, ttl=60):
     """Stdlib LRU cache with a notion of expiration time. Inspired by
     https://stackoverflow.com/a/71634221 and others.
+
+    The maxsize=None default arg makes this (by default) behave like
+    functools.cache instead of functools.lru_cache (this is a little cleaner to
+    use for caching the return value of functions that have no arguments).
     """
 
     class Result:

--- a/conbench/cachetools.py
+++ b/conbench/cachetools.py
@@ -1,0 +1,35 @@
+import time
+from functools import lru_cache, wraps
+
+
+def lru_cache_with_ttl(maxsize=128, typed=False, ttl=60):
+    """Stdlib LRU cache with a notion of expiration time. Inspired by
+    https://stackoverflow.com/a/71634221 and others.
+    """
+
+    class Result:
+        __slots__ = ("value", "deadline")
+
+        def __init__(self, value, deadline):
+            self.value = value
+            self.deadline = deadline
+
+    def decorator(func):
+        @lru_cache(maxsize=maxsize, typed=typed)
+        def cached_func(*args, **kwargs):
+            value = func(*args, **kwargs)
+            deadline = time.monotonic() + ttl
+            return Result(value, deadline)
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            result = cached_func(*args, **kwargs)
+            if result.deadline < time.monotonic():
+                result.value = func(*args, **kwargs)
+                result.deadline = time.monotonic() + ttl
+            return result.value
+
+        wrapper.cache_clear = cached_func.cache_clear
+        return wrapper
+
+    return decorator

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -84,6 +84,10 @@ class BenchmarkResult(Base, EntityMixin):
     commit: Mapped[Optional[Commit]] = relationship("Commit", lazy="joined")
 
     # Non-empty URL to the repository without trailing slash.
+    # Note(JP): maybe it is easier to think of this as just "repo_url" because
+    # while it is not required that each result is associated with a particular
+    # commit, but instead it is required to be associated with a (one!) code
+    # repository as identified by its user-given repository URL.
     commit_repo_url: Mapped[str] = NotNull(s.Text)
 
     hardware_id: Mapped[str] = NotNull(s.String(50), s.ForeignKey("hardware.id"))

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -928,10 +928,11 @@ def validate_and_augment_result_tags(userres: Any):
             )
 
 
-# Note(JP): This is a special "skip scan" query tailored for current
+# Note(JP): This tries to be a special "skip scan" query tailored for current
 # implementation details (PostgreSQL 15, current DB schema). It is designed to
-# quickly obtain one benchmark result row from results table, each result
-# having a unique run_id set. See
+# quickly and efficiently obtain one benchmark result row from results table,
+# with each result having a unique run_id set, and results overall being sorted
+# by time (most recent first). For more detail, see
 # https://github.com/conbench/conbench/issues/1466 for more details and
 # background.
 _RECENT_RUNS_QUERY = """
@@ -957,7 +958,7 @@ LIMIT 500;
 """
 
 
-def one_result_per_n_recent_runs() -> List[BenchmarkResult]:
+def fetch_one_result_per_n_recent_runs() -> List[BenchmarkResult]:
     from sqlalchemy.sql import text
 
     bmrs = (
@@ -966,8 +967,9 @@ def one_result_per_n_recent_runs() -> List[BenchmarkResult]:
         .all()
     )
 
-    log.info("found %s results", len(bmrs))
-
+    # Note(JP): as of the time of writing we're still having to reach out to
+    # the database to get commit information: one query per result, I think.
+    # That SELECT query (one per result) will often refer to the same c
     return bmrs
 
 

--- a/conbench/templates/index.html
+++ b/conbench/templates/index.html
@@ -2,7 +2,7 @@
 {% block app_content %}
   <h1>CI runs</h1>
   <div class="mt-3">
-    {% for reponame, results_for_runs in reponame_result_map_sorted.items() %}
+    {% for reponame, runs in reponame_runs_map_sorted.items() %}
       <div class="row mb-5">
         <h4>
           Recent  CI runs for <strong>{{ reponame }}</strong>
@@ -41,55 +41,55 @@
               </tr>
             </thead>
             <tbody class="table-group-divider">
-              {% for result_for_run in results_for_runs %}
+              {% for run in runs %}
                 <tr class="no-border">
                   <td>
-                    <code><a href="{{ url_for('app.run', run_id=result_for_run.run_id) }}">{{ result_for_run.ui_time_started_at }}</a></code>
+                    <code><a href="{{ url_for('app.run', run_id=run.run_id) }}">{{ run.time_for_table }}</a></code>
                   </td>
                   <!-- no efficient lookup built so far; can populate this from BMRT cache if we want to -->
-                  <td></td>
+                  <td>{{ run.result_count }}</td>
                   <td>
-                    {% if result_for_run.run_reason %}
-                      <div class="table-entry">{{ result_for_run.run_reason }}</div>
+                    {% if run.run_reason %}
+                      <div class="table-entry">{{ run.run_reason }}</div>
                     {% else %}
                       <div class="table-entry"></div>
                     {% endif %}
                   </td>
                   <td>
                     <span class="table-entry text-truncate d-inline-block"
-                          style="max-width: 140px">{{ result_for_run.hardware.name }}</span>
+                          style="max-width: 140px">{{ run.hardware_name }}</span>
                   </td>
                   <td>
                     <div class="table-entry">
-                      {% if result_for_run.commit is not none %}
-                        {% if result_for_run.commit.author_avatar_url is not none %}
+                      {% if run.commit is not none %}
+                        {% if run.commit.author_avatar_url is not none %}
                           <img alt="avatar"
-                               src="{{ result_for_run.commit.author_avatar_url  }}"
+                               src="{{ run.commit.author_avatar_url  }}"
                                height="25"
                                style="border-radius: 50%">
                           &nbsp;
                         {% endif %}
-                        {{ result_for_run.commit.author_name }}
+                        {{ run.commit.author_name }}
                       {% else %}
                         n/a
                       {% endif %}
                     </div>
                   </td>
                   <td>
-                    {% if result_for_run.commit is not none %}
-                      {% if result_for_run.commit.commit_url is not none %}
-                        <code><a href="{{ result_for_run.commit.commit_url }}">{{ result_for_run.commit.hash[:7] }}</a></code>
+                    {% if run.commit is not none %}
+                      {% if run.commit.commit_url is not none %}
+                        <code><a href="{{ run.commit.commit_url }}">{{ run.commit.hash[:7] }}</a></code>
                       {% else %}
                         {# is this a valid scenario? when there's a hash, but no url? #}
-                        {{ result_for_run.commit.hash[:7] }}
+                        {{ run.commit.hash[:7] }}
                       {% endif %}
                       <!--NOTE: enable full commit has search while maintaining partial hash display -->
-                      <p style="display:none">{{ result_for_run.commit.hash }}</p>
+                      <p style="display:none">{{ run.commit.hash }}</p>
                     {% else %}
                       n/a
                     {% endif %}
                   </td>
-                  <td>{{ result_for_run.ui_commit_short_msg }}</td>
+                  <td>{{ run.commit_message_short }}</td>
                 </tr>
               {% endfor %}
             </tbody>


### PR DESCRIPTION
For #1466.

This patch
- Makes the landing page show a per-run result count again (see code comments for caveats).
- Re-introduces a `RunForDisplay` object.
- Adds a short-lived cache for a  `RunForDisplay` collection to shave off O(N) SELECT queries for commit/hardware information. That cache is based on stdlib [`lru_cache`](https://docs.python.org/3/library/functools.html#functools.lru_cache) with the additional notion of an expiration time.