### PR TITLE
webapp: compare runs: paginate

### DIFF
--- a/conbench/app/compare.py
+++ b/conbench/app/compare.py
@@ -282,13 +282,23 @@ class CompareRuns(Compare):
         try:
             api = CompareRunsAPI()
             response = api._get_response_as_dict(
-                compare_ids=f"{baseline_id}...{contender_id}",
                 cursor=None,
-                page_size=None,
+                compare_ids=f"{baseline_id}...{contender_id}",
+                page_size=1000,
                 threshold=None,
                 threshold_z=None,
             )
-            return response["data"], None
+            comparisons = response["data"]
+            while response["metadata"]["next_page_cursor"]:
+                response = api._get_response_as_dict(
+                    cursor=response["metadata"]["next_page_cursor"],
+                    compare_ids=f"{baseline_id}...{contender_id}",
+                    page_size=1000,
+                    threshold=None,
+                    threshold_z=None,
+                )
+                comparisons += response["data"]
+            return comparisons, None
         except HTTPException as e:
             return [], e.description
 


### PR DESCRIPTION
Fixes #1564. Adds pagination to the backend query that powers the compare runs webapp page.

I tested this locally on a particularly nasty Arrow comparison. It took the page load time from ~80s to ~30s! This should definitely help with avoiding DB timeouts as well, since each DB query is smaller.

The main reason this works is that adding _any page size at all_ makes the Postgres planner use a much better index (the `history_fingerprint` one) when making the history query. I tried a few different page sizes; changing it didn't really have an effect on performance aside from the original speedup from including a page size in the first place.

Proof this is working: here's an RDS Performance Insights screenshot, where the left side was a run without a page size, and the right side was a run with the page size of 1000. All the time is spent on calculations/serialization rather than reading data files.

![Screenshot 2024-02-02 at 09 44 15](https://github.com/conbench/conbench/assets/16600275/c86aa658-3581-4dcc-b3ef-fd32967f93d6)

