### PR TITLE
conbenchlegacy: fix moving target dep

### DIFF
--- a/legacy/requirements-dev.txt
+++ b/legacy/requirements-dev.txt
@@ -1,3 +1,5 @@
 conbench[server]
 Flask==2.2.3
 pytest>=7.0.0
+# Flask 2.2.3 isn't compatible with werkzeug >= 3
+werkzeug<3


### PR DESCRIPTION
Fixes #1497. `werkzeug 3.0.0` came out recently and breaks Flask 2.2.3, which is used in our test suite for `conbenchlegacy`.