### PR TITLE
ci: address chromedriver/selenium issue #1472

### DIFF
--- a/ci/screenshot.Dockerfile
+++ b/ci/screenshot.Dockerfile
@@ -12,16 +12,16 @@ RUN apt-get update && apt-get install -y -q --no-install-recommends \
 RUN pip install pip --upgrade
 RUN pip install selenium webdriver_manager && pip cache purge
 
-# Use static chromedriver version for now until webdriver manager is through
-# the hoops. Also see https://github.com/conbench/conbench/issues/1364
 # Install chrome driver manager into cache.
 # This will then lead to e.g.
 #    Driver [/root/.wdm/drivers/chromedriver/linux64/108.0.5359/chromedriver] found in cache
 # during execution.
-#RUN python -c "from webdriver_manager.chrome import ChromeDriverManager; ChromeDriverManager().install()"
-RUN curl -fsSL -o /chromedriver.zip https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/115.0.5790.98/linux64/chromedriver-linux64.zip
-RUN unzip /chromedriver.zip
-RUN cd / && ls
+RUN python -c "from webdriver_manager.chrome import ChromeDriverManager; ChromeDriverManager().install()"
+# Temporarily used, maybe still useful in future:
+# https://github.com/conbench/conbench/issues/1364
+# RUN curl -fsSL -o /chromedriver.zip https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/115.0.5790.98/linux64/chromedriver-linux64.zip
+# RUN unzip /chromedriver.zip
+# RUN cd / && ls
 
 
 COPY screenshot.py .

--- a/ci/screenshot.py
+++ b/ci/screenshot.py
@@ -33,7 +33,7 @@ from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.by import By
 
-# from webdriver_manager.chrome import ChromeDriverManager
+from webdriver_manager.chrome import ChromeDriverManager
 
 # from selenium.webdriver.support.ui import WebDriverWait
 # from selenium.webdriver.common.by import By
@@ -245,11 +245,13 @@ def _get_driver():
     # A temporary fix for our CI (and linux devs :-) until
     # https://github.com/SergeyPirogov/webdriver_manager/issues/536 is resolved
     # upstream. Also see https://github.com/conbench/conbench/issues/1364.
-    # driver = webdriver.Chrome(service=Service(cdm.install()), options=wd_options)
     driver = webdriver.Chrome(
-        service=Service(executable_path="/chromedriver-linux64/chromedriver"),
-        options=wd_options,
+        service=Service(ChromeDriverManager().install()), options=wd_options
     )
+    # driver = webdriver.Chrome(
+    #    service=Service(executable_path="/chromedriver-linux64/chromedriver"),
+    #    options=wd_options,
+    # )
 
     # The waiter is only optionally used later.
     # waiter = WebDriverWait(driver, 30)

--- a/ci/screenshot.py
+++ b/ci/screenshot.py
@@ -32,7 +32,6 @@ from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.by import By
-
 from webdriver_manager.chrome import ChromeDriverManager
 
 # from selenium.webdriver.support.ui import WebDriverWait


### PR DESCRIPTION
For https://github.com/conbench/conbench/issues/1472. Tested locally:

```
$ cd ci/
$ docker build --no-cache  --progress=plain . -t conbench-screenshot -f screenshot.Dockerfile
...
$ docker run --net=host -v $(pwd)/ci-artifacts:/artifacts conbench-screenshot python screenshot.py http://rofl.com /artifacts fron
...
230913-13:53:05.620 WDM INFO: ====== WebDriver manager ======
230913-13:53:05.820 WDM INFO: Get LATEST chromedriver version for google-chrome
230913-13:53:05.820 WDM INFO: Get LATEST chromedriver version for google-chrome
230913-13:53:05.820 WDM INFO: There is no [linux64] chromedriver "117.0.5938.62" for browser google-chrome "117.0.5938.62" in cache
230913-13:53:05.820 WDM INFO: Get LATEST chromedriver version for google-chrome
230913-13:53:05.956 WDM INFO: WebDriver version 117.0.5938.62 selected
230913-13:53:05.957 WDM INFO: Modern chrome version https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/117.0.5938.62/linux64/chromedriver-linux64.zip
230913-13:53:05.958 WDM INFO: About to download new driver from https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/117.0.5938.62/linux64/chromedriver-linux64.zip
230913-13:53:06.094 WDM INFO: Driver downloading response is 200
...
```
Does not seem to use the (in-image) cached driver version, but works.