### PR TITLE
plots: fix unequal-size error

### DIFF
--- a/conbench/app/_plots.py
+++ b/conbench/app/_plots.py
@@ -242,6 +242,7 @@ def simple_bar_plot(benchmarks, height=400, width=400, vbar_width=0.7):
 
 def _insert_nans(some_list: list, indexes: List[int]):
     """Insert nans into a list before the given indexes."""
+    some_list = some_list.copy()
     for ix in sorted(indexes, reverse=True):
         some_list.insert(ix, float("nan"))
     return some_list


### PR DESCRIPTION
I noticed `[bokeh] data source has columns of inconsistent lengths` errors in the logs and consoles when loading plots. I narrowed this down to the `_insert_nans()` function. It was being called on the `commit_messages` variable multiple times, and was not idempotent. Now it's idempotent.