### PR TITLE
fix config

### DIFF
--- a/conbench/config.py
+++ b/conbench/config.py
@@ -34,7 +34,7 @@ class ConfigClass:
     # - "best" (default): Use the min value if less_is_better for the unit, or the max
     #                     value if not.
     # - "mean": Use the mean.
-    SVS_TYPE = os.environ.get("SVS_TYPE", "best")
+    SVS_TYPE = os.environ.get("SVS_TYPE") or "best"
 
     LOG_LEVEL_STDERR = os.environ.get("CONBENCH_LOG_LEVEL_STDERR", "INFO")
     LOG_LEVEL_FILE = None


### PR DESCRIPTION
I noticed after deploying #1571 to staging that some webapp pages returned a 500 with the traceback ending with:
```
  File "/app/conbench/entities/benchmark_result.py", line 510, in _single_value_summary
    assert Config.SVS_TYPE == "best"
           ^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```
My intention is that if the environment variable is empty or unset, this should default to `"best"`, and I assume this AssertionError is thrown because the environment variable is empty. This should fix that.
