### PR TITLE
api/benchmark-results: speed up

### DIFF
--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -1135,8 +1135,7 @@ s.Index("benchmark_result_batch_id_index", BenchmarkResult.batch_id)
 s.Index("benchmark_result_info_id_index", BenchmarkResult.info_id)
 s.Index("benchmark_result_context_id_index", BenchmarkResult.context_id)
 
-# We order by benchmark_result.timestamp in /api/benchmarks/ -- that wants
-# and index!
+# We order by benchmark_result.timestamp during many queries
 s.Index("benchmark_result_timestamp_index", BenchmarkResult.timestamp)
 
 # An important index. "Give me all comparable results" is a very common query.
@@ -1146,6 +1145,20 @@ s.Index(
 
 # History queries look for specific commit_ids
 s.Index("benchmark_result_commit_id_index", BenchmarkResult.commit_id)
+
+# These indexes are important for how /api/benchmark-results/ accesses the DB for
+# pagination.
+s.Index(
+    "benchmark_result_id_idx",
+    BenchmarkResult.id,
+    postgresql_where=(BenchmarkResult.timestamp >= "2023-06-03"),
+)
+s.Index(
+    "benchmark_result_run_reason_id_idx",
+    BenchmarkResult.run_reason,
+    BenchmarkResult.id,
+    postgresql_where=(BenchmarkResult.timestamp >= "2023-06-03"),
+)
 
 
 class _Serializer(EntitySerializer):

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -1411,18 +1411,6 @@
                 "description": 'Return benchmark results.\n\nNote that this endpoint does not provide on-the-fly change detection\nanalysis (lookback z-score method) since the "baseline" is ill-defined.\n\nThis endpoint implements pagination; see the `cursor` and `page_size` query\nparameters for how it works.\n\nFor legacy reasons, this endpoint will not return results from before\n`2023-06-03 UTC`, unless the `run_id` query parameter is used to filter\nbenchmark results.\n',
                 "parameters": [
                     {
-                        "description": "Filter results to one specific conceptual benchmark name.",
-                        "in": "query",
-                        "name": "name",
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "Filter results to one specific `batch_id`.",
-                        "in": "query",
-                        "name": "batch_id",
-                        "schema": {"type": "string"},
-                    },
-                    {
                         "description": "Filter results to one specific `run_id`. Using this argument allows the\nresponse to return results from before `2023-06-03 UTC`.\n",
                         "in": "query",
                         "name": "run_id",

--- a/migrations/versions/74182bab6a9f_add_pagination_indexes.py
+++ b/migrations/versions/74182bab6a9f_add_pagination_indexes.py
@@ -1,0 +1,45 @@
+"""add pagination indexes
+
+Revision ID: 74182bab6a9f
+Revises: 9bee3b519bf1
+Create Date: 2023-10-17 15:26:26.623525
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "74182bab6a9f"
+down_revision = "9bee3b519bf1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        "benchmark_result_id_idx",
+        "benchmark_result",
+        ["id"],
+        unique=False,
+        postgresql_where=sa.text("timestamp >= '2023-06-03'"),
+    )
+    op.create_index(
+        "benchmark_result_run_reason_id_idx",
+        "benchmark_result",
+        ["run_reason", "id"],
+        unique=False,
+        postgresql_where=sa.text("timestamp >= '2023-06-03'"),
+    )
+
+
+def downgrade():
+    op.drop_index(
+        "benchmark_result_run_reason_id_idx",
+        table_name="benchmark_result",
+        postgresql_where=sa.text("timestamp >= '2023-06-03'"),
+    )
+    op.drop_index(
+        "benchmark_result_id_idx",
+        table_name="benchmark_result",
+        postgresql_where=sa.text("timestamp >= '2023-06-03'"),
+    )


### PR DESCRIPTION
This PR adds a couple of partial indexes to BenchmarkResult that speed up the `GET /api/benchmark-results/` list endpoint. Fixes #1502. See discussion there.

It also removes the `name` and `batch_id` query parameters from that endpoint. I didn't see those being used in any clients, and in order to make sure that using those arguments wouldn't cause 500s on Arrow-scale data, we'd have to do a lot more careful indexing. I chose to get rid of them instead.