### PR TITLE
webapp: speed up landing page by adding index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ alembic-new-migration: teardown-app
 		exit 1; \
 	fi
 	docker compose run --detach db
-	CREATE_ALL_TABLES=false docker compose \
+	CREATE_ALL_TABLES=false docker compose -f docker-compose.yml -f docker-compose.dev.yml \
 		run -e CREATE_ALL_TABLES app alembic upgrade head
 	CREATE_ALL_TABLES=false docker compose -f docker-compose.yml -f docker-compose.dev.yml \
 		run -e CREATE_ALL_TABLES  app alembic revision --autogenerate -m ${ALEMBIC_MIGRATION_NAME}

--- a/alembic.ini
+++ b/alembic.ini
@@ -63,7 +63,7 @@ keys = console
 keys = generic
 
 [logger_root]
-level = WARN
+level = INFO
 handlers = console
 qualname =
 
@@ -84,5 +84,5 @@ level = NOTSET
 formatter = generic
 
 [formatter_generic]
-format = %(levelname)-5.5s [%(name)s] %(message)s
+format = [%(asctime)s.%(msecs)03d] [%(process)d] [%(name)s] %(levelname)s: %(message)s
 datefmt = %H:%M:%S

--- a/conbench/entities/benchmark_result.py
+++ b/conbench/entities/benchmark_result.py
@@ -1,6 +1,5 @@
 import functools
 import hashlib
-import json
 import logging
 import math
 import statistics

--- a/migrations/versions/b8a3e65efb9d_landing_page_index.py
+++ b/migrations/versions/b8a3e65efb9d_landing_page_index.py
@@ -1,0 +1,34 @@
+"""landing_page_index
+
+Revision ID: b8a3e65efb9d
+Revises: 74182bab6a9f
+Create Date: 2023-12-04 16:45:12.036321
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "b8a3e65efb9d"
+down_revision = "74182bab6a9f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        "benchmark_result_run_id_timestamp_idx",
+        "benchmark_result",
+        ["run_id", "timestamp"],
+        unique=False,
+        postgresql_where=sa.text("timestamp >= '2023-11-19'"),
+    )
+
+
+def downgrade():
+    op.drop_index(
+        "benchmark_result_run_id_timestamp_idx",
+        table_name="benchmark_result",
+        postgresql_where=sa.text("timestamp >= '2023-11-19'"),
+    )

--- a/migrations/versions/b8a3e65efb9d_landing_page_index.py
+++ b/migrations/versions/b8a3e65efb9d_landing_page_index.py
@@ -5,9 +5,8 @@ Revises: 74182bab6a9f
 Create Date: 2023-12-04 16:45:12.036321
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "b8a3e65efb9d"


### PR DESCRIPTION
Fixes #1482. This PR adds a partial index that speeds up `fetch_one_result_per_each_of_n_recent_runs()`, which powers the landing page. 

That function was fast only when PG's shared buffer cache was hit, but when it was missed it was very slow to read through all the data in the `benchmark_result` table. This PR should improve the cache miss time by limiting the files to look through to only data from the last 2 weeks. (For all the instances we track, 2 weeks is more than enough time to get the last 250 runs.)

I validated that on Arrow-scale data this speeds up the cache-hit time from 1130 ms to 40 ms. Unfortunately I couldn't test the cache-miss time (which used to be 70s or so!) but I have confidence that it should be much faster as well, since according to EXPLAIN ANALYZE the new query is reading 100x fewer blocks from the cache.

The write time does not slow down much either.