### PR TITLE
api/history: change schema to prepare for pagination

### DIFF
--- a/conbench/api/_docs.py
+++ b/conbench/api/_docs.py
@@ -84,7 +84,10 @@ spec.components.response("CompareList", _200_ok(ex.COMPARE_LIST))
 spec.components.response("ContextEntity", _200_ok(ex.CONTEXT_ENTITY))
 spec.components.response("ContextList", _200_ok([ex.CONTEXT_ENTITY]))
 spec.components.response("InfoList", _200_ok([ex.INFO_ENTITY]))
-spec.components.response("HistoryList", _200_ok([ex.HISTORY_ENTITY]))
+spec.components.response(
+    "HistoryList",
+    _200_ok({"data": [ex.HISTORY_ENTITY], "metadata": {"next_page_cursor": None}}),
+)
 spec.components.response("InfoEntity", _200_ok(ex.INFO_ENTITY))
 spec.components.response("HardwareEntity", _200_ok(ex.HARDWARE_ENTITY))
 spec.components.response("HardwareList", _200_ok([ex.HARDWARE_ENTITY]))

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -714,59 +714,62 @@
             "HistoryList": {
                 "content": {
                     "application/json": {
-                        "example": [
-                            [
-                                {
-                                    "benchmark_result_id": "some-benchmark-uuid-1",
-                                    "case_id": "some-case-uuid-1",
-                                    "commit_hash": "02addad336ba19a654f9c857ede546331be7b631",
-                                    "commit_msg": "ARROW-11771: [Developer][Archery] Move benchmark tests (so CI runs them)",
-                                    "commit_timestamp": "2021-02-25T01:02:51",
-                                    "context_id": "some-context-uuid-1",
-                                    "data": [
-                                        0.099094,
-                                        0.037129,
-                                        0.036381,
-                                        0.148896,
-                                        0.008104,
-                                        0.005496,
-                                        0.009871,
-                                        0.006008,
-                                        0.007978,
-                                        0.004733,
-                                    ],
-                                    "hardware_hash": "diana-2-2-4-17179869184",
-                                    "history_fingerprint": "some-hexdigest",
-                                    "mean": 0.036369,
-                                    "repository": "https://github.com/org/repo",
-                                    "run_name": "some run name",
-                                    "single_value_summary": 0.036369,
-                                    "single_value_summary_type": "mean",
-                                    "times": [
-                                        0.099094,
-                                        0.037129,
-                                        0.036381,
-                                        0.148896,
-                                        0.008104,
-                                        0.005496,
-                                        0.009871,
-                                        0.006008,
-                                        0.007978,
-                                        0.004733,
-                                    ],
-                                    "unit": "s",
-                                    "zscorestats": {
-                                        "begins_distribution_change": False,
-                                        "is_outlier": False,
-                                        "residual": 0.0,
-                                        "rolling_mean": 0.036369,
-                                        "rolling_mean_excluding_this_commit": 0.036369,
-                                        "rolling_stddev": 0.0,
-                                        "segment_id": 0.0,
-                                    },
-                                }
-                            ]
-                        ]
+                        "example": {
+                            "data": [
+                                [
+                                    {
+                                        "benchmark_result_id": "some-benchmark-uuid-1",
+                                        "case_id": "some-case-uuid-1",
+                                        "commit_hash": "02addad336ba19a654f9c857ede546331be7b631",
+                                        "commit_msg": "ARROW-11771: [Developer][Archery] Move benchmark tests (so CI runs them)",
+                                        "commit_timestamp": "2021-02-25T01:02:51",
+                                        "context_id": "some-context-uuid-1",
+                                        "data": [
+                                            0.099094,
+                                            0.037129,
+                                            0.036381,
+                                            0.148896,
+                                            0.008104,
+                                            0.005496,
+                                            0.009871,
+                                            0.006008,
+                                            0.007978,
+                                            0.004733,
+                                        ],
+                                        "hardware_hash": "diana-2-2-4-17179869184",
+                                        "history_fingerprint": "some-hexdigest",
+                                        "mean": 0.036369,
+                                        "repository": "https://github.com/org/repo",
+                                        "run_name": "some run name",
+                                        "single_value_summary": 0.036369,
+                                        "single_value_summary_type": "mean",
+                                        "times": [
+                                            0.099094,
+                                            0.037129,
+                                            0.036381,
+                                            0.148896,
+                                            0.008104,
+                                            0.005496,
+                                            0.009871,
+                                            0.006008,
+                                            0.007978,
+                                            0.004733,
+                                        ],
+                                        "unit": "s",
+                                        "zscorestats": {
+                                            "begins_distribution_change": False,
+                                            "is_outlier": False,
+                                            "residual": 0.0,
+                                            "rolling_mean": 0.036369,
+                                            "rolling_mean_excluding_this_commit": 0.036369,
+                                            "rolling_stddev": 0.0,
+                                            "segment_id": 0.0,
+                                        },
+                                    }
+                                ]
+                            ],
+                            "metadata": {"next_page_cursor": None},
+                        }
                     }
                 },
                 "description": "OK",
@@ -1714,7 +1717,7 @@
         },
         "/api/history/{benchmark_result_id}/": {
             "get": {
-                "description": "Get benchmark history.",
+                "description": "Get details about all error-free benchmark results on the default branch\nthat match the given benchmark result's history fingerprint.\n\nThis endpoint also returns results of the lookback z-score analysis,\ncomparing each result to commits in its git history ending with its parent\ncommit. More details about this analysis can be found at\nhttps://conbench.github.io/conbench/pages/lookback_zscore.html.\n\nThough the response has pagination metadata, pagination is not currently\nimplemented. All matching results will be returned in one page.\n",
                 "parameters": [
                     {
                         "in": "path",

--- a/conbench/tests/api/test_history.py
+++ b/conbench/tests/api/test_history.py
@@ -1,4 +1,5 @@
 from io import StringIO
+from typing import List
 
 import pandas as pd
 from pandas import DatetimeIndex
@@ -7,7 +8,7 @@ from ...api._examples import _api_history_entity
 from ...tests.api import _asserts, _fixtures
 
 
-def _expected_entity(benchmark_result):
+def _expected_entity(benchmark_result) -> List[dict]:
     return _api_history_entity(
         benchmark_result.id,
         benchmark_result.case_id,
@@ -30,7 +31,10 @@ class TestHistoryGet(_asserts.GetEnforcer):
         response = client.get(f"/api/history/{benchmark_result.id}/")
         assert response.status_code == 200
         hist_endpont_resp_deser = response.json
-        expected_resp_deser = _expected_entity(benchmark_result)
+        expected_resp_deser = {
+            "data": _expected_entity(benchmark_result),
+            "metadata": {"next_page_cursor": None},
+        }
         assert hist_endpont_resp_deser == expected_resp_deser
 
     def test_csv_download(self, client):


### PR DESCRIPTION
As a first step to #1506, this PR changes the schema so clients know to expect pagination from the history endpoint.

As discussed in that issue, we'll hold off on the implementation until #1512 is done.