### PR TITLE
benchalerts: re-enable integration tests

### DIFF
--- a/benchalerts/tests/integration_tests/test_alert_pipeline.py
+++ b/benchalerts/tests/integration_tests/test_alert_pipeline.py
@@ -27,7 +27,6 @@ def test_alert_pipeline(monkeypatch: pytest.MonkeyPatch, github_auth: str):
     """While this test is running, you can watch
     https://github.com/conbench/benchalerts/pull/5 to see the statuses change!
     """
-    pytest.skip("https://github.com/conbench/conbench/issues/1478 causes this to fail")
     test_status_repo = "conbench/benchalerts"
     test_status_commit = "f6e70aeb29ce07c40eed0c0175e9dced488ed6ee"
 
@@ -92,7 +91,7 @@ def test_alert_pipeline(monkeypatch: pytest.MonkeyPatch, github_auth: str):
 
 There was 1 benchmark result indicating a performance regression:
 
-- Commit Run on `GitHub-runner-8-core` at [2023-02-28 18:08:51Z](https://velox-conbench.voltrondata.run/compare/runs/GHA-4286800623-1...GHA-4296026775-1/)
+- Commit Run on `GitHub-runner-8-core` at [2023-02-28 18:08:47Z](https://velox-conbench.voltrondata.run/compare/runs/GHA-4286800623-1...GHA-4296026775-1/)
   - [`flatMap` (C++) with source=cpp-micro, suite=velox_benchmark_basic_vector_fuzzer](https://velox-conbench.voltrondata.run/compare/benchmarks/a128eb19cc9442409148c91f7fa18cdf...ff7a1a86df5a4d56b6dbfb006c13c638)
 
 The [full Conbench report](https://github.com/conbench/benchalerts/runs/RUN_ID) has more details."""

--- a/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
+++ b/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
@@ -58,7 +58,7 @@ def test_GetConbenchZComparisonStep(
     expected_len: int,
 ):
     if "ursa" in conbench_url and os.getenv("CI"):
-        pytest.skip("This currently takes a really long time, so skip in CI")
+        pytest.skip("This currently takes a long time due to #745, so skip in CI")
     monkeypatch.setenv("CONBENCH_URL", conbench_url)
     step = GetConbenchZComparisonStep(
         commit_hash=commit_hash, baseline_run_type=BaselineRunCandidates.parent

--- a/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
+++ b/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+
 import pytest
 
 from benchalerts.pipeline_steps.conbench import (

--- a/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
+++ b/benchalerts/tests/integration_tests/test_pipeline_steps/test_conbench.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import pytest
 
 from benchalerts.pipeline_steps.conbench import (
@@ -56,11 +57,8 @@ def test_GetConbenchZComparisonStep(
     commit_hash: str,
     expected_len: int,
 ):
-    pytest.skip("https://github.com/conbench/conbench/issues/1478 causes this to fail")
-    if "ursa" in conbench_url:
-        pytest.skip(
-            "https://github.com/conbench/conbench/issues/745 means timeouts cause this to fail"
-        )
+    if "ursa" in conbench_url and os.getenv("CI"):
+        pytest.skip("This currently takes a really long time, so skip in CI")
     monkeypatch.setenv("CONBENCH_URL", conbench_url)
     step = GetConbenchZComparisonStep(
         commit_hash=commit_hash, baseline_run_type=BaselineRunCandidates.parent


### PR DESCRIPTION
Since fixes for #1478 and #745 are deployed to our servers, we can re-enable these integration (smoke?) tests. Fixes #748.