### PR TITLE
benchalerts: skip integration tests failing due to #1478

### DIFF
--- a/benchalerts/tests/integration_tests/test_alert_pipeline.py
+++ b/benchalerts/tests/integration_tests/test_alert_pipeline.py
@@ -27,6 +27,7 @@ def test_alert_pipeline(monkeypatch: pytest.MonkeyPatch, github_auth: str):
     """While this test is running, you can watch
     https://github.com/conbench/benchalerts/pull/5 to see the statuses change!
     """
+    pytest.skip("https://github.com/conbench/conbench/issues/1478 causes this to fail")
     test_status_repo = "conbench/benchalerts"
     test_status_commit = "f6e70aeb29ce07c40eed0c0175e9dced488ed6ee"
 

--- a/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
+++ b/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
@@ -56,6 +56,7 @@ def test_GetConbenchZComparisonStep(
     commit_hash: str,
     expected_len: int,
 ):
+    pytest.skip("https://github.com/conbench/conbench/issues/1478 causes this to fail")
     if "ursa" in conbench_url:
         pytest.skip(
             "https://github.com/conbench/conbench/issues/745 means timeouts cause this to fail"


### PR DESCRIPTION
We will come back and unskip these once #1478 is fixed.