### PR TITLE
api/compare/runs: speed up

### DIFF
--- a/conbench/api/compare.py
+++ b/conbench/api/compare.py
@@ -426,6 +426,8 @@ class CompareRunsAPI(ApiEndpoint):
         """Get all benchmark results for a run. Abort if the run doesn't exist or if
         there are no results for the run.
         """
+        # TODO: fairly slow; e.g. 3 seconds for 3500 results. Maybe we select only the
+        # columns we need. Today it's joining to case, context, hardware, and commit
         result = current_session.scalars(
             s.select(BenchmarkResult).where(BenchmarkResult.run_id == run_id)
         ).all()

--- a/conbench/api/runs.py
+++ b/conbench/api/runs.py
@@ -123,10 +123,9 @@ def _search_for_baseline_run(
     """Search for and return information about a baseline run of a contender run, where
     the baseline run:
 
-    - is on the given baseline_commit, or in its git ancestry (up to
-        ``commit_limit`` commits ago)
-    - matches the contender run's hardware checksum
-    - has a BenchmarkResult with the case_id/context_id of any of the contender
+    - is on the given baseline_commit (but not the same run), or in its git ancestry (up
+        to ``commit_limit`` commits ago)
+    - has a BenchmarkResult with the history fingerprint of any of the contender
         run's BenchmarkResults
 
     Always returns a _CandidateBaselineSearchResult, and if there are no matches for

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -1144,6 +1144,9 @@ s.Index(
     "benchmark_result_history_fingerprint_index", BenchmarkResult.history_fingerprint
 )
 
+# History queries look for specific commit_ids
+s.Index("benchmark_result_commit_id_index", BenchmarkResult.commit_id)
+
 
 class _Serializer(EntitySerializer):
     def _dump(self, benchmark_result):

--- a/migrations/versions/9bee3b519bf1_add_history_fingerprint.py
+++ b/migrations/versions/9bee3b519bf1_add_history_fingerprint.py
@@ -76,6 +76,7 @@ def upgrade():
         "info_id",
         "run_id",
         "timestamp",
+        "commit_id",
     ]:
         p(colname)
         op.create_index(


### PR DESCRIPTION
This PR is an internal change to speed up the compare endpoint by simplifying the query used to get historic results for the lookback z-score calculation.

I'm using this to test:
https://conbench.ursa.dev/api/compare/runs/5f3caa45241e469db3fb9f791cf6670e...f7fcdc05191c4cc4892a761f2208f7ea/

which has about 3500 results per run, each having a different history fingerprint, and therefore needs to pull about 350K results to do the z-score calculations (with a lookback of 100 commits). 

- On the current Arrow deployment (before we removed the run table), assuming no query timeout, this call takes about 75 seconds. 
- On the current head of `main` on staging with Arrow data, it takes about 210 seconds. 
- After this PR, it takes about 30 seconds. 

That's still long, and I have an idea for a user-facing change to speed it up (pagination), but this is drastically better than this endpoint has been since #636 in February.