### PR TITLE
webapp: auto-render URL lists as a href

### DIFF
--- a/conbench/templates/benchmark-result.html
+++ b/conbench/templates/benchmark-result.html
@@ -206,15 +206,15 @@
               {{ k }}
               {% if v is not none %}
                 <div align="right" style="display:inline-block; float: right;">
-                  {% if not isinstance(v, list) %}
-                    <code>{{ v | urlize(target="_blank") }}</code>
-                  {% else %}
+                  {% if v is iterable and (v is not string and v is not mapping) %}
                     <code>[
                       {% for i in v %}
                         {{ i | urlize(target="_blank") }}
                         {% if not loop.last %},{% endif %}
                       {% endfor %}
                     ]</code>
+                  {% else %}
+                    <code>{{ v | urlize(target="_blank") }}</code>
                   {% endif %}
                 </div>
               {% endif %}

--- a/conbench/templates/benchmark-result.html
+++ b/conbench/templates/benchmark-result.html
@@ -212,9 +212,7 @@
                     <code>[
                     {% for i in v %}
                       {{ i | urlize(target="_blank") }}
-                      {% if not loop.last %}
-                        ,
-                      {% endif %}
+                      {% if not loop.last %},{% endif %}
                     {% endfor %}
                     ]</code>
                   {% endif %}

--- a/conbench/templates/benchmark-result.html
+++ b/conbench/templates/benchmark-result.html
@@ -210,10 +210,10 @@
                     <code>{{ v | urlize(target="_blank") }}</code>
                   {% else %}
                     <code>[
-                    {% for i in v %}
-                      {{ i | urlize(target="_blank") }}
-                      {% if not loop.last %},{% endif %}
-                    {% endfor %}
+                      {% for i in v %}
+                        {{ i | urlize(target="_blank") }}
+                        {% if not loop.last %},{% endif %}
+                      {% endfor %}
                     ]</code>
                   {% endif %}
                 </div>

--- a/conbench/templates/benchmark-result.html
+++ b/conbench/templates/benchmark-result.html
@@ -206,7 +206,18 @@
               {{ k }}
               {% if v is not none %}
                 <div align="right" style="display:inline-block; float: right;">
-                  <code>{{ v | urlize(target="_blank") }}</code>
+                  {% if not isinstance(v, list) %}
+                    <code>{{ v | urlize(target="_blank") }}</code>
+                  {% else %}
+                    <code>[
+                    {% for i in v %}
+                      {{ i | urlize(target="_blank") }}
+                      {% if not loop.last %}
+                        ,
+                      {% endif %}
+                    {% endfor %}
+                    ]</code>
+                  {% endif %}
                 </div>
               {% endif %}
             </li>

--- a/conbench/tests/app/test_results.py
+++ b/conbench/tests/app/test_results.py
@@ -101,6 +101,24 @@ class TestBenchmarkResultGet(_asserts.GetEnforcer):
         # Ensure the result page looks as expected
         self._assert_view(client, post_response.json["id"])
 
+    def test_display_result_urlize_optional_info(self, client):
+        # Test that benchmark result view/page loads fine for the results that
+        # have optional_benchmark_info only.
+        self.authenticate(client)
+
+        result = _fixtures.VALID_RESULT_PAYLOAD.copy()
+        result["optional_benchmark_info"] = {
+            "single_url": "https://foo.bar",
+            "list_of_single_url": ["https://foo.bar"],
+            "list_of_two_urls": ["https://foo.bar", "https://foo.bar"],
+        }
+
+        resp = client.post("/api/benchmark-results/", json=result)
+        assert resp.status_code == 201, resp.text
+        bmr_id = resp.json["id"]
+        resp = client.get(f"benchmark-results/{bmr_id}/")
+        assert resp.status_code == 200, resp.text
+
 
 class TestBenchmarkResultDelete(_asserts.DeleteEnforcer):
     def test_authenticated(self, client):

--- a/conbench/tests/populate_local_conbench.py
+++ b/conbench/tests/populate_local_conbench.py
@@ -122,6 +122,7 @@ def generate_benchmarks_data(
     data["optional_benchmark_info"] = {
         "log uri": "s3://some/log",
         "log url": "https://some/log",
+        'log urls': ["https://some/log", "https://another/one"],
         "trace uri": "s3://some/trace",
     }
 

--- a/conbench/tests/populate_local_conbench.py
+++ b/conbench/tests/populate_local_conbench.py
@@ -122,7 +122,7 @@ def generate_benchmarks_data(
     data["optional_benchmark_info"] = {
         "log uri": "s3://some/log",
         "log url": "https://some/log",
-        'log urls': ["https://some/log", "https://another/one"],
+        "log urls": ["https://some/log", "https://another/one"],
         "trace uri": "s3://some/trace",
     }
 


### PR DESCRIPTION
This PR causes lists of urls in the optional benchmark info part of the web app to render as links.

Solves https://github.com/conbench/conbench/issues/460