### PR TITLE
FIX Update jsonnet docker image

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -217,7 +217,7 @@ jobs:
         id: minikube
         uses: medyagh/setup-minikube@e1ee887a96c50e34066a4bf9f172eb94ae69d454
         with:
-          kubernetes-version: v1.26.7
+          kubernetes-version: v1.28.0
           # By convention, both locally and in CI we call this mk-conbench.
           start-args: '--profile mk-conbench --extra-config=kubelet.cgroup-driver=systemd'
           cpus: max

--- a/Makefile
+++ b/Makefile
@@ -313,7 +313,7 @@ jsonnet-kube-prom-manifests:
 	mkdir -p _kpbuild && cd _kpbuild  && mkdir -p cb-kube-prometheus
 	cd _kpbuild/cb-kube-prometheus && git clone https://github.com/prometheus-operator/kube-prometheus . &&	git checkout 7fafc4cadc1
 	cd _kpbuild/cb-kube-prometheus && \
-		time docker run --rm -v $$(pwd):$$(pwd) --workdir $$(pwd) quay.io/coreos/jsonnet-ci \
+		time docker run --rm -v $$(pwd):$$(pwd) --workdir $$(pwd) akamai/jsonnet \
 			sh -c 'jb install && chmod -R 777 *'
 	cd _kpbuild/cb-kube-prometheus && /bin/ls -ahl
 	cp k8s/kube-prometheus/conbench-flavor.jsonnet _kpbuild/cb-kube-prometheus


### PR DESCRIPTION
Quay.io image no longer exists, moving to an Akamai image on Docker instead. This impacts Buildkite-based [deployments](https://buildkite.com/apache-arrow/conbench-deploy/builds/129#01995431-e88f-4021-9227-55899e0db817/114-196) for the Conbench Apache Arrow deployment.

Other fixes:
- [x] Updating CI [cb-on-mikikube](https://github.com/conbench/conbench/actions/runs/18727942560/job/53418176529#step:3:21) to use a newer version of k8s 