### PR TITLE
webapp: benchmark-result: pprint error info

### DIFF
--- a/conbench/templates/benchmark-result.html
+++ b/conbench/templates/benchmark-result.html
@@ -147,8 +147,13 @@
                    style="display:inline-block;
                           white-space: pre;
                           float: center">
-                {{ v | urlize(target="_blank")
-                }}
+                <code>
+                  {% if v is string %}
+                    {{ v | urlize(target="_blank") }}
+                  {% else %}
+                    {{ v | pprint }}
+                  {% endif %}
+                </code>
               </div>
             </li>
           {% endfor %}


### PR DESCRIPTION
Some Conbench instances add nested error info. This PR makes displaying that a little prettier.