### PR TITLE
landing page: fetch less runs (more reasonable load time on cache miss)

### DIFF
--- a/conbench/app/index.py
+++ b/conbench/app/index.py
@@ -156,7 +156,7 @@ def _get_recent_runs() -> List["RunForDisplay"]:
 
     # Get one result per run from DB. Expect results to be sorted in time, most
     # recent first.
-    bmrs = fetch_one_result_per_n_recent_runs()
+    bmrs = fetch_one_result_per_each_of_n_recent_runs()
 
     runs_for_display: List[RunForDisplay] = []
 

--- a/conbench/app/index.py
+++ b/conbench/app/index.py
@@ -13,7 +13,7 @@ from ..app import rule
 from ..app._endpoint import AppEndpoint, authorize_or_terminate
 from ..app.results import RunMixin
 from ..config import Config
-from ..entities.benchmark_result import fetch_one_result_per_n_recent_runs
+from ..entities.benchmark_result import fetch_one_result_per_each_of_n_recent_runs
 from ..entities.commit import Commit
 
 log = logging.getLogger(__name__)

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -939,7 +939,7 @@ def validate_and_augment_result_tags(userres: Any):
 # by time (most recent first). For more detail, see
 # https://github.com/conbench/conbench/issues/1466 for more details and
 # background.
-_RECENT_RUNS_QUERY = """
+_RECENT_RUNS_QUERY_TEMPL = """
 WITH RECURSIVE t AS (
    (
       SELECT *
@@ -958,16 +958,16 @@ WITH RECURSIVE t AS (
    )
 SELECT * FROM t WHERE run_id IS NOT NULL
 ORDER BY timestamp desc
-LIMIT 500;
+LIMIT {limit};
 """
 
 
-def fetch_one_result_per_n_recent_runs() -> List[BenchmarkResult]:
+def fetch_one_result_per_each_of_n_recent_runs(n: int = 250) -> List[BenchmarkResult]:
     from sqlalchemy.sql import text
 
     bmrs = (
         current_session.query(BenchmarkResult)
-        .from_statement(text(_RECENT_RUNS_QUERY))
+        .from_statement(text(_RECENT_RUNS_QUERY_TEMPL.format(limit=n)))
         .all()
     )
 


### PR DESCRIPTION
This patch

- does a rename from `fetch_one_result_per_n_recent_runs()` to `fetch_one_result_per_each_of_n_recent_runs()` which is logically more expressive/correct
- adds the `n` parameter to the function
- sets the default to 250 (previously: 500)