### PR TITLE
ci: kube-prom: jb install from local dir (respect pyrra version pin), bump to kube-prometheus 0.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -311,10 +311,10 @@ set-build-info:
 .PHONY: jsonnet-kube-prom-manifests
 jsonnet-kube-prom-manifests:
 	mkdir -p _kpbuild && cd _kpbuild  && mkdir -p cb-kube-prometheus
-	cd _kpbuild/cb-kube-prometheus && echo '{"version": 1, "dependencies": [], "legacyImports": true}' > jsonnetfile.json
+	cd _kpbuild/cb-kube-prometheus && git clone https://github.com/prometheus-operator/kube-prometheus . &&	git checkout 7fafc4cadc1
 	cd _kpbuild/cb-kube-prometheus && \
 		time docker run --rm -v $$(pwd):$$(pwd) --workdir $$(pwd) quay.io/coreos/jsonnet-ci \
-			sh -c 'jb install github.com/prometheus-operator/kube-prometheus/jsonnet/kube-prometheus@d3889807798d && chmod -R 777 *'
+			sh -c 'jb install && chmod -R 777 *'
 	cd _kpbuild/cb-kube-prometheus && /bin/ls -ahl
 	cp k8s/kube-prometheus/conbench-flavor.jsonnet _kpbuild/cb-kube-prometheus
 	cp k8s/kube-prometheus/conbench-grafana-dashboard.json _kpbuild/cb-kube-prometheus
@@ -353,7 +353,7 @@ jsonnet-kube-prom-manifests:
 		fi
 	cat _kpbuild/cb-kube-prometheus/conbench-flavor.jsonnet
 	cd _kpbuild/cb-kube-prometheus && \
-		wget https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/d3889807798d/build.sh -O build.sh
+		wget https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/7fafc4cadc1/build.sh -O build.sh
 	cd _kpbuild/cb-kube-prometheus && \
 		time docker run  --rm -v $$(pwd):$$(pwd) --workdir $$(pwd) quay.io/coreos/jsonnet-ci \
 			sh -c 'bash build.sh conbench-flavor.jsonnet && chmod -R 777 *'


### PR DESCRIPTION
This is to resolve #1493. High-level root cause is a typical moving target problem triggered by the [pyrra 0.7 release from about one day ago](https://github.com/pyrra-dev/pyrra/commit/f2052cce0c848bb8c4c4d5d964a97b5038237487). Note that kube-prometheus tries to version-pin the precise version of pyrra to be used in the build. But that version pin does not seem to apply using the installation method we have picked so far (following docs). I have reported that via https://github.com/prometheus-operator/kube-prometheus/issues/2224 and also documented my initial findings over there.

This patch here makes use of [this finding](https://github.com/prometheus-operator/kube-prometheus/issues/2224#issuecomment-1737247869).

Note that while doing this I have also taken liberty to bump to the kube-prometheus 0.13 release. Let's see if this builds fine.
