### PR TITLE
benchalerts: allow for custom alerts to not post comments

### DIFF
--- a/benchalerts/benchalerts/pipeline_steps/slack.py
+++ b/benchalerts/benchalerts/pipeline_steps/slack.py
@@ -78,13 +78,17 @@ class SlackMessageAboutBadCheckStep(AlertPipelineStep):
             log.info("GitHub Check was successful; not posting to Slack.")
             return None
 
+        message = self.alerter.slack_message(
+            full_comparison=full_comparison,
+            check_details=check_details,
+            comment_details=comment_details,
+        )
+        if not message:
+            log.info("No message; not posting to Slack.")
+            return None
+
         res = self.slack_client.post_message(
-            message=self.alerter.slack_message(
-                full_comparison=full_comparison,
-                check_details=check_details,
-                comment_details=comment_details,
-            ),
-            channel_id=self.channel_id,
+            message=message, channel_id=self.channel_id
         )
         return res
 


### PR DESCRIPTION
This PR enables custom Alerters to choose to return `""` for a GitHub PR or Slack comment, and not post a comment in that case. This is useful for suppression of messages based on what happened when running benchmarks.