### PR TITLE
devprod: type hint the session object

### DIFF
--- a/conbench/dbsession.py
+++ b/conbench/dbsession.py
@@ -50,7 +50,9 @@ def _get_session():
     return app.scoped_session
 
 
-current_session = LocalProxy(_get_session)
+# LocalProxy is not a good type hint. When used, this object acts as a scoped_session.
+# This type hint allows all SQLAlchemy query results to also be type hinted.
+current_session: scoped_session = LocalProxy(_get_session)  # type: ignore[assignment]
 """Provides the current SQL Alchemy session within a request.
 
 Will raise an exception if no :data:`~flask.current_app` is available or it has

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -963,13 +963,11 @@ LIMIT {limit};
 
 
 def fetch_one_result_per_each_of_n_recent_runs(n: int = 250) -> List[BenchmarkResult]:
-    from sqlalchemy.sql import text
-
-    bmrs = (
-        current_session.query(BenchmarkResult)
-        .from_statement(text(_RECENT_RUNS_QUERY_TEMPL.format(limit=n)))
-        .all()
+    query = s.select(BenchmarkResult).from_statement(
+        s.text(_RECENT_RUNS_QUERY_TEMPL.format(limit=n))
     )
+    # Need to type hint this again because from_statement() overrides the type hints.
+    bmrs: List[BenchmarkResult] = list(current_session.scalars(query).all())
 
     # Note(JP): as of the time of writing we're still having to reach out to
     # the database to get commit information: one query per result, I think.


### PR DESCRIPTION
Fixes #1461. Correctly type-hints the `current_session` object, enabling better type-hinting throughout the codebase. Also fixes one mypy false positive that arose because of this.