### PR TITLE
benchclients: fix bug on 3.8

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -169,7 +169,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           # in order of dependency

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -169,7 +169,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.8"
       - name: Install dependencies
         run: |
           # in order of dependency

--- a/benchclients/python/benchclients/conbench.py
+++ b/benchclients/python/benchclients/conbench.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import List
+from typing import List, Optional
 
 import requests
 
@@ -173,7 +173,7 @@ class ConbenchClient(RetryingHTTPClient):
         # Rely on the details to have been logged previously
         raise RetryingHTTPClientLoginError("login failed (see logs), giving up")
 
-    def get_all(self, path: str, params: dict | None = None) -> List[dict]:
+    def get_all(self, path: str, params: Optional[dict] = None) -> List[dict]:
         """
         Make GET requests to a paginated Conbench endpoint. Expect responses with status
         code 200, expect a JSON document in the response body of the form


### PR DESCRIPTION
benchclients is still used in some python 3.8 environments, like https://github.com/voltrondata-labs/arrow-benchmarks-ci. We should use 3.8-compatible type hints.