### PR TITLE
Speed up compare runs endpoint a little more

### DIFF
--- a/conbench/api/compare.py
+++ b/conbench/api/compare.py
@@ -623,10 +623,10 @@ class CompareRunsAPI(ApiEndpoint):
             schema:
               type: integer
               minimum: 1
-              maximum: 500
+              maximum: 1000
             description: |
                 The max number of unique fingerprints to return per page for pagination
-                (see `cursor`). Default 100. Max 500.
+                (see `cursor`). Default 100. Max 1000.
         tags:
           - Comparisons
         """
@@ -641,10 +641,10 @@ class CompareRunsAPI(ApiEndpoint):
             page_size_arg = f.request.args.get("page_size", 100)
             try:
                 page_size = int(page_size_arg)
-                assert 1 <= page_size <= 500
+                assert 1 <= page_size <= 1000
             except Exception:
                 self.abort_400_bad_request(
-                    "page_size must be a positive integer no greater than 500"
+                    "page_size must be a positive integer no greater than 1000"
                 )
 
             cursor_arg: Optional[str] = f.request.args.get("cursor")

--- a/conbench/tests/api/_expected_docs.py
+++ b/conbench/tests/api/_expected_docs.py
@@ -1937,10 +1937,10 @@
                         "schema": {"nullable": True, "type": "string"},
                     },
                     {
-                        "description": "The max number of unique fingerprints to return per page for pagination\n(see `cursor`). Default 100. Max 500.\n",
+                        "description": "The max number of unique fingerprints to return per page for pagination\n(see `cursor`). Default 100. Max 1000.\n",
                         "in": "query",
                         "name": "page_size",
-                        "schema": {"maximum": 500, "minimum": 1, "type": "integer"},
+                        "schema": {"maximum": 1000, "minimum": 1, "type": "integer"},
                     },
                 ],
                 "responses": {

--- a/conbench/tests/api/test_compare.py
+++ b/conbench/tests/api/test_compare.py
@@ -541,7 +541,7 @@ class TestCompareRunsGet(_asserts.GetEnforcer):
         res = client.get(f"/api/compare/runs/foo...bar/?page_size={page_size}")
         self.assert_400_bad_request(
             res,
-            {"_errors": ["page_size must be a positive integer no greater than 500"]},
+            {"_errors": ["page_size must be a positive integer no greater than 1000"]},
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
I was looking into [this research](https://github.com/conbench/conbench/pull/1527#issuecomment-1791458526) in order to address #1345. The core of the problem we see is that sometimes PG picks the commit and timestamp indexes to BitwiseAnd together, but those are heavily correlated. I wanted to force PG to pick commit and history fingerprint because those are completely independent.

I realized I could take out the `timestamp >= earliest_commit_timestamp` clause of the query, since that was always redundant and intended to be a speedup. And that worked! Postgres decided to use commit and fingerprint in most cases:

```
 pg size | num pgs | total (s) | indexes used
---------+---------+-----------+------------------------
    5000 |       1 |      75.6 | commit
    1000 |       4 |      34.1 | fingerprint, commit
     500 |       7 |      38.7 | fingerprint, commit
     100 |      35 |      44.4 | fingerprint, commit
      50 |      69 |      59.9 | fingerprint, commit
      10 |     341 |      90.0 | fingerprint, commit
```

So this PR bumps the max page size up to 1000 (like our other endpoints). Using that, we see about a 20% speedup in total time compared to the max page size before this PR.

I tried messing with adding multiindexes, but they don't get chosen, and even if they did it wouldn't matter because the BitwiseAnd is almost 100% efficient.