### PR TITLE
app/runs: show more than 1000 results

### DIFF
--- a/conbench/app/batches.py
+++ b/conbench/app/batches.py
@@ -38,12 +38,13 @@ class BatchPlot(AppEndpoint, ContextMixin):
 
     @authorize_or_terminate
     def get(self, batch_id):
+        # This will only return 1000 results. This page isn't linked from anywhere.
+        # How useful is this page?
         benchmarks, response = self._get_benchmarks(batch_id)
         if response.status_code != 200:
             self.flash("Error getting benchmarks.")
             return self.redirect("app.index")
 
-        # TODO: switch to a DB query
         benchmarks = benchmarks["data"]
 
         group_by_key = "dataset"  # TODO: move to GRAPHS

--- a/conbench/app/results.py
+++ b/conbench/app/results.py
@@ -380,12 +380,13 @@ class BenchmarkResultList(AppEndpoint, ContextMixin):
 
     @authorize_or_terminate
     def get(self):
+        # This will only return 1000 results. This page isn't linked from anywhere.
+        # How useful is this page?
         benchmarks, response = self._get_benchmarks()
         if response.status_code != 200:
             self.flash("Error getting benchmarks.")
             return self.redirect("app.index")
 
-        # TODO: switch to a DB query
         benchmarks = benchmarks["data"]
 
         return self.page(benchmarks)


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/conbench/conbench/pull/1496#discussion_r1356984948 where the run page shows only up to 1000 benchmark results.

I was going to resolve this and #968 at the same time, but wow, the latter will take a good amount of untangling code. It's still absolutely worth doing, but for now I need to keep this hacky.