### PR TITLE
pin pandas version to <3 due to deployment error

### DIFF
--- a/requirements-webapp.txt
+++ b/requirements-webapp.txt
@@ -18,7 +18,7 @@ numpy
 oauthlib
 openapi-spec-validator
 orjson
-pandas>=2
+pandas>=2,<3
 prometheus-client
 prometheus-flask-exporter
 psycopg2


### PR DESCRIPTION
We're having issues deploying conbench for Arrow.  The reasoning, according to Claude :robot: :

```
The Conbench compare API is returning 500 errors.

  Root cause: Pandas 3.0.0 was released on January 21, 2026. Conbench's requirements-webapp.txt has pandas>=2 with no upper bound, so new deployments pull pandas 3.0.

  The failing code is in conbench/entities/history.py line 631. It assigns values to a DataFrame like this:

  df.loc[~df.is_outlier, "column"] = (...).values

  Pandas 3.0 is stricter about index alignment and throws ValueError: cannot reindex on an axis with duplicate labels when the data has certain patterns (likely duplicate benchmark results or
  timestamps).

  Fix options:
  1. Pin pandas>=2,<3 to avoid pandas 3.0 (quick fix)
  2. Rewrite the assignment pattern to avoid index alignment issues (proper fix, needs testing)
  ```